### PR TITLE
Fix RSS title command-line argument injection (#1648)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Tools/BackstageToolsExecutor.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Tools/BackstageToolsExecutor.cs
@@ -6,8 +6,10 @@ using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Infrastructure;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
+using System.Text;
 
 namespace Metalama.Backstage.Tools;
 
@@ -30,7 +32,7 @@ internal sealed class BackstageToolsExecutor : IBackstageToolsExecutor
         this._fileSystem = serviceProvider.GetRequiredBackstageService<IFileSystem>();
     }
 
-    public IProcess Start( BackstageTool tool, string arguments )
+    public IProcess Start( BackstageTool tool, params string[] arguments )
     {
         if ( this._locator.ToolsMustBeExtracted )
         {
@@ -54,22 +56,108 @@ internal sealed class BackstageToolsExecutor : IBackstageToolsExecutor
         {
             processStartInfo = new ProcessStartInfo()
             {
-                FileName = programPath, Arguments = arguments, UseShellExecute = tool.UseShellExecute, WindowStyle = tool.WindowStyle
+                FileName = programPath, Arguments = FormatArguments( arguments ), UseShellExecute = tool.UseShellExecute, WindowStyle = tool.WindowStyle
             };
         }
         else
         {
             var dotnetPath = this._platformInfo.DotNetExePath;
-            var allArguments = $"\"{programPath}\" " + arguments;
+
+            // The program path becomes the first argument passed to dotnet.exe.
+            var allArguments = new List<string>( arguments.Length + 1 ) { programPath };
+            allArguments.AddRange( arguments );
 
             processStartInfo = new ProcessStartInfo()
             {
-                FileName = dotnetPath, Arguments = allArguments, UseShellExecute = tool.UseShellExecute, WindowStyle = tool.WindowStyle
+                FileName = dotnetPath, Arguments = FormatArguments( allArguments ), UseShellExecute = tool.UseShellExecute, WindowStyle = tool.WindowStyle
             };
         }
 
         this._logger.Info?.Log( $"Starting '{processStartInfo.FileName} {processStartInfo.Arguments}." );
 
         return this._processExecutor.Start( processStartInfo );
+    }
+
+    /// <summary>
+    /// Joins an argument vector into a single command-line string, quoting each argument as required so that it
+    /// round-trips through the Windows <c>CommandLineToArgvW</c> parsing rules. This prevents untrusted argument
+    /// values from injecting additional arguments. Equivalent to the .NET <c>PasteArguments</c> implementation,
+    /// which we cannot use directly because it is internal and because <c>ProcessStartInfo.ArgumentList</c>
+    /// is not available on all target frameworks.
+    /// </summary>
+    private static string FormatArguments( IReadOnlyList<string> arguments )
+    {
+        var builder = new StringBuilder();
+
+        foreach ( var argument in arguments )
+        {
+            AppendArgument( builder, argument );
+        }
+
+        return builder.ToString();
+    }
+
+    private static void AppendArgument( StringBuilder builder, string argument )
+    {
+        if ( builder.Length != 0 )
+        {
+            builder.Append( ' ' );
+        }
+
+        // An argument with no whitespace or quote can be appended verbatim.
+        if ( argument.Length != 0 && argument.IndexOfAny( new[] { ' ', '\t', '\n', '\v', '"' } ) < 0 )
+        {
+            builder.Append( argument );
+
+            return;
+        }
+
+        builder.Append( '"' );
+
+        var index = 0;
+
+        while ( index < argument.Length )
+        {
+            var c = argument[index++];
+
+            if ( c == '\\' )
+            {
+                var backslashCount = 1;
+
+                while ( index < argument.Length && argument[index] == '\\' )
+                {
+                    index++;
+                    backslashCount++;
+                }
+
+                if ( index == argument.Length )
+                {
+                    // Backslashes immediately preceding the closing quote must be doubled.
+                    builder.Append( '\\', backslashCount * 2 );
+                }
+                else if ( argument[index] == '"' )
+                {
+                    // Backslashes preceding a quote must be doubled, plus one to escape the quote itself.
+                    builder.Append( '\\', ( backslashCount * 2 ) + 1 );
+                    builder.Append( '"' );
+                    index++;
+                }
+                else
+                {
+                    builder.Append( '\\', backslashCount );
+                }
+            }
+            else if ( c == '"' )
+            {
+                builder.Append( '\\' );
+                builder.Append( '"' );
+            }
+            else
+            {
+                builder.Append( c );
+            }
+        }
+
+        builder.Append( '"' );
     }
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Tools/BackstageToolsExecutor.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Tools/BackstageToolsExecutor.cs
@@ -22,6 +22,8 @@ internal sealed class BackstageToolsExecutor : IBackstageToolsExecutor
     private readonly IBackstageToolsLocator _locator;
     private readonly IFileSystem _fileSystem;
 
+    private static readonly char[] _charactersRequiringQuoting = { ' ', '\t', '\n', '\v', '"' };
+
     public BackstageToolsExecutor( IServiceProvider serviceProvider )
     {
         this._serviceProvider = serviceProvider;
@@ -105,7 +107,7 @@ internal sealed class BackstageToolsExecutor : IBackstageToolsExecutor
         }
 
         // An argument with no whitespace or quote can be appended verbatim.
-        if ( argument.Length != 0 && argument.IndexOfAny( new[] { ' ', '\t', '\n', '\v', '"' } ) < 0 )
+        if ( argument.Length != 0 && argument.IndexOfAny( _charactersRequiringQuoting ) < 0 )
         {
             builder.Append( argument );
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Tools/IBackstageToolsExecutor.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Tools/IBackstageToolsExecutor.cs
@@ -9,5 +9,8 @@ namespace Metalama.Backstage.Tools;
 
 internal interface IBackstageToolsExecutor : IBackstageService
 {
-    IProcess Start( BackstageTool tool, string arguments );
+    // The arguments are passed as a vector (not a single string) and are quoted by the implementation, so that
+    // untrusted values (e.g. an RSS feed title flowing into a toast notification) cannot inject extra arguments
+    // into the child process. See https://github.com/metalama/Metalama/issues/1648.
+    IProcess Start( BackstageTool tool, params string[] arguments );
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/UserInterfaceService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/UserInterfaceService.cs
@@ -10,6 +10,7 @@ using Metalama.Backstage.Tools;
 using Metalama.Backstage.UserInterface.Toasts;
 using System;
 using System.Diagnostics;
+using System.Globalization;
 using System.Net;
 using System.Net.Http;
 using System.Net.Sockets;
@@ -91,7 +92,8 @@ public abstract class UserInterfaceService : IUserInterfaceService
     {
         var port = GetFreePort();
 
-        using var webServerProcess = this._backstageToolExecutor.Start( BackstageTool.Worker, $"web --port {port} " );
+        using var webServerProcess =
+            this._backstageToolExecutor.Start( BackstageTool.Worker, "web", "--port", port.ToString( CultureInfo.InvariantCulture ) );
 
         // Wait until the server has started.
         var baseAddress = new Uri( $"http://localhost:{port}/" );

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/WindowsUserInterfaceService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/WindowsUserInterfaceService.cs
@@ -6,6 +6,7 @@ using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Tools;
 using Metalama.Backstage.UserInterface.Toasts;
 using System;
+using System.Collections.Generic;
 
 #if NETFRAMEWORK || NETCOREAPP
 using Metalama.Backstage.Diagnostics;
@@ -30,28 +31,33 @@ internal sealed class WindowsUserInterfaceService : UserInterfaceService
 
     public override void ShowToastNotification( ToastNotification notification )
     {
-        // Build arguments.
-        var arguments = $"notify {notification.Kind.Name}";
+        // Build the argument vector. Title/Text/Uri can come from an untrusted RSS feed, so they MUST be passed as
+        // separate vector elements (quoted by the executor) and never concatenated into the command line, otherwise
+        // a value containing a quote could inject extra arguments. See issue #1648.
+        var arguments = new List<string> { "notify", notification.Kind.Name };
 
         if ( !string.IsNullOrEmpty( notification.Title ) )
         {
-            arguments += $" --title \"{notification.Title}\"";
+            arguments.Add( "--title" );
+            arguments.Add( notification.Title! );
         }
 
         if ( !string.IsNullOrEmpty( notification.Text ) )
         {
-            arguments += $" --text \"{notification.Text}\"";
+            arguments.Add( "--text" );
+            arguments.Add( notification.Text! );
         }
 
         if ( !string.IsNullOrEmpty( notification.Uri ) )
         {
-            arguments += $" --uri \"{notification.Uri}\"";
+            arguments.Add( "--uri" );
+            arguments.Add( notification.Uri! );
         }
 
         try
         {
             // Start the UI process.
-            this._toolsExecutor.Start( BackstageTool.DesktopWindows, arguments );
+            this._toolsExecutor.Start( BackstageTool.DesktopWindows, arguments.ToArray() );
             this.OnToastNotificationShown();
         }
         catch ( Exception e )

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/WindowsUserInterfaceServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/WindowsUserInterfaceServiceTests.cs
@@ -25,53 +25,106 @@ namespace Metalama.Backstage.Tests.UserInterface;
 /// </summary>
 public sealed class WindowsUserInterfaceServiceTests : TestsBase
 {
+    private const string _injectedUri = "evil://attacker-controlled";
+    private const string _legitimateUri = "https://metalama.net/legitimate";
+
     public WindowsUserInterfaceServiceTests( ITestOutputHelper logger ) : base( logger ) { }
 
+    public static IEnumerable<object[]> MaliciousTitles()
+    {
+        // Break out of the quoted argument and inject a second --uri.
+        yield return ["Pwned\" --uri \"" + _injectedUri];
+
+        // A trailing backslash before the closing quote must not let the quote be escaped away.
+        yield return ["Pwned\\\" --uri \"" + _injectedUri];
+
+        // Multiple backslashes followed by a quote.
+        yield return ["Pwned\\\\\" --uri \"" + _injectedUri];
+    }
+
     /// <summary>
-    /// Verifies that a toast notification whose title contains a quote followed by extra switches cannot inject
-    /// additional arguments (such as an attacker-controlled <c>--uri</c>) into the desktop tool's argv.
+    /// Verifies that a toast notification whose title contains quotes/backslashes followed by extra switches cannot
+    /// inject additional arguments (such as an attacker-controlled <c>--uri</c>) into the desktop tool's argv.
+    /// </summary>
+    [Theory]
+    [MemberData( nameof(MaliciousTitles) )]
+    public async Task ToastTitleCannotInjectCommandLineArguments( string maliciousTitle )
+    {
+        var args = await this.ShowNotificationAndGetArgumentsAsync( new ToastNotification( ToastNotificationKinds.News, maliciousTitle, null, _legitimateUri ) );
+
+        // The malicious title must reach the child process as a single, verbatim argument.
+        AssertSwitchValue( args, "--title", maliciousTitle );
+
+        // The attacker must not be able to inject a second --uri argument: exactly one --uri, with the legitimate value.
+        AssertSwitchValue( args, "--uri", _legitimateUri );
+        Assert.DoesNotContain( _injectedUri, args );
+    }
+
+    /// <summary>
+    /// Verifies that the notification text (also potentially untrusted) cannot inject additional arguments.
     /// </summary>
     [Fact]
-    public async Task ToastTitleCannotInjectCommandLineArguments()
+    public async Task ToastTextCannotInjectCommandLineArguments()
+    {
+        var maliciousText = "Body\" --uri \"" + _injectedUri;
+
+        var args = await this.ShowNotificationAndGetArgumentsAsync(
+            new ToastNotification( ToastNotificationKinds.News, "Title", maliciousText, _legitimateUri ) );
+
+        AssertSwitchValue( args, "--text", maliciousText );
+        AssertSwitchValue( args, "--uri", _legitimateUri );
+        Assert.DoesNotContain( _injectedUri, args );
+    }
+
+    /// <summary>
+    /// Verifies that a benign notification still passes its title and URI through to the child process unchanged.
+    /// </summary>
+    [Fact]
+    public async Task BenignToastNotificationPassesArgumentsCorrectly()
+    {
+        const string title = "Metalama 2026.1 released";
+
+        var args = await this.ShowNotificationAndGetArgumentsAsync(
+            new ToastNotification( ToastNotificationKinds.News, title, null, _legitimateUri ) );
+
+        Assert.Contains( "notify", args );
+        AssertSwitchValue( args, "--title", title );
+        AssertSwitchValue( args, "--uri", _legitimateUri );
+    }
+
+    private async Task<IReadOnlyList<string>> ShowNotificationAndGetArgumentsAsync( ToastNotification notification )
     {
         // This service and the CommandLineToArgvW helper are Windows-only.
-        if ( !OperatingSystem.IsWindows() )
-        {
-            return;
-        }
+        Assert.True( OperatingSystem.IsWindows() );
 
         this.UserDeviceDetection.IsInteractiveDevice = true;
 
-        const string injectedUri = "evil://attacker-controlled";
-        const string legitimateUri = "https://metalama.net/legitimate";
-
-        // A title that breaks out of the quoted --title argument and injects its own --uri.
-        var maliciousTitle = $"Pwned\" --uri \"{injectedUri}";
-
         var service = new WindowsUserInterfaceService( this.ServiceProvider );
-        service.ShowToastNotification( new ToastNotification( ToastNotificationKinds.News, maliciousTitle, null, legitimateUri ) );
+        service.ShowToastNotification( notification );
 
         await this.BackgroundTasks.WhenNoPendingTaskAsync();
 
         var startInfo = Assert.Single( this.ProcessExecutor.StartedProcesses );
-        var args = GetEffectiveArguments( startInfo );
 
-        // The malicious title must reach the child process as a single, verbatim argument.
-        Assert.Contains( maliciousTitle, args );
+        return GetEffectiveArguments( startInfo );
+    }
 
-        // The attacker must not be able to inject a second --uri argument.
-        var uriPositions = args.Select( ( a, i ) => (Value: a, Index: i) ).Where( t => t.Value == "--uri" ).Select( t => t.Index ).ToList();
-        Assert.Single( uriPositions );
-
-        // The single --uri value must be the legitimate URI, never the injected one.
-        Assert.Equal( legitimateUri, args[uriPositions[0] + 1] );
-        Assert.DoesNotContain( injectedUri, args );
+    /// <summary>
+    /// Asserts that <paramref name="switchName"/> appears exactly once in <paramref name="args"/> and that the token
+    /// immediately following it equals <paramref name="expectedValue"/>.
+    /// </summary>
+    private static void AssertSwitchValue( IReadOnlyList<string> args, string switchName, string expectedValue )
+    {
+        var positions = args.Select( ( a, i ) => (Value: a, Index: i) ).Where( t => t.Value == switchName ).Select( t => t.Index ).ToList();
+        Assert.Single( positions );
+        Assert.True( positions[0] + 1 < args.Count, $"'{switchName}' has no value." );
+        Assert.Equal( expectedValue, args[positions[0] + 1] );
     }
 
     /// <summary>
     /// Returns the argument vector that the child process would actually receive, independently of whether the
-    /// arguments were passed via <see cref="ProcessStartInfo.ArgumentList"/> (the safe form) or via the legacy
-    /// <see cref="ProcessStartInfo.Arguments"/> string (which must then be parsed the way Windows would parse it).
+    /// arguments were passed via <c>ProcessStartInfo.ArgumentList</c> (the safe form) or via the
+    /// <see cref="ProcessStartInfo.Arguments"/> string (which is then parsed the way Windows would parse it).
     /// </summary>
     private static IReadOnlyList<string> GetEffectiveArguments( ProcessStartInfo startInfo )
         => startInfo.ArgumentList.Count > 0

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/WindowsUserInterfaceServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/WindowsUserInterfaceServiceTests.cs
@@ -1,0 +1,114 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Testing;
+using Metalama.Backstage.UserInterface;
+using Metalama.Backstage.UserInterface.Toasts;
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Tests.UserInterface;
+
+/// <summary>
+/// Security regression tests for <c>WindowsUserInterfaceService</c>, which launches the desktop notification
+/// tool as a child process. The notification title/text can originate from an untrusted RSS feed
+/// (threat model: a hijacked/MITM'd metalama.net backend), so it must never be able to inject
+/// additional command-line arguments into the child process (issue #1648).
+/// </summary>
+public sealed class WindowsUserInterfaceServiceTests : TestsBase
+{
+    public WindowsUserInterfaceServiceTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// Verifies that a toast notification whose title contains a quote followed by extra switches cannot inject
+    /// additional arguments (such as an attacker-controlled <c>--uri</c>) into the desktop tool's argv.
+    /// </summary>
+    [Fact]
+    public async Task ToastTitleCannotInjectCommandLineArguments()
+    {
+        // This service and the CommandLineToArgvW helper are Windows-only.
+        if ( !OperatingSystem.IsWindows() )
+        {
+            return;
+        }
+
+        this.UserDeviceDetection.IsInteractiveDevice = true;
+
+        const string injectedUri = "evil://attacker-controlled";
+        const string legitimateUri = "https://metalama.net/legitimate";
+
+        // A title that breaks out of the quoted --title argument and injects its own --uri.
+        var maliciousTitle = $"Pwned\" --uri \"{injectedUri}";
+
+        var service = new WindowsUserInterfaceService( this.ServiceProvider );
+        service.ShowToastNotification( new ToastNotification( ToastNotificationKinds.News, maliciousTitle, null, legitimateUri ) );
+
+        await this.BackgroundTasks.WhenNoPendingTaskAsync();
+
+        var startInfo = Assert.Single( this.ProcessExecutor.StartedProcesses );
+        var args = GetEffectiveArguments( startInfo );
+
+        // The malicious title must reach the child process as a single, verbatim argument.
+        Assert.Contains( maliciousTitle, args );
+
+        // The attacker must not be able to inject a second --uri argument.
+        var uriPositions = args.Select( ( a, i ) => (Value: a, Index: i) ).Where( t => t.Value == "--uri" ).Select( t => t.Index ).ToList();
+        Assert.Single( uriPositions );
+
+        // The single --uri value must be the legitimate URI, never the injected one.
+        Assert.Equal( legitimateUri, args[uriPositions[0] + 1] );
+        Assert.DoesNotContain( injectedUri, args );
+    }
+
+    /// <summary>
+    /// Returns the argument vector that the child process would actually receive, independently of whether the
+    /// arguments were passed via <see cref="ProcessStartInfo.ArgumentList"/> (the safe form) or via the legacy
+    /// <see cref="ProcessStartInfo.Arguments"/> string (which must then be parsed the way Windows would parse it).
+    /// </summary>
+    private static IReadOnlyList<string> GetEffectiveArguments( ProcessStartInfo startInfo )
+        => startInfo.ArgumentList.Count > 0
+            ? startInfo.ArgumentList
+            : ParseCommandLine( startInfo.Arguments );
+
+    [DllImport( "shell32.dll", SetLastError = true, CharSet = CharSet.Unicode )]
+    private static extern IntPtr CommandLineToArgvW( [MarshalAs( UnmanagedType.LPWStr )] string lpCmdLine, out int pNumArgs );
+
+    [DllImport( "kernel32.dll" )]
+    private static extern IntPtr LocalFree( IntPtr hMem );
+
+    private static IReadOnlyList<string> ParseCommandLine( string commandLine )
+    {
+        // CommandLineToArgvW treats argv[0] specially (the program name), so we prepend a dummy token and drop it.
+        var argv = CommandLineToArgvW( "dummy.exe " + commandLine, out var argc );
+
+        if ( argv == IntPtr.Zero )
+        {
+            throw new Win32Exception( Marshal.GetLastWin32Error() );
+        }
+
+        try
+        {
+            var result = new List<string>();
+
+            for ( var i = 1; i < argc; i++ )
+            {
+                var ptr = Marshal.ReadIntPtr( argv, i * IntPtr.Size );
+                result.Add( Marshal.PtrToStringUni( ptr )! );
+            }
+
+            return result;
+        }
+        finally
+        {
+            LocalFree( argv );
+        }
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/WindowsUserInterfaceServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/WindowsUserInterfaceServiceTests.cs
@@ -8,7 +8,6 @@ using Metalama.Backstage.UserInterface.Toasts;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Runtime.InteropServices;
 using System.Threading.Tasks;
@@ -27,6 +26,10 @@ public sealed class WindowsUserInterfaceServiceTests : TestsBase
 {
     private const string _injectedUri = "evil://attacker-controlled";
     private const string _legitimateUri = "https://metalama.net/legitimate";
+
+    // This service and the CommandLineToArgvW helper are Windows-only. Fully qualified to avoid binding to the
+    // TestRuntimeInformation member of the base class.
+    private static bool IsWindows => System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform( OSPlatform.Windows );
 
     public WindowsUserInterfaceServiceTests( ITestOutputHelper logger ) : base( logger ) { }
 
@@ -50,6 +53,11 @@ public sealed class WindowsUserInterfaceServiceTests : TestsBase
     [MemberData( nameof(MaliciousTitles) )]
     public async Task ToastTitleCannotInjectCommandLineArguments( string maliciousTitle )
     {
+        if ( !IsWindows )
+        {
+            return;
+        }
+
         var args = await this.ShowNotificationAndGetArgumentsAsync( new ToastNotification( ToastNotificationKinds.News, maliciousTitle, null, _legitimateUri ) );
 
         // The malicious title must reach the child process as a single, verbatim argument.
@@ -66,6 +74,11 @@ public sealed class WindowsUserInterfaceServiceTests : TestsBase
     [Fact]
     public async Task ToastTextCannotInjectCommandLineArguments()
     {
+        if ( !IsWindows )
+        {
+            return;
+        }
+
         var maliciousText = "Body\" --uri \"" + _injectedUri;
 
         var args = await this.ShowNotificationAndGetArgumentsAsync(
@@ -82,6 +95,11 @@ public sealed class WindowsUserInterfaceServiceTests : TestsBase
     [Fact]
     public async Task BenignToastNotificationPassesArgumentsCorrectly()
     {
+        if ( !IsWindows )
+        {
+            return;
+        }
+
         const string title = "Metalama 2026.1 released";
 
         var args = await this.ShowNotificationAndGetArgumentsAsync(
@@ -94,9 +112,6 @@ public sealed class WindowsUserInterfaceServiceTests : TestsBase
 
     private async Task<IReadOnlyList<string>> ShowNotificationAndGetArgumentsAsync( ToastNotification notification )
     {
-        // This service and the CommandLineToArgvW helper are Windows-only.
-        Assert.True( OperatingSystem.IsWindows() );
-
         this.UserDeviceDetection.IsInteractiveDevice = true;
 
         var service = new WindowsUserInterfaceService( this.ServiceProvider );
@@ -106,7 +121,9 @@ public sealed class WindowsUserInterfaceServiceTests : TestsBase
 
         var startInfo = Assert.Single( this.ProcessExecutor.StartedProcesses );
 
-        return GetEffectiveArguments( startInfo );
+        // The executor builds a single, escaped command-line string (ProcessStartInfo.ArgumentList is not available
+        // on all target frameworks). We re-parse it the way Windows would to recover the effective argument vector.
+        return ParseCommandLine( startInfo.Arguments );
     }
 
     /// <summary>
@@ -120,16 +137,6 @@ public sealed class WindowsUserInterfaceServiceTests : TestsBase
         Assert.True( positions[0] + 1 < args.Count, $"'{switchName}' has no value." );
         Assert.Equal( expectedValue, args[positions[0] + 1] );
     }
-
-    /// <summary>
-    /// Returns the argument vector that the child process would actually receive, independently of whether the
-    /// arguments were passed via <c>ProcessStartInfo.ArgumentList</c> (the safe form) or via the
-    /// <see cref="ProcessStartInfo.Arguments"/> string (which is then parsed the way Windows would parse it).
-    /// </summary>
-    private static IReadOnlyList<string> GetEffectiveArguments( ProcessStartInfo startInfo )
-        => startInfo.ArgumentList.Count > 0
-            ? startInfo.ArgumentList
-            : ParseCommandLine( startInfo.Arguments );
 
     [DllImport( "shell32.dll", SetLastError = true, CharSet = CharSet.Unicode )]
     private static extern IntPtr CommandLineToArgvW( [MarshalAs( UnmanagedType.LPWStr )] string lpCmdLine, out int pNumArgs );


### PR DESCRIPTION
## Summary

Fixes #1648 ΓÇö **Security (MEDIUM): RSS feed title injects arbitrary arguments into the desktop process on Windows.**

`WindowsUserInterfaceService.ShowToastNotification` built the child-process (`Metalama.Backstage.Desktop.Windows.exe`) command line by interpolating the untrusted toast `Title`/`Text`/`Uri` into a string with no escaping. A `Title` from a hijacked/MITM'd RSS feed containing a `"` could break out of the quoted `--title` argument and inject arbitrary `argv` (e.g. an attacker-controlled `--uri`).

## Fix

Pass arguments as a vector end-to-end instead of a concatenated string:
- `IBackstageToolsExecutor.Start( BackstageTool, params string[] arguments )`.
- `BackstageToolsExecutor` quotes each argument with the canonical Windows algorithm (round-trips through `CommandLineToArgvW`). `ProcessStartInfo.ArgumentList` is not usable because the assembly also targets `netframework4.7.2`/`netstandard2.0`.
- `WindowsUserInterfaceService` and the `web` server call site pass separate tokens.

## Tests

`WindowsUserInterfaceServiceTests`: title injection (incl. backslash/quote edge cases), text injection, benign baseline. Verified the test fails before the fix (injected a second `--uri`) and passes after. 13 affected tests green on `net8.0` and `netframework4.7.2`.

## Checklist

- [x] Phase 1 ΓÇö Understand the issue
- [x] Phase 2 ΓÇö Failing regression test reproducing the injection
- [x] Phase 3 ΓÇö Fix
- [x] Phase 4 ΓÇö Full build & test (zero warnings)
- [x] Phase 5 ΓÇö Finalize (marked ready, review requested)

ΓÇö Claude for Gael