### PR TITLE
Fix scope mismatch exception when compilation lacks Metalama.Framework reference

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ClassifyingCompilationContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ClassifyingCompilationContext.cs
@@ -31,5 +31,7 @@ internal sealed class ClassifyingCompilationContext
 
     public Compilation SourceCompilation => this.CompilationContext.Compilation;
 
+    public bool ReferencesMetalamaFramework => this.CompilationContext.ReferencesMetalamaFramework;
+
     public SafeSymbolComparer SymbolComparer => this.CompilationContext.SymbolComparer;
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Services/CompilationContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Services/CompilationContext.cs
@@ -83,6 +83,14 @@ public sealed class CompilationContext : ICompilationServices, ITemplateReflecti
     internal ImmutableDictionary<AssemblyIdentity, IAssemblySymbol> Assemblies
         => this.Compilation.SourceModule.ReferencedAssemblySymbols.Concat( this.Compilation.Assembly ).ToImmutableDictionary( x => x.Identity, x => x );
 
+    /// <summary>
+    /// Gets a value indicating whether the compilation references the <c>Metalama.Framework</c> assembly. This can be
+    /// <c>false</c> transiently when the IDE analyzes a project whose references are momentarily incomplete.
+    /// </summary>
+    [Memo]
+    internal bool ReferencesMetalamaFramework
+        => this.Compilation.SourceModule.ReferencedAssemblySymbols.Any( a => a.Name == "Metalama.Framework" );
+
     [Memo]
     internal IEqualityComparer<IEvent> EventComparer => new MemberComparer<IEvent>( this.Comparers.Default );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingCodeValidator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingCodeValidator.cs
@@ -217,6 +217,15 @@ namespace Metalama.Framework.Engine.Templating
             bool? hasCompileTimeCodeFast,
             CancellationToken cancellationToken )
         {
+            if ( !compilationContext.ReferencesMetalamaFramework )
+            {
+                // There is nothing to validate when the compilation does not reference Metalama. This situation can
+                // happen transiently when the IDE analyzes a project whose references are momentarily incomplete,
+                // e.g. during a 'git clean' (https://github.com/metalama/Metalama/issues/1630). Proceeding would
+                // throw when resolving Metalama symbols.
+                return true;
+            }
+
             Visitor visitor = new(
                 serviceProvider,
                 semanticModel,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingCodeValidator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Templating/TemplatingCodeValidator.cs
@@ -60,6 +60,17 @@ namespace Metalama.Framework.Engine.Templating
             Action<ScopedSuppression>? reportSuppression,
             CancellationToken cancellationToken )
         {
+            if ( !compilationContext.ReferencesMetalamaFramework )
+            {
+                // There is nothing to validate when the compilation does not reference Metalama. Short-circuit
+                // before walking syntax trees and requesting semantic models. See the comment in ValidateCore
+                // and https://github.com/metalama/Metalama/issues/1630.
+                return new TwoPhaseValidationResult(
+                    Task.FromResult( true ),
+                    Task.FromResult( true ),
+                    CancellationTokenSource.CreateLinkedTokenSource( cancellationToken ) );
+            }
+
             var taskScheduler = serviceProvider.GetRequiredService<IConcurrentTaskRunner>();
             var observer = serviceProvider.Global.GetService<ITemplatingCodeValidatorObserver>();
             var semanticModelProvider = compilationContext.SemanticModelProvider;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SemanticModelAnalyzerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Templating/SemanticModelAnalyzerTests.cs
@@ -451,6 +451,38 @@ namespace Metalama.Framework.Tests.UnitTests.Templating
         }
 
         [Fact]
+        public void NoMetalamaReference_DoesNotThrow()
+        {
+            // Regression test for https://github.com/metalama/Metalama/issues/1630.
+            // While the IDE is open, a 'git clean' can momentarily leave a compilation that still has the
+            // Metalama analyzer loaded but no metadata reference to Metalama.Framework. The validator must
+            // degrade to a no-op instead of crashing.
+            using var testContext = this.CreateTestContext();
+
+            var compilation = testContext.CreateCSharpCompilation(
+                """
+                class X { void M() {} }
+                """,
+                addMetalamaReferences: false );
+
+            List<Diagnostic> diagnostics = new();
+            var syntaxTree = compilation.SyntaxTrees[0];
+            var semanticModel = compilation.GetSemanticModel( syntaxTree );
+
+            // This should not throw.
+            TemplatingCodeValidator.Validate(
+                testContext.ServiceProvider,
+                semanticModel,
+                diagnostics.Add,
+                null,
+                false,
+                false,
+                testContext.CancellationToken );
+
+            Assert.Empty( diagnostics );
+        }
+
+        [Fact]
         public void WellKnownTypesNotReported()
         {
             using var testContext = this.CreateTestContext();


### PR DESCRIPTION
## Summary
- `TemplatingCodeValidator.Visitor` resolved Metalama symbols (`TypeFabric`, `IAdviceAttribute`, `ICompileTimeSerializable`) unconditionally in its constructor, throwing `InvalidOperationException` when the compilation did not reference `Metalama.Framework`.
- This happened transiently at design time — e.g. when a `git clean` left a project with incomplete references while the Rider/Roslyn analyzer was still running — and was reported as a telemetry crash.
- Added a `[Memo]`-cached `CompilationContext.ReferencesMetalamaFramework` property and exposed it via `ClassifyingCompilationContext`.
- `TemplatingCodeValidator.ValidateCore` now returns early (success, no diagnostics) when the compilation does not reference `Metalama.Framework`, before constructing the `Visitor`. This is consistent with the aspect pipeline, which already guards this case (`CompileTimeCompilationBuilder`).
- Added regression test `SemanticModelAnalyzerTests.NoMetalamaReference_DoesNotThrow`.

## Issues Fixed
- Fixes #1630 - Scope mismatch exception during a cleanup