### PR TITLE
Fix CS0030 on expression-bodied async void Task override (#1638)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ExpressionBodySubstitution.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/Substitution/ExpressionBodySubstitution.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.SyntaxGeneration;
 using Metalama.Framework.Engine.Utilities.Comparers;
@@ -139,8 +140,30 @@ namespace Metalama.Framework.Engine.Linking.Substitution
 
                         BlockSyntax DiscardBlock()
                         {
+                            // For async methods (with the async modifier), use the result type (the inner type
+                            // of Task<T>/ValueTask<T>) instead of the full return type, because when inlining
+                            // with await, the expression-bodied expression has the awaited type.
+                            // For non-async methods that return Task<T>/ValueTask<T>, we must use the full
+                            // return type since their expressions are of type Task<T>.
+                            var returnType = this._originalContainingSymbol.ReturnType;
+
+                            if ( this._originalContainingSymbol.IsAsyncSafe() &&
+                                 AsyncHelper.TryGetAsyncInfo( returnType, out var resultType, out _ ) )
+                            {
+                                returnType = resultType;
+                            }
+
+                            // For void-returning methods (including void-like async methods like Task/ValueTask),
+                            // we can't discard a void value, so just use the expression as a statement.
+                            if ( returnType.SpecialType == SpecialType.System_Void )
+                            {
+                                return
+                                    syntaxGenerator.FormattedBlock( ExpressionStatement( arrowExpressionClause.Expression ) )
+                                        .WithLinkerGeneratedFlags( LinkerGeneratedFlags.FlattenableBlock );
+                            }
+
                             var returnTypeSyntax =
-                                substitutionContext.SyntaxGenerationContext.SyntaxGenerator.TypeSyntax( this._originalContainingSymbol.ReturnType );
+                                substitutionContext.SyntaxGenerationContext.SyntaxGenerator.TypeSyntax( returnType );
 
                             return syntaxGenerator.FormattedBlock(
                                     SyntaxFactoryEx.DiscardStatement(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Async/AsyncTemplate/VoidAsyncExpressionBody.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Async/AsyncTemplate/VoidAsyncExpressionBody.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Threading.Tasks;
+using Metalama.Framework.Aspects;
+
+namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Async.AsyncTemplate.VoidAsyncExpressionBody
+{
+    internal class Aspect : OverrideMethodAspect
+    {
+        public override dynamic? OverrideMethod()
+        {
+            Console.WriteLine( "enter" );
+
+            return meta.Proceed();
+        }
+
+        public override async Task<dynamic?> OverrideAsyncMethod()
+        {
+            Console.WriteLine( "enter" );
+
+            return await meta.ProceedAsync();
+        }
+    }
+
+    // <target>
+    internal class TargetCode
+    {
+        // Regression test for #1638: an expression-bodied, void-returning async Task method
+        // generated CS0030 "Cannot convert type 'void' to 'System.Threading.Tasks.Task'".
+        [Aspect]
+        private async Task DoVoidAsync() => await Task.Delay( 1 );
+
+        [Aspect]
+        private async Task<int> GetValueAsync() => await Task.FromResult( 42 );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Async/AsyncTemplate/VoidAsyncExpressionBody.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Async/AsyncTemplate/VoidAsyncExpressionBody.cs
@@ -34,6 +34,9 @@ namespace Metalama.Framework.Tests.AspectTests.Tests.Aspects.Async.AsyncTemplate
         private async Task DoVoidAsync() => await Task.Delay( 1 );
 
         [Aspect]
+        private async ValueTask DoVoidValueTaskAsync() => await new ValueTask( Task.Delay( 1 ) );
+
+        [Aspect]
         private async Task<int> GetValueAsync() => await Task.FromResult( 42 );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Async/AsyncTemplate/VoidAsyncExpressionBody.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Aspects/Async/AsyncTemplate/VoidAsyncExpressionBody.t.cs
@@ -1,0 +1,25 @@
+internal class TargetCode
+{
+  // Regression test for #1638: an expression-bodied, void-returning async Task method
+  // generated CS0030 "Cannot convert type 'void' to 'System.Threading.Tasks.Task'".
+  [Aspect]
+  private async Task DoVoidAsync()
+  {
+    global::System.Console.WriteLine("enter");
+    await Task.Delay(1);
+    return;
+  }
+  [Aspect]
+  private async ValueTask DoVoidValueTaskAsync()
+  {
+    global::System.Console.WriteLine("enter");
+    await new ValueTask(Task.Delay(1));
+    return;
+  }
+  [Aspect]
+  private async Task<int> GetValueAsync()
+  {
+    global::System.Console.WriteLine("enter");
+    return await Task.FromResult(42);
+  }
+}


### PR DESCRIPTION
Fixes #1638.

## Problem

Metalama 2026.1.16 regressed (works in 2026.0.23): an `OverrideMethodAspect` whose `OverrideAsyncMethod()` returns `Task<dynamic>` and does `return await meta.ProceedAsync();`, when applied to an **expression-bodied, void-returning `async Task`** method, generated code that failed with:

```
CS0030: Cannot convert type 'void' to 'System.Threading.Tasks.Task'
```

The generated body cast the awaited **void** expression to `Task`:

```csharp
private async Task DoVoidAsync()
{
    global::System.Console.WriteLine("enter");
    _ = (global::System.Threading.Tasks.Task)(await Task.Delay(1));   // <-- await is void → CS0030
    return;
}
```

`Task<int>` targets and block-bodied void `async Task` targets were unaffected.

## Root cause

In the linker, `ReturnStatementSubstitution` (block-bodied methods) already resolved the *awaited result type* for `async` methods and, for void-like async (`Task`/`ValueTask`), emitted a plain expression statement instead of a discard-cast. The analogous `ExpressionBodySubstitution.DiscardBlock()` (expression-bodied methods) lacked this logic and always cast to the full return type (`Task`) — hence the regression was specific to the expression-bodied void-async form.

## Fix

`ExpressionBodySubstitution.DiscardBlock()` now mirrors `ReturnStatementSubstitution`: it resolves the awaited result type for `async` methods and, when that type is `void`, emits the expression as a statement rather than a discard-cast.

## Tests

Added `VoidAsyncExpressionBody` aspect test covering expression-bodied `async Task` (void), `async ValueTask` (void) and `async Task<int>` forms.

## Checklist
- [x] Phase 1: Understand the issue
- [x] Phase 2: Failing regression test
- [x] Phase 3: Implement fix
- [x] Phase 4: `Build.ps1 build` (zero warnings) + AspectTests (net8.0/net48) + LinkerTests pass
- [x] Phase 5: Finalize, mark ready, request review

— Claude for @PostSharpAgent
