### PR TITLE
Fix RpcService deadlock on TestContext.OnTimeout + ClientEndpoint mid-connect leak (#1624)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -308,12 +308,26 @@ public abstract partial class ClientEndpoint : BaseEndpoint
                 await this.TestSyncProvider.SyncPointAsync( $"ClientEndpoint.AfterStartsListening:{pipeName}", cancellationToken );
             }
 
-            // Update collections. Ownership of pipeStream and rpc transfers to _connectionByStream
-            // here; un-register them from pending tracking so Dispose disposes them exactly once
-            // via the normal _connectionByStream path.
-            InterlockedHelper.Update( ref this._connectionByStream, x => x.Add( rpc, new Connection( pipeStream, rpc, newClients ) ) );
-            this.UnregisterPending( rpc );
-            this.UnregisterPending( pipeStream );
+            // Atomically transfer ownership of pipeStream and rpc from the pending list to
+            // _connectionByStream. Both steps under _pendingLock so a concurrent Dispose either
+            // sees the resources in pending (and disposes them there) or in _connectionByStream
+            // (and disposes them there) — never both. If we removed from pending OUTSIDE this lock,
+            // a Dispose that snapshotted pending after publish but before unregister would dispose
+            // the resources and the _connectionByStream loop would dispose them a second time.
+            lock ( this._pendingLock )
+            {
+                if ( this._disposed )
+                {
+                    // Dispose ran between our last RegisterPending and now. It already disposed
+                    // pipeStream and rpc (they were in its snapshot). Just bail; ConnectCoreAsync's
+                    // catch block will run SetFailure on the clients.
+                    throw new ObjectDisposedException( this.GetType().FullName );
+                }
+
+                InterlockedHelper.Update( ref this._connectionByStream, x => x.Add( rpc, new Connection( pipeStream, rpc, newClients ) ) );
+                this._pendingDisposables.Remove( rpc );
+                this._pendingDisposables.Remove( pipeStream );
+            }
 
             if ( this.TestSyncProvider != null )
             {
@@ -402,6 +416,10 @@ public abstract partial class ClientEndpoint : BaseEndpoint
 
     protected override void Dispose( bool disposing )
     {
+        // Always run the base class disposal: BaseEndpoint cancels DisposeCancellationToken and
+        // calls GC.SuppressFinalize, both of which we want even on the finalizer path.
+        base.Dispose( disposing );
+
         if ( !disposing )
         {
             return;
@@ -409,7 +427,7 @@ public abstract partial class ClientEndpoint : BaseEndpoint
 
         // Take a snapshot of pending resources under the lock, then mark disposed so any concurrent
         // ConnectCoreAsync attempting to RegisterPending after this point disposes its own resources
-        // and bails out.
+        // and bails out, and so the publish-handoff in ConnectCoreAsync sees _disposed and bails.
         IDisposable[] pending;
 
         lock ( this._pendingLock )
@@ -420,14 +438,15 @@ public abstract partial class ClientEndpoint : BaseEndpoint
         }
 
         // Dispose pending resources OUTSIDE the lock (their Dispose may run user code or take
-        // other locks). Order: rpc objects first (they hold references to the stream), then streams.
-        // We just iterate; any IDisposable will get disposed — for our two types the order doesn't
-        // matter because both will tolerate the other being already disposed.
-        foreach ( var d in pending )
+        // other locks). Iterate in reverse-insertion order so the JsonRpc is disposed before its
+        // underlying NamedPipeClientStream — the JsonRpc holds the stream and may want to write
+        // a shutdown message before the stream goes away. (RegisterPending is called for the
+        // pipe stream first, then for the rpc; iterating backwards inverts that.)
+        for ( var i = pending.Length - 1; i >= 0; i-- )
         {
             try
             {
-                d.Dispose();
+                pending[i].Dispose();
             }
             catch ( Exception ex )
             {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -233,7 +233,13 @@ public abstract partial class ClientEndpoint : BaseEndpoint
         bool firstConnection,
         CancellationToken cancellationToken = default )
     {
-        ImmutableArray<RpcClient> newClients;
+        ImmutableArray<RpcClient> newClients = ImmutableArray<RpcClient>.Empty;
+
+        // Tracked outside the try so the catch can dispose them on any failure between
+        // RegisterPending and the publish handoff to _connectionByStream.
+        NamedPipeClientStream? pipeStream = null;
+        JsonRpc? rpc = null;
+        var handoffCompleted = false;
 
         try
         {
@@ -260,7 +266,7 @@ public abstract partial class ClientEndpoint : BaseEndpoint
 
             this.Logger.Trace?.Log( $"Connecting to the named pipe '{pipeName}'." );
 
-            var pipeStream = new NamedPipeClientStream( ".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous );
+            pipeStream = new NamedPipeClientStream( ".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous );
 
             // Register the pipe as pending BEFORE awaiting the connect. If Dispose runs between
             // now and the point where we publish to _connectionByStream, this entry ensures the
@@ -279,7 +285,7 @@ public abstract partial class ClientEndpoint : BaseEndpoint
             this.Logger.Trace?.Log( $"Connected to the named pipe '{pipeName}'." );
 
             // Create the callback channel.
-            var rpc = CreateRpc( pipeStream );
+            rpc = CreateRpc( pipeStream );
             this.RegisterPending( rpc );
             rpc.Disconnected += this.OnRpcDisconnected;
 
@@ -329,6 +335,8 @@ public abstract partial class ClientEndpoint : BaseEndpoint
                 this._pendingDisposables.Remove( pipeStream );
             }
 
+            handoffCompleted = true;
+
             if ( this.TestSyncProvider != null )
             {
                 await this.TestSyncProvider.SyncPointAsync( $"ClientEndpoint.BeforeSignalingAwaiters:{pipeName}", cancellationToken );
@@ -356,6 +364,42 @@ public abstract partial class ClientEndpoint : BaseEndpoint
             this.Logger.LogException( e, $"Cannot connect to the endpoint '{pipeName}'" );
 
             this.ExceptionHandler?.OnException( e, this.Logger, this.DisposeCancellationToken.IsCancellationRequested );
+
+            // Clean up resources registered as pending before the handoff. If the handoff completed,
+            // ownership transferred to _connectionByStream and Dispose will handle them; if not (the
+            // common failure path: ConnectAsync threw, AddLocalRpcTarget threw, etc.) the pending
+            // list would accumulate them until the endpoint itself is disposed. Dispose in LIFO
+            // order for the same reason as in Dispose.
+            if ( !handoffCompleted )
+            {
+                if ( rpc != null )
+                {
+                    this.UnregisterPending( rpc );
+
+                    try
+                    {
+                        rpc.Dispose();
+                    }
+                    catch ( Exception disposeEx )
+                    {
+                        this.Logger.Warning?.Log( $"Disposing pending rpc on connect failure threw: {disposeEx}" );
+                    }
+                }
+
+                if ( pipeStream != null )
+                {
+                    this.UnregisterPending( pipeStream );
+
+                    try
+                    {
+                        pipeStream.Dispose();
+                    }
+                    catch ( Exception disposeEx )
+                    {
+                        this.Logger.Warning?.Log( $"Disposing pending pipe stream on connect failure threw: {disposeEx}" );
+                    }
+                }
+            }
 
             foreach ( var client in newClients )
             {
@@ -454,12 +498,31 @@ public abstract partial class ClientEndpoint : BaseEndpoint
             }
         }
 
-        lock ( this._connectionByStream )
+        // _connectionByStream is an ImmutableDictionary swapped via InterlockedHelper.Update (and via
+        // a non-locked field write in OnRpcDisconnected). No other code locks on it, so a lock here
+        // would be misleading — it grants no synchronization. Read the field once into a local
+        // (atomic for a reference) and iterate the snapshot. Wrap each Dispose so that a thrown
+        // exception from one connection doesn't prevent the others from being released.
+        var connections = this._connectionByStream;
+
+        foreach ( var connection in connections.Values )
         {
-            foreach ( var rpc in this._connectionByStream.Values )
+            try
             {
-                rpc.Rpc.Dispose();
-                rpc.Stream.Dispose();
+                connection.Rpc.Dispose();
+            }
+            catch ( Exception ex )
+            {
+                this.Logger.Warning?.Log( $"Disposing connection rpc threw: {ex}" );
+            }
+
+            try
+            {
+                connection.Stream.Dispose();
+            }
+            catch ( Exception ex )
+            {
+                this.Logger.Warning?.Log( $"Disposing connection stream threw: {ex}" );
             }
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -40,6 +40,16 @@ public abstract partial class ClientEndpoint : BaseEndpoint
     private readonly ConcurrentDictionary<Type, TaskCompletionSource<RpcClient>> _clientAwaiters = new();
     private readonly object _addClientLock = new();
 
+    // Tracks resources created during ConnectCoreAsync that have not yet been published to
+    // _connectionByStream. Without this, calling Dispose while a ConnectCoreAsync has not yet
+    // reached the publication point would leak the underlying NamedPipeClientStream (and its
+    // JsonRpc), because Dispose only iterates _connectionByStream — and the pipe is added there
+    // only after rpc.StartListening succeeds. A leaked client pipe means the server-side JsonRpc
+    // never sees a disconnect, which can hang any code waiting for OnRpcDisconnected to fire.
+    private readonly object _pendingLock = new();
+    private readonly List<IDisposable> _pendingDisposables = new();
+    private bool _disposed;
+
     protected ClientEndpoint(
         IServiceProvider serviceProvider,
         string pipeName ) :
@@ -251,6 +261,14 @@ public abstract partial class ClientEndpoint : BaseEndpoint
             this.Logger.Trace?.Log( $"Connecting to the named pipe '{pipeName}'." );
 
             var pipeStream = new NamedPipeClientStream( ".", pipeName, PipeDirection.InOut, PipeOptions.Asynchronous );
+
+            // Register the pipe as pending BEFORE awaiting the connect. If Dispose runs between
+            // now and the point where we publish to _connectionByStream, this entry ensures the
+            // pipe is closed — which is what causes the server to observe a disconnect. Without
+            // this, disposing a ClientEndpoint mid-connect leaks the pipe and the server hangs
+            // forever waiting for OnRpcDisconnected.
+            this.RegisterPending( pipeStream );
+
             await pipeStream.ConnectAsync( cancellationToken ).WarnIfLongAsync( this.Logger, "Connect to pipe stream.", cancellationToken );
 
             if ( this.TestSyncProvider != null )
@@ -262,6 +280,7 @@ public abstract partial class ClientEndpoint : BaseEndpoint
 
             // Create the callback channel.
             var rpc = CreateRpc( pipeStream );
+            this.RegisterPending( rpc );
             rpc.Disconnected += this.OnRpcDisconnected;
 
             if ( firstConnection )
@@ -289,8 +308,12 @@ public abstract partial class ClientEndpoint : BaseEndpoint
                 await this.TestSyncProvider.SyncPointAsync( $"ClientEndpoint.AfterStartsListening:{pipeName}", cancellationToken );
             }
 
-            // Update collections.
+            // Update collections. Ownership of pipeStream and rpc transfers to _connectionByStream
+            // here; un-register them from pending tracking so Dispose disposes them exactly once
+            // via the normal _connectionByStream path.
             InterlockedHelper.Update( ref this._connectionByStream, x => x.Add( rpc, new Connection( pipeStream, rpc, newClients ) ) );
+            this.UnregisterPending( rpc );
+            this.UnregisterPending( pipeStream );
 
             if ( this.TestSyncProvider != null )
             {
@@ -351,17 +374,73 @@ public abstract partial class ClientEndpoint : BaseEndpoint
         }
     }
 
+    private void RegisterPending( IDisposable disposable )
+    {
+        lock ( this._pendingLock )
+        {
+            if ( this._disposed )
+            {
+                // Dispose already ran. Dispose this resource directly so the caller doesn't leak it,
+                // and surface the situation as an exception so ConnectCoreAsync's catch block runs
+                // its normal cleanup (SetFailure on pending clients, etc.).
+                disposable.Dispose();
+
+                throw new ObjectDisposedException( this.GetType().FullName );
+            }
+
+            this._pendingDisposables.Add( disposable );
+        }
+    }
+
+    private void UnregisterPending( IDisposable disposable )
+    {
+        lock ( this._pendingLock )
+        {
+            this._pendingDisposables.Remove( disposable );
+        }
+    }
+
     protected override void Dispose( bool disposing )
     {
-        if ( disposing )
+        if ( !disposing )
         {
-            lock ( this._connectionByStream )
+            return;
+        }
+
+        // Take a snapshot of pending resources under the lock, then mark disposed so any concurrent
+        // ConnectCoreAsync attempting to RegisterPending after this point disposes its own resources
+        // and bails out.
+        IDisposable[] pending;
+
+        lock ( this._pendingLock )
+        {
+            this._disposed = true;
+            pending = this._pendingDisposables.ToArray();
+            this._pendingDisposables.Clear();
+        }
+
+        // Dispose pending resources OUTSIDE the lock (their Dispose may run user code or take
+        // other locks). Order: rpc objects first (they hold references to the stream), then streams.
+        // We just iterate; any IDisposable will get disposed — for our two types the order doesn't
+        // matter because both will tolerate the other being already disposed.
+        foreach ( var d in pending )
+        {
+            try
             {
-                foreach ( var rpc in this._connectionByStream.Values )
-                {
-                    rpc.Rpc.Dispose();
-                    rpc.Stream.Dispose();
-                }
+                d.Dispose();
+            }
+            catch ( Exception ex )
+            {
+                this.Logger.Warning?.Log( $"Disposing pending resource threw: {ex}" );
+            }
+        }
+
+        lock ( this._connectionByStream )
+        {
+            foreach ( var rpc in this._connectionByStream.Values )
+            {
+                rpc.Rpc.Dispose();
+                rpc.Stream.Dispose();
             }
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -434,20 +434,38 @@ public abstract partial class ClientEndpoint : BaseEndpoint
 
     private void RegisterPending( IDisposable disposable )
     {
+        bool alreadyDisposed;
+
         lock ( this._pendingLock )
         {
-            if ( this._disposed )
+            alreadyDisposed = this._disposed;
+
+            if ( !alreadyDisposed )
             {
-                // Dispose already ran. Dispose this resource directly so the caller doesn't leak it,
-                // and surface the situation as an exception so ConnectCoreAsync's catch block runs
-                // its normal cleanup (SetFailure on pending clients, etc.).
-                disposable.Dispose();
-
-                throw new ObjectDisposedException( this.GetType().FullName );
+                this._pendingDisposables.Add( disposable );
             }
-
-            this._pendingDisposables.Add( disposable );
         }
+
+        if ( !alreadyDisposed )
+        {
+            return;
+        }
+
+        // Dispose already ran. Dispose the resource OUTSIDE _pendingLock so user code that
+        // JsonRpc.Dispose (or other IDisposables) may invoke — Disconnected handlers, etc. — cannot
+        // contend with the lock or block other RegisterPending callers. Then surface
+        // ObjectDisposedException so ConnectCoreAsync's catch block runs its normal cleanup
+        // (SetFailure on pending clients) and the caller does not leak the resource.
+        try
+        {
+            disposable.Dispose();
+        }
+        catch ( Exception ex )
+        {
+            this.Logger.Warning?.Log( $"Disposing pending resource registered after Dispose threw: {ex}" );
+        }
+
+        throw new ObjectDisposedException( this.GetType().FullName );
     }
 
     private void UnregisterPending( IDisposable disposable )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcService.cs
@@ -91,7 +91,7 @@ public abstract class RpcService<TApi> : RpcService, IDisposable where TApi : IR
     // Per-rpc registration entries. Created in ConfigureRpc, removed in OnRpcDisconnected. Each entry
     // owns its own lock so that OnRpcStarted (promotion to _clients/_apis) and OnRpcDisconnected (cleanup)
     // are serialized for the same rpc only. Operations on different rpcs do not contend, so a disconnect
-    // on one client cannot be blocked behind another client's in-flight promotion.
+    // on one client cannot be blocked behind another client's ongoing promotion.
     private readonly ConcurrentDictionary<JsonRpc, RegistrationEntry> _registrations = new();
 
     protected RpcService( ServerEndpoint serverEndpoint ) : base( serverEndpoint ) { }
@@ -157,17 +157,49 @@ public abstract class RpcService<TApi> : RpcService, IDisposable where TApi : IR
             return;
         }
 
-        lock ( entry.Lock )
+        // Mark IsDisconnected BEFORE acquiring entry.Lock. A concurrent OnRpcStarted that is past
+        // its _registrations lookup but still waiting on the lock will observe this flag (volatile
+        // read inside the lock) when it resumes and skip the _clients/_apis TryAdd. Setting the
+        // flag outside the lock means we never need to actually hold the lock for correctness —
+        // the in-lock TryRemove below is only an optimization for the case where the entry was
+        // already promoted.
+        entry.IsDisconnected = true;
+
+        // Use TryEnter, not Monitor.Enter: OnRpcDisconnected can run on a disposal/cancellation
+        // thread that is itself blocking the lock holder. Example seen in CI: a test cancellation
+        // token fires, the CTS.Cancel cascade runs async continuations inline on the timer thread,
+        // disposal of the endpoint triggers JsonRpc.Disconnected synchronously, and OnRpcDisconnected
+        // ends up needing entry.Lock — which is held by an OnRpcStarted whose user callback is
+        // synchronously waiting for a signal that the very same thread is supposed to deliver after
+        // disposal returns. A blocking Enter deadlocks; TryEnter degrades to best-effort cleanup
+        // and lets the cancellation cascade complete.
+        var lockTaken = false;
+
+        try
         {
-            // Setting IsDisconnected ensures any concurrent OnRpcStarted that already looked up the
-            // entry but is still waiting for this lock will skip promotion when it resumes.
-            entry.IsDisconnected = true;
+            Monitor.TryEnter( entry.Lock, TimeSpan.FromSeconds( 5 ), ref lockTaken );
 
             // _apis must be cleaned up alongside _clients so that subscribers iterating Apis
             // (e.g. EventHubRpcService.ForwardEventAsync) do not invoke a stored IRpcEventSender
-            // over a dead JsonRpc.
+            // over a dead JsonRpc. The IsDisconnected flag set above prevents a concurrent
+            // OnRpcStarted from re-adding to either dictionary, so removing outside the lock
+            // (lockTaken == false) is also safe: any TryAdd that already happened is undone here,
+            // and any TryAdd still pending is skipped by the IsDisconnected check.
             this._clients.TryRemove( rpc, out _ );
             this._apis.TryRemove( rpc, out _ );
+
+            if ( !lockTaken )
+            {
+                this.Logger.Warning?.Log(
+                    $"OnRpcDisconnected: could not acquire registration lock for rpc within timeout; cleanup proceeded without the lock." );
+            }
+        }
+        finally
+        {
+            if ( lockTaken )
+            {
+                Monitor.Exit( entry.Lock );
+            }
         }
     }
 
@@ -215,6 +247,12 @@ public abstract class RpcService<TApi> : RpcService, IDisposable where TApi : IR
 
     private sealed class RegistrationEntry
     {
+        // Volatile because OnRpcDisconnected writes it outside entry.Lock to avoid blocking on the
+        // lock (see OnRpcDisconnected comments). OnRpcStarted reads it inside the lock, but the
+        // lock acquire only fences the reader's own operations — without volatile, the unlocked
+        // write may not be visible.
+        private volatile bool _isDisconnected;
+
         public RegistrationEntry( IRpcCallback callback, TApi api )
         {
             this.Callback = callback;
@@ -227,6 +265,10 @@ public abstract class RpcService<TApi> : RpcService, IDisposable where TApi : IR
 
         public object Lock { get; } = new();
 
-        public bool IsDisconnected { get; set; }
+        public bool IsDisconnected
+        {
+            get => this._isDisconnected;
+            set => this._isDisconnected = value;
+        }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Threading/TaskExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Threading/TaskExtensions.cs
@@ -81,7 +81,15 @@ public static class TaskExtensions
 
     private static async Task WithCancellationSlow( this Task task, bool continueOnCapturedContext, CancellationToken cancellationToken )
     {
-        var taskCompletionSource = new TaskCompletionSource<bool>();
+        // RunContinuationsAsynchronously is critical: the cancellation callback below fires
+        // synchronously on the thread that calls CancellationTokenSource.Cancel (e.g. a Timer
+        // thread for a CancelAfter token). Without this option, TrySetResult would invoke our
+        // awaiter's continuation inline on that thread, and via async-method chaining the entire
+        // user continuation graph would execute on the cancelling thread. Locks held elsewhere by
+        // that very thread (or that it is supposed to release) become impossible to acquire,
+        // producing hard-to-diagnose deadlocks. Queuing continuations to the thread pool instead
+        // breaks the cascade at its root.
+        var taskCompletionSource = new TaskCompletionSource<bool>( TaskCreationOptions.RunContinuationsAsynchronously );
 
         var registration = cancellationToken.Register(
             s => ((TaskCompletionSource<bool>) s!).TrySetResult( true ),
@@ -105,7 +113,8 @@ public static class TaskExtensions
 
     private static async Task<T> WithCancellationSlow<T>( this Task<T> task, bool continueOnCapturedContext, CancellationToken cancellationToken )
     {
-        var taskCompletionSource = new TaskCompletionSource<bool>();
+        // See the non-generic overload for why RunContinuationsAsynchronously is required.
+        var taskCompletionSource = new TaskCompletionSource<bool>( TaskCreationOptions.RunContinuationsAsynchronously );
 
         var registration = cancellationToken.Register(
             s => ((TaskCompletionSource<bool>) s!).TrySetResult( true ),

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceRaiseEventTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceRaiseEventTests.cs
@@ -245,6 +245,13 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
     /// <c>OnPendingClientPromoting</c> hook and asserts that broadcasting after the dust settles only
     /// reaches the still-connected client.
     /// </summary>
+    /// <remarks>
+    /// This test also covers issue #1624 (mid-connect dispose): it pauses client2 at
+    /// <c>ClientEndpoint.AfterGetsServer</c> so client2 is provably mid-connect (pipe accepted, no rpc
+    /// yet) when <c>Dispose</c> is called. The test relies on <c>ClientEndpoint.Dispose</c> closing the
+    /// pending pipe stream so the server can observe the disconnect — without that fix
+    /// <c>client2.Dispose()</c> is a no-op in this state and the test hangs.
+    /// </remarks>
     [Fact]
     public async Task OnRpcStarted_DisconnectInMiddleOfPromotion_DoesNotLeaveDeadRpcInDictionaries()
     {
@@ -282,7 +289,11 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
         var service = await serverEndpoint.GetRequiredServiceAsync<EventTestService>( testContext.CancellationToken );
 
         var promotingReachedTcs = new TaskCompletionSource<bool>();
-        var promotingReleaseTcs = new TaskCompletionSource<bool>();
+
+        // RunContinuationsAsynchronously: when we TrySetResult below, we don't want the OnRpcStarted
+        // thread's continuation (the rest of the hook + the rest of OnRpcStarted) to run inline on the
+        // test thread.
+        var promotingReleaseTcs = new TaskCompletionSource<bool>( TaskCreationOptions.RunContinuationsAsynchronously );
         var disconnectAttemptedTcs = new TaskCompletionSource<bool>();
 
         service.OnPendingClientPromotingHook = () =>
@@ -299,17 +310,28 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
             disconnectAttemptedTcs.TrySetResult( true );
         };
 
+        // Pin client2 at AfterGetsServer: the pipe stream is created and OS-connected to the server,
+        // but client2 has not yet created its rpc or added itself to _connectionByStream. This is
+        // the pending state where ClientEndpoint.Dispose must still close the pipe (issue #1624).
+        // The server's accept side runs independently from this sync point and will reach
+        // OnRpcStarted's hook on its own.
+        var clientPausedSyncPoint = $"ClientEndpoint.AfterGetsServer:{pipeName}";
+        testContext.SyncProvider.EnableSyncPoint( clientPausedSyncPoint );
+
         // Start connecting the second client. Server enters OnRpcStarted, removes pending entry, hits hook.
         var client2 = new EventTestClientEndpoint( testContext.ServiceProvider, pipeName );
         var client2ConnectTask = client2.ConnectAsync( testContext.CancellationToken );
 
-        // Wait until the server's OnRpcStarted is paused mid-promotion.
+        // Wait until both: the server's OnRpcStarted is paused mid-promotion AND client2 is paused
+        // at AfterGetsServer (so we know Dispose will exercise the pending-resource cleanup path).
         await promotingReachedTcs.Task.WithCancellation( testContext.CancellationToken );
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( clientPausedSyncPoint, testContext.CancellationToken );
 
         // Trigger disconnection of client2 while server is paused. With the fix in place, the server's
         // OnRpcDisconnected will block on the registration lock. Without the fix, it would run concurrently
         // and find nothing to remove (since pending was already taken), leaving the dead rpc to be added by
-        // the resuming OnRpcStarted.
+        // the resuming OnRpcStarted. Disposing here also exercises ClientEndpoint.Dispose's pending-resource
+        // cleanup: client2's pipe is registered as pending but not yet in _connectionByStream.
         client2.Dispose();
 
         // Wait until OnRpcDisconnected has been entered for client2's rpc.
@@ -321,6 +343,10 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
 
         // Wait for the server-side disconnect handler to finish (so dictionaries are in their final state).
         await clientDisconnectedTcs.Task.WithCancellation( testContext.CancellationToken );
+
+        // Release client2's sync point so its connect task can unwind (it will fault because the pipe
+        // is disposed; that's acceptable, see the catch below).
+        testContext.SyncProvider.ReleaseSyncPoint( clientPausedSyncPoint );
 
         // Allow the connect task to complete or fail — either is acceptable, the disconnect happens client-side.
         try
@@ -410,7 +436,7 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
     /// <c>OnRpcStarted</c> — so A cannot be removed from <c>_clients</c>/<c>_apis</c> until B finishes
     /// promotion. Concurrent broadcasts (which do not take the lock) can still pick up A's already-dead
     /// callback. The fix replaces the per-service lock with a per-rpc lock on a <c>RegistrationEntry</c>,
-    /// so disconnect cleanup of unrelated rpcs is no longer serialized with any in-flight promotion.
+    /// so disconnect cleanup of unrelated rpcs is no longer serialized with any ongoing promotion.
     /// </summary>
     [Fact]
     public async Task OnRpcDisconnected_OfClientA_NotBlockedByOnRpcStartedOfUnrelatedClientB()
@@ -583,6 +609,62 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
 #pragma warning restore VSTHRD103
 
         await Assert.ThrowsAnyAsync<OperationCanceledException>( () => service.TestSafeBroadcastInvokeAsync( Task.FromCanceled, cts.Token ) );
+    }
+
+    /// <summary>
+    /// Regression test for issue #1624 (Fix 2B). Before the fix, <c>ClientEndpoint.Dispose</c> only
+    /// closed connections that had already been published to <c>_connectionByStream</c> — which
+    /// happens only after <c>rpc.StartListening</c>. Disposing while <c>ConnectCoreAsync</c> was
+    /// still in flight was a silent no-op: the OS pipe stayed open, the server's <c>JsonRpc</c>
+    /// never raised <c>Disconnected</c>, and any code waiting for <c>OnRpcDisconnected</c> hung
+    /// forever. This test pauses client2 at <c>ClientEndpoint.AfterGetsServer</c> (pipe accepted,
+    /// rpc not yet created), disposes the endpoint, and asserts that the server observes the
+    /// disconnect.
+    /// </summary>
+    [Fact]
+    public async Task ClientEndpointDispose_MidConnect_ClosesPendingPipe_ServerSeesDisconnect()
+    {
+        using var testContext = this.CreateRpcTestContext();
+
+        var pipeName = $"{nameof(RpcServiceRaiseEventTests)}_{Guid.NewGuid()}";
+
+        using var serverEndpoint = new EventTestServerEndpoint( testContext.ServiceProvider, pipeName );
+
+        var clientDisconnectedTcs = new TaskCompletionSource<bool>();
+        serverEndpoint.ClientDisconnected += () => clientDisconnectedTcs.TrySetResult( true );
+
+        serverEndpoint.Start();
+
+        // Pause the client right after the OS pipe handshake but before rpc is constructed: only
+        // the NamedPipeClientStream exists and it has not yet been added to _connectionByStream.
+        var syncPointName = $"ClientEndpoint.AfterGetsServer:{pipeName}";
+        testContext.SyncProvider.EnableSyncPoint( syncPointName );
+
+        var clientEndpoint = new EventTestClientEndpoint( testContext.ServiceProvider, pipeName );
+
+        // Fire-and-forget connect: the test disposes before the connect can finish.
+        var connectTask = clientEndpoint.ConnectAsync( testContext.CancellationToken );
+
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( syncPointName, testContext.CancellationToken );
+
+        // Dispose mid-connect. With the fix, the pending pipe is closed and the server's JsonRpc
+        // detects EOF and raises Disconnected (which fires ClientDisconnected).
+        clientEndpoint.Dispose();
+
+        testContext.SyncProvider.ReleaseSyncPoint( syncPointName );
+
+        try
+        {
+            // ReSharper disable once RedundantWithCancellation
+            await connectTask.WithCancellation( testContext.CancellationToken );
+        }
+        catch
+        {
+            // Expected: connection task faults because the pipe was disposed mid-connect.
+        }
+
+        // The real assertion: without the fix, this hangs until the test cancellation token cancels.
+        await clientDisconnectedTcs.Task.WithCancellation( testContext.CancellationToken );
     }
 
     /// <summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.Utilities.Threading;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -22,8 +23,15 @@ public sealed class TaskExtensionsTests
     /// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/> to the internal
     /// <see cref="TaskCompletionSource{T}"/> used by <c>WithCancellationSlow</c>.
     /// </summary>
+    /// <remarks>
+    /// The cancellation runs on a dedicated non-thread-pool <see cref="Thread"/> rather than the
+    /// xUnit test thread. Otherwise the test thread, after yielding at the post-Cancel await, can
+    /// itself be reused by the thread pool to dispatch the queued continuation — producing a
+    /// false match between "cancelling thread" and "continuation thread" even when the invariant
+    /// holds. A dedicated thread is never a thread-pool worker, so its identity is distinct.
+    /// </remarks>
     [Fact]
-    public async Task WithCancellation_OnCancel_DoesNotRunContinuationsInline()
+    public void WithCancellation_OnCancel_DoesNotRunContinuationsInline()
     {
         // A task that never completes on its own: the only way out of WithCancellation is the token.
         var hangingTask = new TaskCompletionSource<int>().Task;
@@ -31,30 +39,43 @@ public sealed class TaskExtensionsTests
         using var cts = new CancellationTokenSource();
         var wrapped = hangingTask.WithCancellation( cts.Token );
 
-        var cancellingThreadId = Thread.CurrentThread.ManagedThreadId;
-        var continuationThreadId = 0;
-        var continuationFinishedTcs = new TaskCompletionSource<bool>( TaskCreationOptions.RunContinuationsAsynchronously );
+        Thread? continuationThread = null;
+        using var continuationDone = new ManualResetEventSlim( false );
 
-        // Request inline continuation: this is the strongest possible "run on the cancelling
-        // thread" hint a consumer could give. With RunContinuationsAsynchronously on the internal
-        // TCS, the runtime is required to honor asynchronous scheduling regardless.
+        // Request synchronous continuation: this is the strongest possible "run on the completing
+        // thread" hint a consumer can give. With RunContinuationsAsynchronously on the internal
+        // TCS, the runtime must still honor asynchronous scheduling and not run the chain inline
+        // on the thread that called Cancel.
         _ = wrapped.ContinueWith(
             _ =>
             {
-                continuationThreadId = Thread.CurrentThread.ManagedThreadId;
-                continuationFinishedTcs.TrySetResult( true );
+                continuationThread = Thread.CurrentThread;
+                continuationDone.Set();
             },
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default );
 
+        Thread? cancellingThread = null;
+        var cancelThread = new Thread(
+            () =>
+            {
+                cancellingThread = Thread.CurrentThread;
 #pragma warning disable VSTHRD103 // Synchronous Cancel is exactly what this test measures.
-        cts.Cancel();
+                cts.Cancel();
 #pragma warning restore VSTHRD103
+            } ) { IsBackground = true, Name = "WithCancellation-cancel-thread" };
 
-        await continuationFinishedTcs.Task;
+        cancelThread.Start();
+        Assert.True( cancelThread.Join( TimeSpan.FromSeconds( 10 ) ), "Cancel thread should complete promptly." );
+        Assert.True( continuationDone.Wait( TimeSpan.FromSeconds( 10 ) ), "Continuation should run." );
 
-        Assert.NotEqual( 0, continuationThreadId );
-        Assert.NotEqual( cancellingThreadId, continuationThreadId );
+        Assert.NotNull( cancellingThread );
+        Assert.NotNull( continuationThread );
+
+        // The continuation must not have run on the dedicated cancelling thread. With Fix 1B's
+        // RunContinuationsAsynchronously the chain dispatches to a thread-pool worker; without it
+        // the entire async cascade runs inline on the cancelling thread and these references match.
+        Assert.NotSame( cancellingThread, continuationThread );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
@@ -24,14 +24,19 @@ public sealed class TaskExtensionsTests
     /// <see cref="TaskCompletionSource{T}"/> used by <c>WithCancellationSlow</c>.
     /// </summary>
     /// <remarks>
-    /// The cancellation runs on a dedicated non-thread-pool <see cref="Thread"/> rather than the
-    /// xUnit test thread. Otherwise the test thread, after yielding at the post-Cancel await, can
-    /// itself be reused by the thread pool to dispatch the queued continuation — producing a
-    /// false match between "cancelling thread" and "continuation thread" even when the invariant
-    /// holds. A dedicated thread is never a thread-pool worker, so its identity is distinct.
+    /// The test asserts the semantic invariant directly: a blocking continuation should not stop
+    /// <c>Cancel</c> from returning. Without <c>RunContinuationsAsynchronously</c> the continuation
+    /// runs inline on the cancelling thread, so <c>Cancel</c> is blocked inside the continuation
+    /// waiting on the same event the test only releases after the timeout has passed. With the flag
+    /// in place the continuation is dispatched to the thread pool and <c>Cancel</c> returns
+    /// immediately.
+    ///
+    /// Cancellation is started on a dedicated non-thread-pool <see cref="Thread"/> so that
+    /// <c>Join</c> measures Cancel's progress directly (a thread-pool task would let the thread pool
+    /// schedule it however it wants, complicating the timing semantics).
     /// </remarks>
     [Fact]
-    public void WithCancellation_OnCancel_DoesNotRunContinuationsInline()
+    public void WithCancellation_OnCancel_DoesNotBlockOnSlowContinuations()
     {
         // A task that never completes on its own: the only way out of WithCancellation is the token.
         var hangingTask = new TaskCompletionSource<int>().Task;
@@ -39,43 +44,39 @@ public sealed class TaskExtensionsTests
         using var cts = new CancellationTokenSource();
         var wrapped = hangingTask.WithCancellation( cts.Token );
 
-        Thread? continuationThread = null;
-        using var continuationDone = new ManualResetEventSlim( false );
+        using var continuationCanProceed = new ManualResetEventSlim( false );
 
-        // Request synchronous continuation: this is the strongest possible "run on the completing
-        // thread" hint a consumer can give. With RunContinuationsAsynchronously on the internal
-        // TCS, the runtime must still honor asynchronous scheduling and not run the chain inline
-        // on the thread that called Cancel.
-        _ = wrapped.ContinueWith(
-            _ =>
-            {
-                continuationThread = Thread.CurrentThread;
-                continuationDone.Set();
-            },
+        // The continuation blocks on continuationCanProceed. With ExecuteSynchronously requested,
+        // an inline-running continuation would freeze the thread that completes wrapped — which,
+        // if Fix 1B regressed, is exactly the cancelling thread.
+        var continued = wrapped.ContinueWith(
+            _ => continuationCanProceed.Wait(),
             CancellationToken.None,
             TaskContinuationOptions.ExecuteSynchronously,
             TaskScheduler.Default );
 
-        Thread? cancellingThread = null;
         var cancelThread = new Thread(
             () =>
             {
-                cancellingThread = Thread.CurrentThread;
 #pragma warning disable VSTHRD103 // Synchronous Cancel is exactly what this test measures.
                 cts.Cancel();
 #pragma warning restore VSTHRD103
             } ) { IsBackground = true, Name = "WithCancellation-cancel-thread" };
 
         cancelThread.Start();
-        Assert.True( cancelThread.Join( TimeSpan.FromSeconds( 10 ) ), "Cancel thread should complete promptly." );
-        Assert.True( continuationDone.Wait( TimeSpan.FromSeconds( 10 ) ), "Continuation should run." );
 
-        Assert.NotNull( cancellingThread );
-        Assert.NotNull( continuationThread );
+        // Primary invariant. With Fix 1B's RunContinuationsAsynchronously the chain dispatches to a
+        // thread-pool worker and the cancelling thread returns immediately. Without it, the entire
+        // async cascade runs inline on the cancelling thread and gets stuck inside the continuation
+        // until we Set the event below — which we delay until after this Join's timeout. So the
+        // bug regressing manifests as Join returning false.
+        var cancelReturned = cancelThread.Join( TimeSpan.FromSeconds( 2 ) );
 
-        // The continuation must not have run on the dedicated cancelling thread. With Fix 1B's
-        // RunContinuationsAsynchronously the chain dispatches to a thread-pool worker; without it
-        // the entire async cascade runs inline on the cancelling thread and these references match.
-        Assert.NotSame( cancellingThread, continuationThread );
+        // Release the continuation so the thread pool (or, in the regressed case, the cancel thread)
+        // unwinds before the test exits. Otherwise we'd leak a blocked worker.
+        continuationCanProceed.Set();
+
+        Assert.True( cancelReturned, "Cancel must return without waiting on the continuation; got blocked instead." );
+        Assert.True( continued.Wait( TimeSpan.FromSeconds( 5 ) ), "Continuation should complete after being released." );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
@@ -1,0 +1,60 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.Utilities.Threading;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Utilities.Threading;
+
+#pragma warning disable VSTHRD200 // Use "Async" suffix - test naming convention prefers descriptive names.
+
+public sealed class TaskExtensionsTests
+{
+    /// <summary>
+    /// Regression test for issue #1624 (Fix 1B). When the cancellation token of a
+    /// <c>WithCancellation</c>-wrapped task fires, the resulting cancellation continuations must
+    /// not execute inline on the thread that calls <c>CancellationTokenSource.Cancel</c>. If they
+    /// did, locks held elsewhere by that thread (or that it is supposed to release later) would be
+    /// unreachable, producing the deadlock observed in CI. The invariant is enforced by passing
+    /// <see cref="TaskCreationOptions.RunContinuationsAsynchronously"/> to the internal
+    /// <see cref="TaskCompletionSource{T}"/> used by <c>WithCancellationSlow</c>.
+    /// </summary>
+    [Fact]
+    public async Task WithCancellation_OnCancel_DoesNotRunContinuationsInline()
+    {
+        // A task that never completes on its own: the only way out of WithCancellation is the token.
+        var hangingTask = new TaskCompletionSource<int>().Task;
+
+        using var cts = new CancellationTokenSource();
+        var wrapped = hangingTask.WithCancellation( cts.Token );
+
+        var cancellingThreadId = Thread.CurrentThread.ManagedThreadId;
+        var continuationThreadId = 0;
+        var continuationFinishedTcs = new TaskCompletionSource<bool>( TaskCreationOptions.RunContinuationsAsynchronously );
+
+        // Request inline continuation: this is the strongest possible "run on the cancelling
+        // thread" hint a consumer could give. With RunContinuationsAsynchronously on the internal
+        // TCS, the runtime is required to honor asynchronous scheduling regardless.
+        _ = wrapped.ContinueWith(
+            _ =>
+            {
+                continuationThreadId = Thread.CurrentThread.ManagedThreadId;
+                continuationFinishedTcs.TrySetResult( true );
+            },
+            CancellationToken.None,
+            TaskContinuationOptions.ExecuteSynchronously,
+            TaskScheduler.Default );
+
+#pragma warning disable VSTHRD103 // Synchronous Cancel is exactly what this test measures.
+        cts.Cancel();
+#pragma warning restore VSTHRD103
+
+        await continuationFinishedTcs.Task;
+
+        Assert.NotEqual( 0, continuationThreadId );
+        Assert.NotEqual( cancellingThreadId, continuationThreadId );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/Threading/TaskExtensionsTests.cs
@@ -36,7 +36,7 @@ public sealed class TaskExtensionsTests
     /// schedule it however it wants, complicating the timing semantics).
     /// </remarks>
     [Fact]
-    public void WithCancellation_OnCancel_DoesNotBlockOnSlowContinuations()
+    public async Task WithCancellation_OnCancel_DoesNotBlockOnSlowContinuations()
     {
         // A task that never completes on its own: the only way out of WithCancellation is the token.
         var hangingTask = new TaskCompletionSource<int>().Task;
@@ -77,6 +77,9 @@ public sealed class TaskExtensionsTests
         continuationCanProceed.Set();
 
         Assert.True( cancelReturned, "Cancel must return without waiting on the continuation; got blocked instead." );
-        Assert.True( continued.Wait( TimeSpan.FromSeconds( 5 ) ), "Continuation should complete after being released." );
+
+        // Await the continuation with a timeout so a badly broken implementation can't hang the test.
+        var raceWinner = await Task.WhenAny( continued, Task.Delay( TimeSpan.FromSeconds( 5 ) ) );
+        Assert.Same( continued, raceWinner );
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1624. CI build [#324196](https://postsharp.teamcity.com/buildConfiguration/Metalama_Metalama20261_Metalama_DebugBuild/324196) hung in `Metalama.Framework.Tests.UnitTests` (net48) for the full 60-minute build timeout. Diagnosis from the `testhost.net48` dump pointed at four distinct issues, all addressed here.

## Changes

### `RpcService<T>.OnRpcDisconnected` no longer blocks on the lock (Fix 1A)
`IsDisconnected` is now a `volatile` field set BEFORE attempting `entry.Lock`, and the cleanup uses `Monitor.TryEnter` with a 5-second timeout. The flag itself is what guarantees no dead rpc survives in `_clients`/`_apis`: a paused `OnRpcStarted` that resumes after the flag is set will skip its `TryAdd`. The (now optional) lock acquisition is just an optimization for cleaning up entries that were already promoted. Without this, a disposal-driven `OnRpcDisconnected` running on the same thread as a synchronously-blocked `OnPendingClientPromoting` deadlocks.

### `TaskExtensions.WithCancellationSlow` stops inlining cancellation continuations (Fix 1B)
The internal `TaskCompletionSource<bool>` now uses `TaskCreationOptions.RunContinuationsAsynchronously`. Before this, `CancellationTokenSource.Cancel` fired callbacks synchronously on the cancelling thread, and via async-method chaining the entire user continuation graph (including `Dispose` paths) ran inline — so locks held elsewhere by that same thread were unreachable.

### `ClientEndpoint.Dispose` closes pending pipes/rpcs (Fix 2B)
Resources created in `ConnectCoreAsync` (`NamedPipeClientStream`, `JsonRpc`) are now tracked in `_pendingDisposables` from creation until they're published to `_connectionByStream`. `Dispose` cleans them up, and `RegisterPending` after `Dispose` disposes the resource and throws so `ConnectCoreAsync` unwinds normally. Previously, disposing a `ClientEndpoint` while `ConnectCoreAsync` was still in flight silently leaked the OS pipe — the server never saw a disconnect and any code waiting for `OnRpcDisconnected` hung forever.

### Test determinism (Fix 2A)
The regression test `OnRpcStarted_DisconnectInMiddleOfPromotion_DoesNotLeaveDeadRpcInDictionaries` now pins client2 at `ClientEndpoint.AfterGetsServer` via the existing sync provider, so it deterministically exercises the mid-connect dispose path (rather than relying on a timing race between client setup and server promotion). A dedicated regression test `ClientEndpointDispose_MidConnect_ClosesPendingPipe_ServerSeesDisconnect` covers the production fix from 2B in isolation.

## Test plan

- [x] `dotnet test -f net48 --filter DesignTime.Rpc` — 80 passed, 1 pre-existing skip
- [x] `dotnet test -f net8.0 --filter Rpc` — 83 passed, 1 pre-existing skip
- [x] Stress-ran the previously-flaky test 10x consecutively on net48 — all pass in ~1s each (vs. the original 60-minute hang)
- [ ] Full TC build (will run on push)

— Claude for @gfraiteur