### PR TITLE
Fix #1636: crash combining IAspectWeaver-based aspects with Metalama.Patterns.Contracts

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/AspectOrdering/AspectLayerSorter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AspectOrdering/AspectLayerSorter.cs
@@ -3,7 +3,6 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Code.Collections;
-using Metalama.Framework.Engine.AspectWeavers;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.Collections;
 using Metalama.Framework.Engine.Diagnostics;
@@ -234,8 +233,6 @@ internal static class AspectLayerSorter
             sortedIndexes[i] = i;
         }
 
-        bool IsWeaver( int index ) => unsortedAspectLayers[index].AspectClass.AspectDriver is IAspectWeaver;
-
         Array.Sort(
             sortedIndexes,
             ( i, j ) =>
@@ -250,23 +247,6 @@ internal static class AspectLayerSorter
                 if ( compareDistance != 0 )
                 {
                     return compareDistance;
-                }
-
-                // When two layers are not explicitly ordered relative to each other (i.e. they have the same
-                // topological distance), process layers backed by an IAspectWeaver (low-level aspects) first.
-                // A weaver always forms its own pipeline stage, so if it were ordered between two layers of the
-                // same high-level aspect (e.g. the default and the secondary "Build" layer of a ContractAspect)
-                // it would split that aspect across two high-level stages, which the pipeline does not support
-                // and which crashes with a KeyNotFoundException in PipelineStepIdComparer (issue #1636). The
-                // layers of a high-level aspect always belong to consecutive distance bands, so moving unordered
-                // weavers to the front of their band keeps every high-level aspect's layers within a single stage.
-                // This only affects layers that are unordered relative to each other; explicit ordering produces
-                // different distances and is therefore unaffected.
-                var compareWeaver = IsWeaver( j ).CompareTo( IsWeaver( i ) );
-
-                if ( compareWeaver != 0 )
-                {
-                    return compareWeaver;
                 }
 
                 // If two aspects are not explicitly ordered, we order them alphabetically.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AspectOrdering/AspectLayerSorter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AspectOrdering/AspectLayerSorter.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Code.Collections;
+using Metalama.Framework.Engine.AspectWeavers;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.Collections;
 using Metalama.Framework.Engine.Diagnostics;
@@ -233,6 +234,8 @@ internal static class AspectLayerSorter
             sortedIndexes[i] = i;
         }
 
+        bool IsWeaver( int index ) => unsortedAspectLayers[index].AspectClass.AspectDriver is IAspectWeaver;
+
         Array.Sort(
             sortedIndexes,
             ( i, j ) =>
@@ -247,6 +250,23 @@ internal static class AspectLayerSorter
                 if ( compareDistance != 0 )
                 {
                     return compareDistance;
+                }
+
+                // When two layers are not explicitly ordered relative to each other (i.e. they have the same
+                // topological distance), process layers backed by an IAspectWeaver (low-level aspects) first.
+                // A weaver always forms its own pipeline stage, so if it were ordered between two layers of the
+                // same high-level aspect (e.g. the default and the secondary "Build" layer of a ContractAspect)
+                // it would split that aspect across two high-level stages, which the pipeline does not support
+                // and which crashes with a KeyNotFoundException in PipelineStepIdComparer (issue #1636). The
+                // layers of a high-level aspect always belong to consecutive distance bands, so moving unordered
+                // weavers to the front of their band keeps every high-level aspect's layers within a single stage.
+                // This only affects layers that are unordered relative to each other; explicit ordering produces
+                // different distances and is therefore unaffected.
+                var compareWeaver = IsWeaver( j ).CompareTo( IsWeaver( i ) );
+
+                if ( compareWeaver != 0 )
+                {
+                    return compareWeaver;
                 }
 
                 // If two aspects are not explicitly ordered, we order them alphabetically.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
@@ -121,6 +121,16 @@ namespace Metalama.Framework.Engine.Diagnostics
             Error,
             "Two layers are not strongly ordered." );
 
+        internal static readonly DiagnosticDefinition<(string AspectType, string WeaverAspectType)> AspectLayersSeparatedByWeaver = new(
+            "LAMA0042",
+            _category,
+            "The aspect '{0}' has several layers, but the low-level aspect '{1}' is ordered between two of these layers. "
+            + "A low-level aspect (i.e. one based on IAspectWeaver) cannot be ordered between two layers of another aspect, "
+            + "because it would split that aspect across two pipeline stages. Add an [assembly: " + nameof(AspectOrderAttribute)
+            + "(...)] attribute to order '{1}' before or after all layers of '{0}'.",
+            Error,
+            "A low-level aspect weaver is ordered between two layers of another aspect." );
+
         internal static readonly DiagnosticDefinition<(string TemplateName, string ClassName, string BaseClassName)>
             TemplateWithSameNameAlreadyDefinedInBaseClass = new(
                 "LAMA0036",

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/AspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/AspectPipeline.cs
@@ -288,6 +288,52 @@ public abstract class AspectPipeline : IDisposable
                         : new PipelineStageConfiguration( PipelineStageKind.LowLevel, g.ToImmutableArray(), (IAspectWeaver) g.Key ) )
             .ToImmutableArray();
 
