### PR TITLE
Security: validate temp directory is not writable by other users (#1650)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
@@ -6,7 +6,17 @@
 
 using JetBrains.Annotations;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Security;
+using System.Security.AccessControl;
+using System.Security.Principal;
+#if NET
+using System.Runtime.Versioning;
+#else
+using System.Globalization;
+#endif
 
 namespace Metalama.Backstage.Utilities;
 
@@ -14,6 +24,8 @@ namespace Metalama.Backstage.Utilities;
 public static class MetalamaPathUtilities
 {
     private static readonly string? _overriddenTempPath;
+    private static readonly object _tempPathVerificationSync = new();
+    private static volatile bool _tempPathVerified;
 
     static MetalamaPathUtilities()
     {
@@ -21,7 +33,14 @@ public static class MetalamaPathUtilities
         _overriddenTempPath = string.IsNullOrEmpty( overriddenTempPath ) ? null : overriddenTempPath;
     }
 
-    public static string GetTempPath() => _overriddenTempPath ?? Path.GetTempPath();
+    public static string GetTempPath()
+    {
+        var tempPath = _overriddenTempPath ?? Path.GetTempPath();
+
+        VerifyTempPathIsSecure( tempPath );
+
+        return tempPath;
+    }
 
     public static string GetTempFileName()
     {
@@ -48,5 +67,164 @@ public static class MetalamaPathUtilities
 
             return path;
         }
+    }
+
+    /// <summary>
+    /// Verifies, only once per process, that the Metalama temporary directory is not writable by other users of the machine.
+    /// Metalama loads and executes assemblies from this directory (compile-time assemblies, extracted tools, bootstrap dependencies),
+    /// so a directory writable by lower-privilege users would let them plant code that Metalama then runs. See issue #1650.
+    /// </summary>
+    private static void VerifyTempPathIsSecure( string tempPath )
+    {
+        if ( _tempPathVerified )
+        {
+            return;
+        }
+
+        lock ( _tempPathVerificationSync )
+        {
+            if ( _tempPathVerified )
+            {
+                return;
+            }
+
+            var metalamaTempDirectory = Path.Combine( tempPath, "Metalama" );
+
+            bool writableByOtherUsers;
+
+            try
+            {
+                // If the directory does not exist yet, there is nothing to plant: it will be created by the current user.
+                writableByOtherUsers = Directory.Exists( metalamaTempDirectory ) && IsDirectoryWritableByOtherUsers( metalamaTempDirectory );
+            }
+            catch ( Exception )
+            {
+                // If we cannot determine the permissions (e.g. an unexpected platform or API failure), do not block the build.
+                writableByOtherUsers = false;
+            }
+
+            if ( writableByOtherUsers )
+            {
+                throw new SecurityException(
+                    $"The Metalama temporary directory '{metalamaTempDirectory}' is writable by other users of this machine. "
+                    + "This would allow them to plant assemblies that Metalama loads and executes. "
+                    + "Restrict the permissions of this directory to the current user, or set the METALAMA_TEMP environment variable "
+                    + "to a directory that only the current user can write to." );
+            }
+
+            _tempPathVerified = true;
+        }
+    }
+
+    /// <summary>
+    /// Determines whether the given directory grants write access to users other than the current one.
+    /// On Windows, this inspects the directory ACL; on Unix, this inspects the group and other write mode bits.
+    /// </summary>
+    internal static bool IsDirectoryWritableByOtherUsers( string directory )
+    {
+        if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+        {
+            return IsDirectoryWritableByOtherUsersOnWindows( directory );
+        }
+
+        return IsDirectoryWritableByOtherUsersOnUnix( directory );
+    }
+
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static bool IsDirectoryWritableByOtherUsersOnWindows( string directory )
+    {
+        var directoryInfo = new DirectoryInfo( directory );
+        var security = directoryInfo.GetAccessControl();
+        var trustedIdentities = GetTrustedWindowsIdentities();
+
+        // Only atomic write/modify rights are listed. Composite rights such as Write, Modify and FullControl must NOT
+        // be used here: their numeric value also includes read and execute bits, which would incorrectly flag a
+        // directory that other users can only read. A composite grant is still detected because its value includes
+        // these atomic bits (e.g. FullControl includes WriteData).
+        const FileSystemRights writeRights =
+            FileSystemRights.WriteData                      // Also known as CreateFiles.
+            | FileSystemRights.AppendData                   // Also known as CreateDirectories.
+            | FileSystemRights.WriteExtendedAttributes
+            | FileSystemRights.WriteAttributes
+            | FileSystemRights.Delete
+            | FileSystemRights.DeleteSubdirectoriesAndFiles
+            | FileSystemRights.ChangePermissions
+            | FileSystemRights.TakeOwnership;
+
+        foreach ( FileSystemAccessRule rule in security.GetAccessRules( true, true, typeof(SecurityIdentifier) ) )
+        {
+            if ( rule.AccessControlType != AccessControlType.Allow )
+            {
+                continue;
+            }
+
+            if ( (rule.FileSystemRights & writeRights) == 0 )
+            {
+                continue;
+            }
+
+            if ( rule.IdentityReference is SecurityIdentifier sid && !trustedIdentities.Contains( sid ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static HashSet<SecurityIdentifier> GetTrustedWindowsIdentities()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+
+        var trustedIdentities = new HashSet<SecurityIdentifier>
+        {
+            new( WellKnownSidType.LocalSystemSid, null ),
+            new( WellKnownSidType.BuiltinAdministratorsSid, null ),
+
+            // In an inherited ACE, CREATOR OWNER resolves to the owner of the object, i.e. the current user.
+            new( WellKnownSidType.CreatorOwnerSid, null )
+        };
+
+        if ( identity.User != null )
+        {
+            trustedIdentities.Add( identity.User );
+        }
+
+        return trustedIdentities;
+    }
+
+#if NET
+    [UnsupportedOSPlatform( "windows" )]
+#endif
+    private static bool IsDirectoryWritableByOtherUsersOnUnix( string directory )
+    {
+#if NET
+        var mode = File.GetUnixFileMode( directory );
+
+        return (mode & (UnixFileMode.GroupWrite | UnixFileMode.OtherWrite)) != 0;
+#else
+        // On netstandard2.0 (which may run on .NET 7 or later) the File.GetUnixFileMode method exists at run time
+        // even though it is not part of the compile-time surface. We call it through reflection.
+        // (net472 is Windows-only and never reaches this method.)
+        var getUnixFileMode = typeof(File).GetMethod( "GetUnixFileMode", new[] { typeof(string) } );
+
+        if ( getUnixFileMode == null )
+        {
+            // Unknown or old runtime: we cannot determine the mode, so we assume the directory is secure to avoid breaking the build.
+            return false;
+        }
+
+        var mode = Convert.ToInt32( getUnixFileMode.Invoke( null, new object[] { directory } ), CultureInfo.InvariantCulture );
+
+        // UnixFileMode.GroupWrite == 0x10, UnixFileMode.OtherWrite == 0x02.
+        const int groupOrOtherWrite = 0x10 | 0x02;
+
+        return (mode & groupOrOtherWrite) != 0;
+#endif
     }
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
@@ -37,7 +37,7 @@ public static class MetalamaPathUtilities
     {
         var tempPath = _overriddenTempPath ?? Path.GetTempPath();
 
-        VerifyTempPathIsSecure( tempPath );
+        EnsureTempPathIsSecure( tempPath );
 
         return tempPath;
     }
@@ -70,11 +70,15 @@ public static class MetalamaPathUtilities
     }
 
     /// <summary>
-    /// Verifies, only once per process, that the Metalama temporary directory is not writable by other users of the machine.
+    /// Ensures, only once per process, that the Metalama temporary directory is not writable by other users of the machine.
     /// Metalama loads and executes assemblies from this directory (compile-time assemblies, extracted tools, bootstrap dependencies),
     /// so a directory writable by lower-privilege users would let them plant code that Metalama then runs. See issue #1650.
+    /// The directory is created (if necessary) and, when it is found to be writable by other users — typically because it was
+    /// created under a world-writable root such as <c>/tmp</c> or <c>C:\Temp</c> and inherited permissive permissions —
+    /// its permissions are tightened to the current user. A <see cref="SecurityException" /> is thrown only if the directory
+    /// remains writable by other users after that attempt, e.g. because it is owned by another user.
     /// </summary>
-    private static void VerifyTempPathIsSecure( string tempPath )
+    private static void EnsureTempPathIsSecure( string tempPath )
     {
         if ( _tempPathVerified )
         {
@@ -90,30 +94,135 @@ public static class MetalamaPathUtilities
 
             var metalamaTempDirectory = Path.Combine( tempPath, "Metalama" );
 
-            bool writableByOtherUsers;
-
             try
             {
-                // If the directory does not exist yet, there is nothing to plant: it will be created by the current user.
-                writableByOtherUsers = Directory.Exists( metalamaTempDirectory ) && IsDirectoryWritableByOtherUsers( metalamaTempDirectory );
+                if ( !Directory.Exists( metalamaTempDirectory ) )
+                {
+                    Directory.CreateDirectory( metalamaTempDirectory );
+                }
+
+                // Several Metalama processes (e.g. concurrent compiler invocations) may secure the directory at the same time,
+                // so we retry a few times before giving up, to tolerate a transient failure caused by such a race.
+                const int maxAttempts = 4;
+
+                for ( var attempt = 0; IsDirectoryWritableByOtherUsers( metalamaTempDirectory ); attempt++ )
+                {
+                    if ( attempt >= maxAttempts )
+                    {
+                        throw new SecurityException(
+                            $"The Metalama temporary directory '{metalamaTempDirectory}' is writable by other users of this machine "
+                            + "and its permissions could not be tightened automatically. "
+                            + "This would allow them to plant assemblies that Metalama loads and executes. "
+                            + "Restrict the permissions of this directory to the current user, or set the METALAMA_TEMP environment variable "
+                            + "to a directory that only the current user can write to." );
+                    }
+
+                    TryRestrictDirectoryToCurrentUser( metalamaTempDirectory );
+                }
+            }
+            catch ( SecurityException )
+            {
+                throw;
             }
             catch ( Exception )
             {
-                // If we cannot determine the permissions (e.g. an unexpected platform or API failure), do not block the build.
-                writableByOtherUsers = false;
-            }
-
-            if ( writableByOtherUsers )
-            {
-                throw new SecurityException(
-                    $"The Metalama temporary directory '{metalamaTempDirectory}' is writable by other users of this machine. "
-                    + "This would allow them to plant assemblies that Metalama loads and executes. "
-                    + "Restrict the permissions of this directory to the current user, or set the METALAMA_TEMP environment variable "
-                    + "to a directory that only the current user can write to." );
+                // If we cannot determine or set the permissions (e.g. an unexpected platform or API failure), do not block the build.
             }
 
             _tempPathVerified = true;
         }
+    }
+
+    /// <summary>
+    /// Best-effort tightening of the permissions of a directory so that only the current user (plus SYSTEM and Administrators on
+    /// Windows) can write to it. Any failure is swallowed; the caller re-checks the result.
+    /// </summary>
+    private static void TryRestrictDirectoryToCurrentUser( string directory )
+    {
+        try
+        {
+            if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+            {
+                RestrictDirectoryToCurrentUserOnWindows( directory );
+            }
+            else
+            {
+                RestrictDirectoryToOwnerOnUnix( directory );
+            }
+        }
+        catch ( Exception )
+        {
+            // Best effort.
+        }
+    }
+
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static void RestrictDirectoryToCurrentUserOnWindows( string directory )
+    {
+        // Replace the whole ACL by a protected (non-inherited) one that grants full control only to the current user,
+        // SYSTEM and the Administrators group.
+        var security = new DirectorySecurity();
+        security.SetAccessRuleProtection( isProtected: true, preserveInheritance: false );
+
+        const InheritanceFlags inheritanceFlags = InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit;
+
+        using ( var identity = WindowsIdentity.GetCurrent() )
+        {
+            if ( identity.User != null )
+            {
+                security.AddAccessRule(
+                    new FileSystemAccessRule( identity.User, FileSystemRights.FullControl, inheritanceFlags, PropagationFlags.None, AccessControlType.Allow ) );
+            }
+        }
+
+        security.AddAccessRule(
+            new FileSystemAccessRule(
+                new SecurityIdentifier( WellKnownSidType.LocalSystemSid, null ),
+                FileSystemRights.FullControl,
+                inheritanceFlags,
+                PropagationFlags.None,
+                AccessControlType.Allow ) );
+
+        security.AddAccessRule(
+            new FileSystemAccessRule(
+                new SecurityIdentifier( WellKnownSidType.BuiltinAdministratorsSid, null ),
+                FileSystemRights.FullControl,
+                inheritanceFlags,
+                PropagationFlags.None,
+                AccessControlType.Allow ) );
+
+        new DirectoryInfo( directory ).SetAccessControl( security );
+    }
+
+#if NET
+    [UnsupportedOSPlatform( "windows" )]
+#endif
+    private static void RestrictDirectoryToOwnerOnUnix( string directory )
+    {
+        // 0700: read/write/execute for the owner only.
+#if NET
+        File.SetUnixFileMode( directory, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute );
+#else
+        var setUnixFileMode = Array.Find(
+            typeof(File).GetMethods(),
+            m => m.Name == "SetUnixFileMode"
+                 && m.GetParameters().Length == 2
+                 && m.GetParameters()[0].ParameterType == typeof(string) );
+
+        if ( setUnixFileMode == null )
+        {
+            return;
+        }
+
+        var unixFileModeType = setUnixFileMode.GetParameters()[1].ParameterType;
+
+        // UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute == 0x100 | 0x80 | 0x40.
+        var mode = Enum.ToObject( unixFileModeType, 0x100 | 0x80 | 0x40 );
+
+        setUnixFileMode.Invoke( null, new[] { directory, mode } );
+#endif
     }
 
     /// <summary>

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Utilities/MetalamaPathSecurityTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Utilities/MetalamaPathSecurityTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Utilities;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+#if NET
+using System.Runtime.Versioning;
+#endif
+using System.Security.AccessControl;
+using System.Security.Principal;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Tests.Utilities;
+
+// Regression tests for https://github.com/metalama/Metalama/issues/1650.
+// Metalama writes artifacts it later loads/executes under the temp directory. If that directory
+// is writable by other (lower-privilege) users, those users can plant malicious DLLs that Metalama
+// then loads. MetalamaPathUtilities must therefore be able to tell whether a directory is writable
+// by users other than the current one.
+public sealed class MetalamaPathSecurityTests
+{
+    private readonly ITestOutputHelper _logger;
+
+    public MetalamaPathSecurityTests( ITestOutputHelper logger )
+    {
+        this._logger = logger;
+    }
+
+    [Fact]
+    public void DirectoryWritableOnlyByCurrentUserIsNotFlagged()
+    {
+        var directory = CreateTempDirectory();
+
+        try
+        {
+            RestrictToCurrentUser( directory );
+
+            Assert.False(
+                MetalamaPathUtilities.IsDirectoryWritableByOtherUsers( directory ),
+                "A directory writable only by the current user must not be reported as writable by other users." );
+        }
+        finally
+        {
+            this.TryDeleteDirectory( directory );
+        }
+    }
+
+    [Fact]
+    public void DirectoryWritableByOtherUsersIsFlagged()
+    {
+        var directory = CreateTempDirectory();
+
+        try
+        {
+            GrantWriteToOtherUsers( directory );
+
+            Assert.True(
+                MetalamaPathUtilities.IsDirectoryWritableByOtherUsers( directory ),
+                "A directory writable by all users must be reported as such, because it allows DLL planting." );
+        }
+        finally
+        {
+            this.TryDeleteDirectory( directory );
+        }
+    }
+
+    private static string CreateTempDirectory()
+    {
+        var directory = Path.Combine( Path.GetTempPath(), "Metalama_Test_1650_" + Guid.NewGuid().ToString( "N" ) );
+        Directory.CreateDirectory( directory );
+
+        return directory;
+    }
+
+    private static void RestrictToCurrentUser( string directory )
+    {
+        if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+        {
+            RestrictToCurrentWindowsUser( directory );
+        }
+        else
+        {
+            SetUnixMode( directory, otherWritable: false );
+        }
+    }
+
+    private static void GrantWriteToOtherUsers( string directory )
+    {
+        if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+        {
+            GrantWriteToEveryone( directory );
+        }
+        else
+        {
+            SetUnixMode( directory, otherWritable: true );
+        }
+    }
+
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static void RestrictToCurrentWindowsUser( string directory )
+    {
+        var directoryInfo = new DirectoryInfo( directory );
+        var security = new DirectorySecurity();
+        var currentUser = WindowsIdentity.GetCurrent().User!;
+
+        // Disable inheritance (drop inherited rules) and grant full control to the current user only.
+        security.SetAccessRuleProtection( true, false );
+        security.SetOwner( currentUser );
+
+        security.AddAccessRule(
+            new FileSystemAccessRule(
+                currentUser,
+                FileSystemRights.FullControl,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow ) );
+
+        directoryInfo.SetAccessControl( security );
+    }
+
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static void GrantWriteToEveryone( string directory )
+    {
+        var directoryInfo = new DirectoryInfo( directory );
+        var security = directoryInfo.GetAccessControl();
+        var everyone = new SecurityIdentifier( WellKnownSidType.WorldSid, null );
+
+        security.AddAccessRule(
+            new FileSystemAccessRule(
+                everyone,
+                FileSystemRights.Modify,
+                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                PropagationFlags.None,
+                AccessControlType.Allow ) );
+
+        directoryInfo.SetAccessControl( security );
+    }
+
+    private static void SetUnixMode( string directory, bool otherWritable )
+    {
+#if NET
+        var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
+
+        if ( otherWritable )
+        {
+            mode |= UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
+        }
+
+        File.SetUnixFileMode( directory, mode );
+#else
+        _ = directory;
+        _ = otherWritable;
+
+        throw new PlatformNotSupportedException();
+#endif
+    }
+
+    private void TryDeleteDirectory( string directory )
+    {
+        try
+        {
+            Directory.Delete( directory, recursive: true );
+        }
+        catch ( Exception e )
+        {
+            this._logger.WriteLine( $"Failed to delete '{directory}': {e.Message}" );
+        }
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Utilities/MetalamaPathSecurityTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Utilities/MetalamaPathSecurityTests.cs
@@ -68,6 +68,25 @@ public sealed class MetalamaPathSecurityTests
         }
     }
 
+    [Fact]
+    public void DirectoryReadableButNotWritableByOtherUsersIsNotFlagged()
+    {
+        var directory = CreateTempDirectory();
+
+        try
+        {
+            GrantReadOnlyToOtherUsers( directory );
+
+            Assert.False(
+                MetalamaPathUtilities.IsDirectoryWritableByOtherUsers( directory ),
+                "A directory that other users can only read must not be reported as writable by them." );
+        }
+        finally
+        {
+            this.TryDeleteDirectory( directory );
+        }
+    }
+
     private static string CreateTempDirectory()
     {
         var directory = Path.Combine( Path.GetTempPath(), "Metalama_Test_1650_" + Guid.NewGuid().ToString( "N" ) );
@@ -100,17 +119,46 @@ public sealed class MetalamaPathSecurityTests
         }
     }
 
+    private static void GrantReadOnlyToOtherUsers( string directory )
+    {
+        if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+        {
+            GrantReadAndExecuteToEveryone( directory );
+        }
+        else
+        {
+            SetUnixMode( directory, otherWritable: false, otherReadable: true );
+        }
+    }
+
 #if NET
     [SupportedOSPlatform( "windows" )]
 #endif
-    private static void RestrictToCurrentWindowsUser( string directory )
+    private static void RestrictToCurrentWindowsUser( string directory ) => SetWindowsAcl( directory, everyoneRights: null );
+
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static void GrantWriteToEveryone( string directory ) => SetWindowsAcl( directory, FileSystemRights.Modify );
+
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static void GrantReadAndExecuteToEveryone( string directory ) => SetWindowsAcl( directory, FileSystemRights.ReadAndExecute );
+
+    // Sets a deterministic, non-inherited ACL: full control to the current user, plus an optional rule for 'Everyone'.
+    // Starting from a protected ACL ensures the only non-trivial entry is the one we add, regardless of what the parent
+    // (e.g. %TEMP%) grants.
+#if NET
+    [SupportedOSPlatform( "windows" )]
+#endif
+    private static void SetWindowsAcl( string directory, FileSystemRights? everyoneRights )
     {
         var directoryInfo = new DirectoryInfo( directory );
         var security = new DirectorySecurity();
         var currentUser = WindowsIdentity.GetCurrent().User!;
 
-        // Disable inheritance (drop inherited rules) and grant full control to the current user only.
-        security.SetAccessRuleProtection( true, false );
+        security.SetAccessRuleProtection( isProtected: true, preserveInheritance: false );
         security.SetOwner( currentUser );
 
         security.AddAccessRule(
@@ -121,30 +169,24 @@ public sealed class MetalamaPathSecurityTests
                 PropagationFlags.None,
                 AccessControlType.Allow ) );
 
+        if ( everyoneRights != null )
+        {
+            security.AddAccessRule(
+                new FileSystemAccessRule(
+                    new SecurityIdentifier( WellKnownSidType.WorldSid, null ),
+                    everyoneRights.Value,
+                    InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
+                    PropagationFlags.None,
+                    AccessControlType.Allow ) );
+        }
+
         directoryInfo.SetAccessControl( security );
     }
 
 #if NET
-    [SupportedOSPlatform( "windows" )]
+    [UnsupportedOSPlatform( "windows" )]
 #endif
-    private static void GrantWriteToEveryone( string directory )
-    {
-        var directoryInfo = new DirectoryInfo( directory );
-        var security = directoryInfo.GetAccessControl();
-        var everyone = new SecurityIdentifier( WellKnownSidType.WorldSid, null );
-
-        security.AddAccessRule(
-            new FileSystemAccessRule(
-                everyone,
-                FileSystemRights.Modify,
-                InheritanceFlags.ContainerInherit | InheritanceFlags.ObjectInherit,
-                PropagationFlags.None,
-                AccessControlType.Allow ) );
-
-        directoryInfo.SetAccessControl( security );
-    }
-
-    private static void SetUnixMode( string directory, bool otherWritable )
+    private static void SetUnixMode( string directory, bool otherWritable, bool otherReadable = false )
     {
 #if NET
         var mode = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
@@ -154,11 +196,17 @@ public sealed class MetalamaPathSecurityTests
             mode |= UnixFileMode.GroupRead | UnixFileMode.GroupWrite | UnixFileMode.GroupExecute
                     | UnixFileMode.OtherRead | UnixFileMode.OtherWrite | UnixFileMode.OtherExecute;
         }
+        else if ( otherReadable )
+        {
+            mode |= UnixFileMode.GroupRead | UnixFileMode.GroupExecute
+                    | UnixFileMode.OtherRead | UnixFileMode.OtherExecute;
+        }
 
         File.SetUnixFileMode( directory, mode );
 #else
         _ = directory;
         _ = otherWritable;
+        _ = otherReadable;
 
         throw new PlatformNotSupportedException();
 #endif


### PR DESCRIPTION
## Security: predictable world-writable temp artifacts (#1650)

Fixes #1650.

Metalama writes artifacts it later loads/executes — the compile-time assembly cache and extracted Backstage tools — under the temp directory (`METALAMA_TEMP` or the default `%TEMP%\Metalama` / `$TMPDIR/Metalama`). On a host where the temp root is writable by other users (e.g. `/tmp` on Linux/macOS, or a machine-wide `C:\Temp`), a lower-privilege user can plant a DLL that Metalama then trusts on file existence and loads → local code execution / privilege escalation.

### Approach (per @gfraiteur's guidance)

> verify that `METALAMA_TEMP` (or its default value, `%TEMP%\Metalama`) is not writable by other users. This check can be performed once, and the result can be stored in a static variable.

`MetalamaPathUtilities.GetTempPath()` now performs a one-time, statically-cached `EnsureTempPathIsSecure`:

1. Creates `{temp}/Metalama` if absent.
2. If the directory is writable by other users — `IsDirectoryWritableByOtherUsers`:
   - **Windows**: any *Allow* ACE granting an atomic write/modify right to an identity other than the current user, SYSTEM, Administrators or CREATOR OWNER. Composite rights (Write/Modify/FullControl) are intentionally excluded from the mask because their numeric value also contains read/execute bits (which would wrongly flag a read-only shared directory); composite grants are still caught because their value includes the atomic write bits.
   - **Unix**: the group- or other-write mode bit is set (`File.GetUnixFileMode` on .NET 8; via reflection on the netstandard2.0 build, which runs on .NET 7+).
   - it tightens the permissions to the current user (protected ACL on Windows / `0700` on Unix), retrying a few times to tolerate concurrent compiler processes.
3. Throws a `SecurityException` with a remediation hint **only** if the directory is *still* writable by other users after that attempt (e.g. it is owned by another user).

This secures the directory rather than failing the build on machines that legitimately use a shared temp root (validated: the consolidated build runs every `csc` invocation through this path and `C:\Temp\Metalama` ends up restricted to SYSTEM / Administrators / current user, inheritance disabled).

### Tests
`MetalamaPathSecurityTests` (3 tests, green on net8.0 + net472): writable-by-everyone ⇒ flagged; current-user-only ⇒ not flagged; readable-but-not-writable-by-others ⇒ not flagged (this case caught a real masking bug). Full `Metalama.Backstage.Tests` suite passes on both TFMs (1253/1252, 0 failures); full `Build.ps1 build` succeeds with zero warnings.

### Open question for @gfraiteur
The third sink listed in the issue, `ResourceExtractor` (`Metalama.Framework.CompilerExtensions`, netstandard2.0), reads `METALAMA_TEMP` independently, has **no** reference to `Metalama.Backstage`, and runs the earliest (it extracts and loads Backstage itself). It is therefore *not* covered here. That project deliberately avoids `System.Security.AccessControl` (its `MutexAcl` uses raw P/Invoke + SDDL), so covering it cleanly means duplicating a platform-specific check there (and in the `Metalama.Compiler.Shared` copy). I kept it out to avoid risk in the bootstrap path — let me know if you want it included.

### Checklist
- [x] Phase 1 — Understand
- [x] Phase 2 — Failing regression test
- [x] Phase 3 — Implement the check + securing
- [x] Phase 4 — Build & test (zero warnings, all Backstage tests green, full build validated)
- [x] Phase 5 — Ready for review

— Claude for Gael