### PR TITLE
Fix CodeLens summary missing TooltipText (#1615)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/CodeLens/CodeLensServiceImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/CodeLens/CodeLensServiceImpl.cs
@@ -167,10 +167,12 @@ internal sealed class CodeLensServiceImpl : PreviewPipelineBasedService, ICodeLe
         var symbol = codePointData.Symbol;
 
         string? executionScopeString = null;
+        FormattableString? tooltipText = null;
 
         if ( symbolClassificationService.IsTemplate( symbol ) )
         {
             executionScopeString = "template";
+            tooltipText = $"This is a Metalama template.";
         }
         else
         {
@@ -181,29 +183,31 @@ internal sealed class CodeLensServiceImpl : PreviewPipelineBasedService, ICodeLe
                 if ( executionScope == ExecutionScope.CompileTime )
                 {
                     executionScopeString = "compile-time";
+                    tooltipText = $"This {symbol.Kind} runs at compile time.";
                 }
                 else if ( symbol is INamedTypeSymbol namedTypeSymbol && namedTypeSymbol.AllInterfaces.Any( t => t.Name == nameof(IAspect) ) )
                 {
-                    {
-                        summary = new CodeLensSummary( MetalamaStringFormatter.Format( $"aspect class" ) );
+                    summary = new CodeLensSummary(
+                        MetalamaStringFormatter.Format( $"aspect class" ),
+                        MetalamaStringFormatter.Format( $"This class defines a Metalama aspect." ) );
 
-                        return true;
-                    }
+                    return true;
                 }
                 else
                 {
                     executionScopeString = "both run-time and compile-time";
+                    tooltipText = $"This {symbol.Kind} runs at both run time and compile time.";
                 }
             }
         }
 
         if ( executionScopeString != null )
         {
-            {
-                summary = new CodeLensSummary( MetalamaStringFormatter.Format( $"{executionScopeString} {symbol.Kind}" ) );
+            summary = new CodeLensSummary(
+                MetalamaStringFormatter.Format( $"{executionScopeString} {symbol.Kind}" ),
+                MetalamaStringFormatter.Format( tooltipText! ) );
 
-                return true;
-            }
+            return true;
         }
 
         summary = null;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/CodeLensTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/CodeLensTests.cs
@@ -199,4 +199,65 @@ public sealed class CodeLensTests : DesignTimeTestBase
 
         Assert.Empty( details2.Entries );
     }
+
+    [Fact]
+    public async Task TooltipText_AspectClassAndTemplateMembers()
+    {
+        // Regression test for https://github.com/metalama/Metalama/issues/1615:
+        // CodeLensSummary instances for aspect classes and template/compile-time/both-time members
+        // were created without a TooltipText, leaving the CodeLens hover empty in Visual Studio.
+        using var testContext = this.CreateTestContext();
+        using TestDesignTimeAspectPipelineFactory factory = new( testContext );
+
+        const string code = """
+                            using Metalama.Framework.Advising;
+                            using Metalama.Framework.Aspects;
+                            using Metalama.Framework.Code;
+
+                            public class MyAspect : TypeAspect
+                            {
+                                [Template]
+                                public void TemplateMethod() { }
+
+                                [CompileTime]
+                                public void CompileTimeMethod() { }
+                            }
+
+                            [RunTimeOrCompileTime]
+                            public class MyBothTimeClass
+                            {
+                                public void BothTimeMethod() { }
+                            }
+                            """;
+
+        var workspaceProvider = factory.ServiceProvider.GetRequiredService<TestWorkspaceProvider>();
+        var projectKey = workspaceProvider.AddOrUpdateProject( testContext, "project", new Dictionary<string, string> { ["code.cs"] = code } );
+
+        var compilation = (await workspaceProvider.GetCompilationAsync( projectKey ))!;
+
+        // We need to run the pipeline because code lens does not run it on its own.
+        var pipeline = factory.CreatePipeline( compilation );
+        await pipeline.ExecuteAsync( compilation, AsyncExecutionContext.Get() );
+
+        var codeLensService = new CodeLensServiceImpl( factory.ServiceProvider );
+
+        var aspectClassSymbol = compilation.GetTypeByMetadataName( "MyAspect" )!;
+        var bothTimeClassSymbol = compilation.GetTypeByMetadataName( "MyBothTimeClass" )!;
+        var aspectClassId = aspectClassSymbol.GetSerializableId();
+        var templateMethodId = aspectClassSymbol.GetMembers( "TemplateMethod" ).Single().GetSerializableId();
+        var compileTimeMethodId = aspectClassSymbol.GetMembers( "CompileTimeMethod" ).Single().GetSerializableId();
+        var bothTimeMethodId = bothTimeClassSymbol.GetMembers( "BothTimeMethod" ).Single().GetSerializableId();
+
+        var aspectClassSummary = await codeLensService.GetCodeLensSummaryAsync( projectKey, aspectClassId, default );
+        Assert.False( string.IsNullOrEmpty( aspectClassSummary.TooltipText ), "Aspect class CodeLens summary must have a non-empty TooltipText." );
+
+        var templateMethodSummary = await codeLensService.GetCodeLensSummaryAsync( projectKey, templateMethodId, default );
+        Assert.False( string.IsNullOrEmpty( templateMethodSummary.TooltipText ), "Template member CodeLens summary must have a non-empty TooltipText." );
+
+        var compileTimeMethodSummary = await codeLensService.GetCodeLensSummaryAsync( projectKey, compileTimeMethodId, default );
+        Assert.False( string.IsNullOrEmpty( compileTimeMethodSummary.TooltipText ), "Compile-time member CodeLens summary must have a non-empty TooltipText." );
+
+        var bothTimeMethodSummary = await codeLensService.GetCodeLensSummaryAsync( projectKey, bothTimeMethodId, default );
+        Assert.False( string.IsNullOrEmpty( bothTimeMethodSummary.TooltipText ), "Both-time member CodeLens summary must have a non-empty TooltipText." );
+    }
 }


### PR DESCRIPTION
Fixes #1615.

## Summary

`CodeLensServiceImpl` constructed `CodeLensSummary` instances without a `TooltipText` for two paths, leaving the CodeLens hover empty in Visual Studio:

- aspect classes (`CodeLensServiceImpl.cs:188`)
- template / compile-time / both-time members (`CodeLensServiceImpl.cs:203`)

The aspect-count branch already supplied a tooltip. This PR aligns the two missing branches with that style:
- aspect class → `"This class defines a Metalama aspect."`
- template → `"This is a Metalama template."`
- compile-time → `"This {kind} runs at compile time."`
- both-time → `"This {kind} runs at both run time and compile time."`

## Checklist

- [x] Phase 1: Understand the issue
- [x] Phase 2: Failing regression test (`CodeLensTests.TooltipText_AspectClassAndTemplateMembers`)
- [x] Phase 3: Implement fix for missing tooltips
- [x] Phase 4: `Build.ps1 build` clean (zero warnings); `Metalama.Framework.Tests.UnitTests` passes 1873/1873 (net8.0) and 1817/1817 (net48)
- [x] Phase 5: Mark PR ready and request review

— Claude for @gfraiteur