+        // Validate that no aspect has its layers split across several stages. A low-level weaver always forms its own
+        // stage, and the layers of a high-level aspect must all be processed within a single high-level stage (the
+        // aspect source is evaluated once, in the stage owning the default layer, and all layers are processed there).
+        // Ordering a weaver between two layers of the same aspect splits it across stages, which is not supported and
+        // would otherwise crash with a KeyNotFoundException in PipelineStepIdComparer (issue #1636).
+        {
+            var firstStageByAspect = new Dictionary<string, int>();
+
+            for ( var stageIndex = 0; stageIndex < stages.Length; stageIndex++ )
+            {
+                foreach ( var layer in stages[stageIndex].AspectLayers )
+                {
+                    var aspectName = layer.AspectClass.FullName;
+
+                    if ( firstStageByAspect.TryGetValue( aspectName, out var firstStageIndex ) )
+                    {
+                        if ( firstStageIndex != stageIndex )
+                        {
+                            // The aspect reappears in a later stage: its layers are separated by an intervening stage.
+                            // Report against the first low-level (weaver) stage that sits between the two layers.
+                            var separatingWeaverStage = stages
+                                .Skip( firstStageIndex + 1 )
+                                .Take( stageIndex - firstStageIndex - 1 )
+                                .First( s => s.Kind == PipelineStageKind.LowLevel );
+
+                            diagnosticAdder.Report(
+                                GeneralDiagnosticDescriptors.AspectLayersSeparatedByWeaver.CreateRoslynDiagnostic(
+                                    layer.AspectClass.GetDiagnosticLocation( compilationModel.RoslynCompilation ),
+                                    (layer.AspectClass.ShortName, separatingWeaverStage.AspectLayers[0].AspectClass.ShortName) ) );
+
+                            this.Logger.Warning?.Log(
+                                $"TryInitialize('{this.ProjectOptions.AssemblyName}') failed: the layers of aspect '{aspectName}' are split across stages." );
+
+                            configuration = null;
+
+                            return false;
+                        }
+                    }
+                    else
+                    {
+                        firstStageByAspect[aspectName] = stageIndex;
+                    }
+                }
+            }
+        }
+
         var eligibilityService = new EligibilityService( allAspectClasses );
         var diagnosticManifest = compileTimeProject.ClosureDiagnosticManifest.Union( extensionInitializationContext.DiagnosticManifest );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspect.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspect.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Threading.Tasks;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.AspectWeavers;
