### PR TITLE
Add regression test for XenoAtom.Logging generator (#1531)

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -177,6 +177,7 @@
   
     <!-- These are test-only dependencies for standalone projects. -->
     <PackageVersion Include="Catglobe.ResXFileCodeGenerator" Version="4.1.2" />
+    <PackageVersion Include="XenoAtom.Logging" Version="1.1.2" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageVersion Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.18.1" />

--- a/Metalama.Framework/src/tests/Standalone/Issue1531/Issue1531.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1531/Issue1531.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Metalama.Framework" />
+    <PackageReference Include="XenoAtom.Logging" />
+  </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1531/LogAspect.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1531/LogAspect.cs
@@ -1,0 +1,13 @@
+using Metalama.Framework.Aspects;
+using XenoAtom.Logging;
+
+namespace Issue1531;
+
+internal class LogAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod()
+    {
+        Program.Logger.Info("Entering method: " + meta.Target.Method.Name);
+        return meta.Proceed();
+    }
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1531/Program.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1531/Program.cs
@@ -1,0 +1,41 @@
+using XenoAtom.Logging;
+using XenoAtom.Logging.Writers;
+
+namespace Issue1531;
+
+public partial class Program
+{
+    public static Logger Logger { get; internal set; }
+
+    [LogFormatter("[{Timestamp:yyyy-MM-dd HH:mm:ss}] [{Level}] [{LoggerName}] {Text}")]
+    public static partial LogFormatter MyLogFormatter { get; }
+
+    static void Main(string[] args)
+    {
+        LogManager.Initialize(new()
+        {
+            RootLogger =
+            {
+                MinimumLevel = LogLevel.Info,
+                Writers =
+                {
+                    new StreamLogWriter(Console.OpenStandardOutput())
+                    {
+                        Formatter = MyLogFormatter with
+                        {
+                            LevelFormat = LogLevelFormat.Long,
+                        }
+                    }
+                }
+            }
+        });
+        Logger = LogManager.GetLogger("Program");
+        SayHello();
+    }
+
+    [LogAspect]
+    static void SayHello()
+    {
+        Logger.Info("Hello, World!");
+    }
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1531/test.json
+++ b/Metalama.Framework/src/tests/Standalone/Issue1531/test.json
@@ -1,0 +1,3 @@
+{
+    "BuildOnly": true
+}


### PR DESCRIPTION
## Summary

- Add standalone regression test for issue metalama/Metalama.Compiler#193: XenoAtom.Logging's `LogFormatterGenerator` fails with `TypeLoadException` in Visual Studio 2026 but works with `dotnet build`
- Add `XenoAtom.Logging` 1.1.2 to test-only dependencies in `Directory.Packages.props`

## Status

The test currently **passes** with `dotnet build` (consistent with the user's report). The `TypeLoadException` is VS-specific and cannot be reproduced in the CLI. See detailed analysis in the issue comments.

## Checklist
- [x] Standalone regression test created
- [ ] Reproduce bug (VS-specific, awaiting user feedback)
- [ ] Implement fix
- [ ] Build and test
- [ ] Finalize

Closes metalama/Metalama.Compiler#193