### PR TITLE
Fix lost-wakeup race in ClientEndpoint awaiter signaling (#1640)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -120,7 +120,19 @@ public abstract partial class ClientEndpoint : BaseEndpoint
                 return client;
             }
 
-            awaiter = this._clientAwaiters.GetOrAdd( typeof(TClient), _ => new TaskCompletionSource<RpcClient>() );
+            // Test-only sync point that pins a waiter in the exact gap this lock protects: after GetClient()
+            // returned null but before the awaiter is registered. No-op in production (TestSyncProvider is null).
+            // Synchronous because we must stay inside _addClientLock; awaiting here is not possible.
+#pragma warning disable VSTHRD103 // SyncPoint synchronously blocks - intentional: it must block while holding _addClientLock.
+            this.TestSyncProvider?.SyncPoint( $"ClientEndpoint.BeforeRegisterAwaiter:{this.PipeName}", cancellationToken );
+#pragma warning restore VSTHRD103
+
+            // RunContinuationsAsynchronously: the awaiter is completed by ConnectCoreAsync while it holds
+            // _addClientLock (see the signaling loop there). Without this flag, SetResult would run this
+            // method's continuation inline under that lock.
+            awaiter = this._clientAwaiters.GetOrAdd(
+                typeof(TClient),
+                _ => new TaskCompletionSource<RpcClient>( TaskCreationOptions.RunContinuationsAsynchronously ) );
         }
 
         await this.EnsureInitialServicesRetrievedAsync( cancellationToken );
@@ -343,12 +355,24 @@ public abstract partial class ClientEndpoint : BaseEndpoint
             }
 
             // Signal waiters.
-            // We must do this _after_ updating the client collections.
-            foreach ( var client in newClients )
+            // We must do this _after_ updating the client collections, and under _addClientLock to close a
+            // lost-wakeup race with GetOrWaitForClientAsync. That method, under _addClientLock, calls
+            // GetClient() (which reads _connectionByStream) and, if it returns null, registers an awaiter.
+            // Since the publish to _connectionByStream (above) and this signaling are otherwise lock-free, a
+            // waiter could observe a null client, then — before it registers its awaiter — this loop could run
+            // and find no awaiter to signal. The waiter would then register and wait forever. Holding the lock
+            // here makes "check-then-register" and "publish-then-signal" mutually exclusive: a waiter that saw
+            // null has already registered its awaiter before we get the lock, or it gets the lock after us and
+            // sees the published client via GetClient(). SetResult does not run continuations inline because the
+            // awaiters are created with RunContinuationsAsynchronously.
+            lock ( this._addClientLock )
             {
-                if ( this._clientAwaiters.TryGetValue( client.GetType(), out var awaiter ) )
+                foreach ( var client in newClients )
                 {
-                    awaiter.SetResult( client );
+                    if ( this._clientAwaiters.TryGetValue( client.GetType(), out var awaiter ) )
+                    {
+                        awaiter.SetResult( client );
+                    }
                 }
             }
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ITestSynchronizationProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ITestSynchronizationProvider.cs
@@ -17,4 +17,13 @@ public interface ITestSynchronizationProvider
     /// <param name="syncPointName">A unique name identifying this sync point, typically in format <c>{ClassName}.{Location}:{Context}</c>.</param>
     /// <param name="cancellationToken">Cancellation token.</param>
     Task SyncPointAsync( string syncPointName, CancellationToken cancellationToken );
+
+    /// <summary>
+    /// Synchronous variant of <see cref="SyncPointAsync"/>, for sync points that must block while a lock is held
+    /// (where awaiting is not possible). Signals that the sync point was reached and blocks the current thread
+    /// until release.
+    /// </summary>
+    /// <param name="syncPointName">A unique name identifying this sync point, typically in format <c>{ClassName}.{Location}:{Context}</c>.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    void SyncPoint( string syncPointName, CancellationToken cancellationToken );
 }

--- a/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestSynchronizationProvider.cs
+++ b/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestSynchronizationProvider.cs
@@ -82,6 +82,25 @@ public sealed class TestSynchronizationProvider : ITestSynchronizationProvider, 
     }
 
     /// <summary>