+using Metalama.Framework.Engine.Utilities.Roslyn;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+#pragma warning disable CS8602
+
+// This test reproduces issue #1636: a weaver-based aspect (IAspectWeaver) used together with a
+// ContractAspect-based aspect in the same compilation, with NO explicit [assembly: AspectOrder]
+// tying them together, used to crash with a KeyNotFoundException in PipelineStepIdComparer.Compare
+// (reported as LAMA0601).
+//
+// A ContractAspect has two layers: the default layer and a secondary "Build" layer, ordered
+// (default -> Build). A weaver-based aspect has no ordering relationship with the contract, so it
+// is sorted only by its (descending) name. The aspect names here are chosen so that the weaver
+// aspect sorts BETWEEN the contract's default and "Build" layers (i.e. ordered list is
+// [NotNullAttribute, MakeVirtualAttribute, NotNullAttribute:Build]) — exactly as happens with the
+// real Metalama.Patterns.Contracts / Metalama.Community.Virtuosity package names. The weaver then
+// splits the high-level pipeline into two stages around itself, leaving the contract's "Build"
+// layer in a different stage than its default layer, which used to throw the KeyNotFoundException.
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Sdk.WeaverAndContractAspect
+{
+    [RequireAspectWeaver( "Metalama.Framework.Tests.AspectTests.Tests.Aspects.Sdk.WeaverAndContractAspect.AspectWeaver" )]
+    internal class MakeVirtualAttribute : TypeAspect { }
+
+    [MetalamaPlugIn]
+    internal class AspectWeaver : IAspectWeaver
+    {
+        public Task TransformAsync( AspectWeaverContext context )
+        {
+            return context.RewriteAspectTargetsAsync( new Rewriter() );
+        }
+
+        private class Rewriter : SafeSyntaxRewriter
+        {
+            public override SyntaxNode? VisitBlock( BlockSyntax node )
+            {
+                return node.WithStatements( node.Statements.Insert( 0, SyntaxFactory.ParseStatement( "global::System.Console.WriteLine(\"Added by weaver.\");" ) ) );
+            }
+        }
+    }
+
+    internal class NotNullAttribute : ContractAspect
+    {
+        public override void Validate( dynamic? value )
+        {
+            if ( value == null )
+            {
+                throw new ArgumentNullException( meta.Target.Parameter.Name );
+            }
+        }
+    }
+
+    // <target>
+    [MakeVirtual]
+    internal class TargetCode
+    {
+        public string Process( [NotNull] string input )
+        {
+            return input;
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspect.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspect.t.cs
@@ -1,13 +1,2 @@
-[MakeVirtual]
-internal class TargetCode
-{
-  public string Process([NotNull] string input)
-  {
-    if (input == null)
-    {
-      throw new global::System.ArgumentNullException("input");
-    }
-    global::System.Console.WriteLine("Added by weaver.");
-    return input;
-  }
-}
+// CompileTimeAspectPipeline.ExecuteAsync failed.
+// Error LAMA0042 on `NotNullAttribute`: `The aspect 'NotNull' has several layers, but the low-level aspect 'MakeVirtual' is ordered between two of these layers. A low-level aspect (i.e. one based on IAspectWeaver) cannot be ordered between two layers of another aspect, because it would split that aspect across two pipeline stages. Add an [assembly: AspectOrderAttribute(...)] attribute to order 'MakeVirtual' before or after all layers of 'NotNull'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspect.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspect.t.cs
@@ -1,0 +1,13 @@
+[MakeVirtual]
+internal class TargetCode
+{
+  public string Process([NotNull] string input)
+  {
+    if (input == null)
+    {
+      throw new global::System.ArgumentNullException("input");
+    }
+    global::System.Console.WriteLine("Added by weaver.");
+    return input;
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspectOrdered.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspectOrdered.cs
@@ -8,31 +8,24 @@ using Metalama.Framework.Aspects;
 using Metalama.Framework.Engine;
 using Metalama.Framework.Engine.AspectWeavers;
 using Metalama.Framework.Engine.Utilities.Roslyn;
+using Metalama.Framework.Tests.AspectTests.Tests.Aspects.Sdk.WeaverAndContractAspectOrdered;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 #pragma warning disable CS8602
 
-// This test covers issue #1636: a weaver-based aspect (IAspectWeaver) used together with a
-// ContractAspect-based aspect in the same compilation, with NO explicit [assembly: AspectOrder]
-// tying them together. It used to crash with a KeyNotFoundException in PipelineStepIdComparer.Compare
-// (reported as LAMA0601). It now fails loud with the clear LAMA0042 diagnostic instead.
-//
-// A ContractAspect has two layers: the default layer and a secondary "Build" layer, ordered
-// (default -> Build). A weaver-based aspect has no ordering relationship with the contract, so it
-// is sorted only by its (descending) name. The aspect names here are chosen so that the weaver
-// aspect sorts BETWEEN the contract's default and "Build" layers (i.e. ordered list is
-// [NotNullAttribute, MakeVirtualAttribute, NotNullAttribute:Build]) — exactly as happens with the
-// real Metalama.Patterns.Contracts / Metalama.Community.Virtuosity package names. The weaver always
-// forms its own pipeline stage, so it would split the contract across two high-level stages, which
-// is not supported. Because a weaver cannot be ordered between two layers of the same aspect, the
-// pipeline reports LAMA0042 and asks the user to add an explicit [assembly: AspectOrder]. See
-// WeaverAndContractAspectOrdered for the working, explicitly-ordered variant.
+// This is the working, explicitly-ordered counterpart of WeaverAndContractAspect (issue #1636).
+// The aspect names are still chosen so that, without ordering, the weaver would sort between the
+// contract's default and "Build" layers. The [assembly: AspectOrder] below orders the weaver before
+// all layers of the contract, so the contract's two layers stay in a single high-level stage and no
+// LAMA0042 is reported. Both the weaver transformation and the contract are applied.
 
-namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Sdk.WeaverAndContractAspect
+[assembly: AspectOrder( AspectOrderDirection.CompileTime, typeof( MakeVirtualAttribute ), typeof( NotNullAttribute ) )]
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Sdk.WeaverAndContractAspectOrdered
 {
-    [RequireAspectWeaver( "Metalama.Framework.Tests.AspectTests.Tests.Aspects.Sdk.WeaverAndContractAspect.AspectWeaver" )]
+    [RequireAspectWeaver( "Metalama.Framework.Tests.AspectTests.Tests.Aspects.Sdk.WeaverAndContractAspectOrdered.AspectWeaver" )]
     internal class MakeVirtualAttribute : TypeAspect { }
 
     [MetalamaPlugIn]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspectOrdered.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Sdk/WeaverAndContractAspectOrdered.t.cs
@@ -1,0 +1,13 @@
+[MakeVirtual]
+internal class TargetCode
+{
+  public string Process([NotNull] string input)
+  {
+    if (input == null)
+    {
+      throw new global::System.ArgumentNullException("input");
+    }
+    global::System.Console.WriteLine("Added by weaver.");
+    return input;
+  }
+}


### PR DESCRIPTION
Fixes #1636.

## Problem

When an `IAspectWeaver`-based aspect (e.g. `Metalama.Community.Virtuosity`'s `[Virtualize]`) is used together with a `Metalama.Patterns.Contracts` attribute (e.g. `[NotNull]`) and there is **no explicit `[assembly: AspectOrder]`**, the compile-time pipeline crashes with an unhandled exception:

```
LAMA0601: Transformer ''MetalamaSourceTransformer'' failed
KeyNotFoundException: The given key ''...NotNullAttribute:Build'' was not present in the dictionary.
  at Metalama.Framework.Engine.Pipeline.PipelineStepIdComparer.Compare
  at Metalama.Framework.Engine.Pipeline.PipelineStepsState.AddAspectInstances
```

## Root cause

A `ContractAspect` has two layers: the default layer and a secondary `Build` layer, with an implicit `default -> Build` ordering. A weaver-based aspect has no ordering relationship with the contract, so the two are sorted only by name, which can place the weaver *between* the contract''s two layers (e.g. `[NotNull(default), Virtualize(weaver), NotNull:Build]`).

Because a weaver always forms its own low-level pipeline stage, this interleaving splits the contract aspect across two high-level stages, leaving its `Build` layer in a different stage than its default layer. The architecture requires all layers of one aspect to live in the same high-level stage (the aspect source is evaluated once, in the stage owning the default layer, and all layers are processed there) -- there is no mechanism to carry a secondary layer''s instances to a later stage. When `PipelineStepsState.AddAspectInstances` later asks the stage''s `PipelineStepIdComparer` to order the `Build`-layer step, that step is absent from the stage''s ordered-layers dictionary -> `KeyNotFoundException`.

This split only happens when the user has not specified an order between the weaver and the multi-layer aspect; once it occurs, there is no valid way for the pipeline to proceed, because the user''s intent (which side of the contract the weaver belongs on) is genuinely ambiguous.

## Fix

Rather than crash deep in the pipeline with an opaque `KeyNotFoundException`, detect the unsupported configuration up front in `AspectPipeline` and report a clear, actionable diagnostic.

- Added a pipeline validation (in `AspectPipeline.cs`) that detects when an aspect''s layers are split across pipeline stages by an intervening low-level (weaver) stage, and fails initialization gracefully instead of letting the later stage crash.
- Introduced a new general diagnostic descriptor **LAMA0042** (`AspectLayersSeparatedByWeaver`) that names the affected aspect and the separating weaver and tells the user to add an explicit `[assembly: AspectOrder(...)]` to order the weaver before or after all layers of the aspect.

This turns an unhandled crash into a precise error the user can act on, and the explicit `AspectOrder` they add resolves the ambiguity so both aspects work together.

## Tests

- **`Sdk/WeaverAndContractAspect`** -- reproduces the exact #1636 scenario (a weaver-based aspect + a `ContractAspect`-derived attribute, no explicit `AspectOrder`). Now expected to fail with `LAMA0042` instead of crashing.
- **`Sdk/WeaverAndContractAspectOrdered`** -- the explicitly-ordered counterpart with `[assembly: AspectOrder(...)]`. Compiles successfully, with both the weaver rewrite and the contract''s null-check applied to the target.

## Checklist
- [x] Reproduce the bug (failing regression test `Sdk/WeaverAndContractAspect`)
- [x] Implement the fix (LAMA0042 diagnostic instead of crash)
- [x] Add the ordered success-path test (`Sdk/WeaverAndContractAspectOrdered`)
- [x] Full `Build.ps1 build` (zero warnings)
- [x] Full test run -- net8.0: AspectTests 2265 passed / 0 failed, UnitTests 1893 passed / 0 failed
- [x] Finalize (marked ready, review requested)

-- Claude for @gfraiteur