### PR TITLE
Fix introduced constructor missing at design-time on introduced type (#1622)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorTransformation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/IntroduceConstructorTransformation.cs
@@ -115,7 +115,8 @@ internal sealed class IntroduceConstructorTransformation
     public override InsertPosition InsertPosition => this.ReplacedMember?.ToInsertPosition() ?? this.BuilderData.InsertPosition;
 
     public override TransformationObservability Observability
-        => this.ReplacedMember == null && this.BuilderData is { IsImplicitlyDeclared: false, IsDesignTimeObservable: true }
+        => (this.ReplacedMember is null or IIntroducedRef)
+           && this.BuilderData is { IsImplicitlyDeclared: false, IsDesignTimeObservable: true }
             ? TransformationObservability.Always
             : TransformationObservability.CompileTimeOnly;
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.0.i.cs
@@ -1,0 +1,12 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Classes.DefaultConstructor_ExplicitReplaces_DesignTime
+{
+  partial class TargetType
+  {
+    partial class GeneratedClass
+    {
+      public GeneratedClass(global::System.Int32 value)
+      {
+      }
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.1.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.1.i.cs
@@ -1,0 +1,9 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Classes.DefaultConstructor_ExplicitReplaces_DesignTime
+{
+  partial class TargetType
+  {
+    partial class GeneratedClass
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @TestScenario(DesignTime)
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+// https://github.com/metalama/Metalama/issues/1622
+// Verifies that when an explicit constructor is introduced on an introduced (nested) class,
+// the constructor appears in the design-time generated source.
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Classes.DefaultConstructor_ExplicitReplaces_DesignTime
+{
+    public class IntroductionAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            var introducedType = builder.IntroduceClass( "GeneratedClass" );
+
+            introducedType.IntroduceConstructor(
+                nameof(ConstructorTemplate),
+                buildConstructor: c =>
+                {
+                    c.AddParameter( "value", typeof(int) );
+                } );
+        }
+
+        [Template]
+        public void ConstructorTemplate() { }
+    }
+
+    // <target>
+    [IntroductionAttribute]
+    public partial class TargetType { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_ExplicitReplaces_DesignTime.t.cs
@@ -1,0 +1,4 @@
+[IntroductionAttribute]
+public partial class TargetType
+{
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.0.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.0.i.cs
@@ -1,0 +1,12 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Classes.DefaultConstructor_Parameterless_DesignTime
+{
+  partial class TargetType
+  {
+    partial class GeneratedClass
+    {
+      public GeneratedClass()
+      {
+      }
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.1.i.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.1.i.cs
@@ -1,0 +1,9 @@
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Classes.DefaultConstructor_Parameterless_DesignTime
+{
+  partial class TargetType
+  {
+    partial class GeneratedClass
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.cs
@@ -1,0 +1,34 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#if TEST_OPTIONS
+// @TestScenario(DesignTime)
+#endif
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+// https://github.com/metalama/Metalama/issues/1622
+// Verifies that a parameterless explicit constructor introduced on an introduced class
+// is visible in the design-time generated source.
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Introductions.Classes.DefaultConstructor_Parameterless_DesignTime
+{
+    public class IntroductionAttribute : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            var introducedType = builder.IntroduceClass( "GeneratedClass" );
+
+            introducedType.IntroduceConstructor( nameof(ConstructorTemplate) );
+        }
+
+        [Template]
+        public void ConstructorTemplate() { }
+    }
+
+    // <target>
+    [IntroductionAttribute]
+    public partial class TargetType { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Introductions/Classes/DefaultConstructor_Parameterless_DesignTime.t.cs
@@ -1,0 +1,4 @@
+[IntroductionAttribute]
+public partial class TargetType
+{
+}


### PR DESCRIPTION
Fixes #1622.

## Summary

When an aspect introduces a class with `IntroduceClass()` and then introduces a constructor on it with `IntroduceConstructor()`, the constructor was missing from the design-time generated source. Other introduced members (fields, properties) appeared correctly. This breaks scenarios like `Metalama.Samples.EnumViewModel` where the editor cannot resolve `new TheIntroducedClass(...)` from user code.

## Root cause

`IntroduceConstructorAdvice` correctly sets `ReplacedImplicitConstructor` to the freshly-introduced class's implicit (default) constructor, mirroring C# semantics (an explicit constructor removes the implicit default). `IntroduceConstructorTransformation.Observability` then degraded to `CompileTimeOnly` because `ReplacedMember != null`, and `DesignTimeSyntaxTreeGenerator` filters out any transformation whose observability is not `Always`.

The check conflated two cases:
- Replaced one is a source constructor (`ISymbolRef`): correct to hide (the source ctor is still physically present in user source, so emitting at design time would conflict).
- Replaced one is an introduced implicit constructor (`IIntroducedRef`) on an introduced type: incorrect to hide, because the implicit ctor isn't physically present anywhere.

## Fix

`IntroduceConstructorTransformation.Observability` now keeps `Always` when the replaced member is either `null` or an `IIntroducedRef`, matching the suggestion in the issue. The same expression continues to degrade to `CompileTimeOnly` when replacing a real `ISymbolRef` source constructor.

## Tests

Two new design-time aspect tests (both use `@TestScenario(DesignTime)`):

- `DefaultConstructor_ExplicitReplaces_DesignTime` — introduces a class + a parameterized constructor; the design-time generated `.i.cs` for `GeneratedClass` now contains the constructor.
- `DefaultConstructor_Parameterless_DesignTime` — same scenario with a parameterless constructor.

Side note: the design-time generator emits two `partial class GeneratedClass` declarations across two `.i.cs` files (one from the class-introduction transformation in the parent type's bucket, one from the constructor-introduction transformation in the introduced type's bucket). This redundancy is already acknowledged as a TODO in `DesignTimeSyntaxTreeGenerator.ProcessTransformationsOnType` ("the injected member should be skipped instead"); merging the two would need a second pass and is intentionally out of scope here. The two declarations merge fine via C# partial-class semantics, so `new GeneratedClass(...)` resolves correctly in the user's source.

## Progress

- [x] Phase 1 — Understand the issue
- [x] Phase 2 — Failing regression test
- [x] Phase 3 — Implement fix
- [x] Phase 4 — `Build.ps1 build` (0 warnings), AspectTests (2264 passed, net8.0), UnitTests (1882 passed, net8.0), LinkerTests (189 passed, net8.0), DefaultConstructor* on net48 (7 passed)
- [x] Phase 5 — Mark ready, request review

— Claude for @gfraiteur