+    /// Synchronous variant of <see cref="ITestSynchronizationProvider.SyncPointAsync"/>. Used for sync points
+    /// that must block while a lock is held, where awaiting is not possible.
+    /// </summary>
+    void ITestSynchronizationProvider.SyncPoint( string syncPointName, CancellationToken cancellationToken )
+    {
+        if ( !this._syncPoints.TryGetValue( syncPointName, out var sp ) )
+        {
+            this.Log( $"SyncPoint '{syncPointName}': not enabled, skipping." );
+
+            return;
+        }
+
+        this.Log( $"SyncPoint '{syncPointName}': reached, signaling and waiting for release." );
+        sp.ReachedSignal.Release();
+        sp.ReleaseSignal.Wait( cancellationToken );
+        this.Log( $"SyncPoint '{syncPointName}': released, continuing." );
+    }
+
+    /// <summary>
     /// Called by test code. Enables a sync point so that code under test will block when reaching it.
     /// This must be called BEFORE starting the operation that will hit the sync point.
     /// </summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/CLAUDE.md
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/CLAUDE.md
@@ -88,7 +88,9 @@ public async Task TestWithSyncPoint()
 
 Available sync points:
 - `ServerEndpoint.AfterGetsClient:{pipeName}` - After server accepts client but before configuring RPC
+- `ClientEndpoint.AfterStartsListening:{pipeName}` - After the client starts listening but before publishing the connection (client not yet visible to `GetClient()`)
 - `ClientEndpoint.BeforeSignalingAwaiters:{pipeName}` - After client updates collections but before signaling awaiters
+- `ClientEndpoint.BeforeRegisterAwaiter:{pipeName}` - **Synchronous** sync point inside `_addClientLock` in `GetOrWaitForClientAsync`, after `GetClient()` returned null and before the awaiter is registered. Use `SyncProvider` as usual; it blocks the calling thread (the lock is held), so the code under test must be on a background task. Used by the #1640 lost-wakeup regression test.
 
 ## Waiting for Server-Side Connection/Disconnection
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcClientTests.LostWakeup.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcClientTests.LostWakeup.cs
@@ -1,0 +1,96 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - acceptable in test code
+
+using Metalama.Framework.Engine.Utilities.Threading;
+using System;
+using System.Threading.Tasks;
+using Xunit;
+
+// ReSharper disable AccessToDisposedClosure
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Rpc;
+
+public sealed partial class RpcClientTests
+{
+    /// <summary>
+    /// Regression test for #1640: a lost-wakeup race between <c>GetOrWaitForClientAsync</c> and
+    /// <c>ConnectCoreAsync</c>. The test deterministically forces the bad interleaving — a waiter observes no
+    /// client and is then suspended (still holding the add-client lock) while the connection publishes the
+    /// client and signals awaiters — and asserts the waiter is still released.
+    /// </summary>
+    [Fact]
+    public async Task GetOrWaitForClient_SignalBeforeAwaiterRegistered_StillCompletes()
+    {
+        using var testContext = this.CreateRpcTestContext();
+        var ct = testContext.CancellationToken;
+
+        var pipeName = $"{nameof(RpcClientTests)}_{Guid.NewGuid()}";
+
+        // Pins the connection after StartListening but BEFORE it publishes the client to _connectionByStream.
+        var afterStartsListening = $"ClientEndpoint.AfterStartsListening:{pipeName}";
+
+        // Pins the waiter inside _addClientLock, after GetClient() returned null but before it registers its awaiter.
+        var beforeRegisterAwaiter = $"ClientEndpoint.BeforeRegisterAwaiter:{pipeName}";
+
+        using var serverEndpoint = new TestServerEndpoint( testContext.ServiceProvider, pipeName );
+        serverEndpoint.Start();
+
+        using var clientEndpoint = new TestClientEndpoint( testContext.ServiceProvider, pipeName );
+
+        // (1) Start connecting and pin it just past StartListening but before it publishes the client. At this
+        // point ConnectCoreAsync has already released _addClientLock, so the waiter can acquire it, and the
+        // client is not yet visible to GetClient().
+        testContext.SyncProvider.EnableSyncPoint( afterStartsListening );
+        var connectTask = Task.Run( () => clientEndpoint.ConnectAsync( ct ), ct );
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( afterStartsListening, ct );
+
+        // (2) Start a waiter. Under _addClientLock it sees no client (not published yet) and suspends at
+        // BeforeRegisterAwaiter, still holding _addClientLock, before registering its awaiter.
+        testContext.SyncProvider.EnableSyncPoint( beforeRegisterAwaiter );
+        var getApiTask = Task.Run( () => clientEndpoint.GetOrWaitForClientAsync<TestClient>( ct ).AsTask(), ct );
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( beforeRegisterAwaiter, ct );
+
+        // (3) Let the connection proceed. It publishes the client and then signals awaiters.
+        //   - Before the fix, signaling is lock-free: it runs now (no awaiter registered yet → wakeup lost) and
+        //     ConnectAsync completes while the waiter is still suspended.
+        //   - After the fix, signaling takes _addClientLock, so ConnectAsync blocks until the waiter releases it.
+        testContext.SyncProvider.ReleaseSyncPoint( afterStartsListening );
+
+        // (4) Distinguish the two states without a race: ConnectAsync completing while the waiter still holds the
+        // lock proves signaling already ran without the lock (the bug). The bounded wait is a state probe, not a
+        // timing hack — after the fix ConnectAsync is *designed* to stay blocked here until step (5), so we cannot
+        // wait for it unconditionally.
+        using var probeCts = System.Threading.CancellationTokenSource.CreateLinkedTokenSource( ct );
+        probeCts.CancelAfter( TimeSpan.FromSeconds( 2 ) );
+
+        var connectCompletedEarly = false;
+
+        try
+        {
+            await connectTask.WithCancellation( probeCts.Token );
+            connectCompletedEarly = true;
+        }
+        catch ( OperationCanceledException ) when ( probeCts.IsCancellationRequested && !ct.IsCancellationRequested )
+        {
+            // Expected with the fix: ConnectAsync is blocked on _addClientLock held by the suspended waiter.
+        }
+
+        Assert.False(
+            connectCompletedEarly,
+            "ConnectAsync signaled awaiters without holding _addClientLock while a waiter was registering — the lost-wakeup race is present." );
+
+        // (5) Release the waiter so it registers its awaiter and awaits it. With the fix, ConnectAsync's signaling
+        // (blocked on the lock) now runs and completes the just-registered awaiter.
+        testContext.SyncProvider.ReleaseSyncPoint( beforeRegisterAwaiter );
+
+        // The waiter MUST still be released. Before the fix it would hang here forever (the wakeup was lost) and
+        // the test would fail via the test-context cancellation token.
+        var client = await getApiTask.WithCancellation( ct );
+        await connectTask.WithCancellation( ct );
+
+        Assert.NotNull( client );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcClientTests.LostWakeup.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcClientTests.LostWakeup.cs
@@ -32,6 +32,9 @@ public sealed partial class RpcClientTests
         // Pins the connection after StartListening but BEFORE it publishes the client to _connectionByStream.
         var afterStartsListening = $"ClientEndpoint.AfterStartsListening:{pipeName}";
 
+        // Pins the connection after it has published the client but right before it signals awaiters.
+        var beforeSignalingAwaiters = $"ClientEndpoint.BeforeSignalingAwaiters:{pipeName}";
+
         // Pins the waiter inside _addClientLock, after GetClient() returned null but before it registers its awaiter.
         var beforeRegisterAwaiter = $"ClientEndpoint.BeforeRegisterAwaiter:{pipeName}";
 
@@ -53,16 +56,24 @@ public sealed partial class RpcClientTests
         var getApiTask = Task.Run( () => clientEndpoint.GetOrWaitForClientAsync<TestClient>( ct ).AsTask(), ct );
         await testContext.SyncProvider.WaitForSyncPointReachedAsync( beforeRegisterAwaiter, ct );
 
-        // (3) Let the connection proceed. It publishes the client and then signals awaiters.
-        //   - Before the fix, signaling is lock-free: it runs now (no awaiter registered yet → wakeup lost) and
-        //     ConnectAsync completes while the waiter is still suspended.
-        //   - After the fix, signaling takes _addClientLock, so ConnectAsync blocks until the waiter releases it.
+        // (3) Let the connection publish the client and advance to right before it signals awaiters. Gating here
+        // (rather than probing immediately after publish) guarantees the connection is *poised to signal* before
+        // step (5), so the buggy, lock-free signal fires promptly and deterministically — it does not depend on
+        // ConnectAsync reaching the signaling section within some time window.
+        testContext.SyncProvider.EnableSyncPoint( beforeSignalingAwaiters );
         testContext.SyncProvider.ReleaseSyncPoint( afterStartsListening );
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( beforeSignalingAwaiters, ct );
 
-        // (4) Distinguish the two states without a race: ConnectAsync completing while the waiter still holds the
-        // lock proves signaling already ran without the lock (the bug). The bounded wait is a state probe, not a
-        // timing hack — after the fix ConnectAsync is *designed* to stay blocked here until step (5), so we cannot
-        // wait for it unconditionally.
+        // (4) Release the connection into the signaling section.
+        //   - Before the fix, signaling is lock-free: it runs now (no awaiter registered yet → wakeup lost) and
+        //     ConnectAsync completes while the waiter is still suspended holding _addClientLock.
+        //   - After the fix, signaling takes _addClientLock, so ConnectAsync blocks until the waiter releases it.
+        testContext.SyncProvider.ReleaseSyncPoint( beforeSignalingAwaiters );
+
+        // (5) Distinguish the two states without a race: ConnectAsync completing while the waiter still holds the
+        // lock proves signaling already ran without the lock (the bug). The connection is poised to signal, so the
+        // buggy path completes promptly; the bounded wait only bounds the fixed path, where ConnectAsync is
+        // *designed* to stay blocked here until step (6), so we cannot wait for it unconditionally.
         using var probeCts = System.Threading.CancellationTokenSource.CreateLinkedTokenSource( ct );
         probeCts.CancelAfter( TimeSpan.FromSeconds( 2 ) );
 
@@ -82,7 +93,7 @@ public sealed partial class RpcClientTests
             connectCompletedEarly,
             "ConnectAsync signaled awaiters without holding _addClientLock while a waiter was registering — the lost-wakeup race is present." );
 
-        // (5) Release the waiter so it registers its awaiter and awaits it. With the fix, ConnectAsync's signaling
+        // (6) Release the waiter so it registers its awaiter and awaits it. With the fix, ConnectAsync's signaling
         // (blocked on the lock) now runs and completes the just-registered awaiter.
         testContext.SyncProvider.ReleaseSyncPoint( beforeRegisterAwaiter );
 


### PR DESCRIPTION
## Summary
- Fix a lost-wakeup race in `ClientEndpoint`: `GetOrWaitForClientAsync` checked for the client and registered its awaiter under `_addClientLock`, but `ConnectCoreAsync` published the connection and signaled awaiters *without* that lock. A waiter could observe no client and, before registering its awaiter, miss the signal and wait forever.
- Signal awaiters under `_addClientLock`, making check-then-register and publish-then-signal mutually exclusive.
- Create the awaiter `TaskCompletionSource` with `RunContinuationsAsynchronously` so `SetResult` does not run continuations inline under the lock.
- Add a deterministic regression test (`RpcClientTests.GetOrWaitForClient_SignalBeforeAwaiterRegistered_StillCompletes`) that forces the bad interleaving via a new synchronous test sync point inside the lock. It passes with the fix and fails fast without it.

This affects design-time / IDE scenarios only (e.g. `RpcServiceProviderClientEndpoint` dynamic service-client lookups). It does not affect compile-time, build output, or the user application runtime.

## Issues Fixed
- #1640 - Lost-wakeup race in ClientEndpoint between GetOrWaitForClientAsync and ConnectCoreAsync (intermittent RPC hang)

— Claude