### PR TITLE
Security: restrict RSS feed link to http/https scheme (#1647)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
@@ -6,6 +6,7 @@ using Metalama.Backstage.Desktop.Windows.Commands;
 using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.UserInterface;
 using Metalama.Backstage.UserInterface.Toasts;
+using Metalama.Backstage.Utilities;
 using System;
 using System.Diagnostics.CodeAnalysis;
 
@@ -90,8 +91,7 @@ internal static class ViewModelBuilder
             // Defense in depth: ensure the URI uses a safe (http/https) scheme before it reaches Windows protocol
             // activation. The primary validation is in RssClient, but the URI is server-controlled, so we re-check here.
             // See issue #1647.
-            if ( !Uri.TryCreate( settings.Uri, UriKind.Absolute, out var newsUri )
-                 || (newsUri.Scheme != Uri.UriSchemeHttp && newsUri.Scheme != Uri.UriSchemeHttps) )
+            if ( !UrlHelper.IsSafe( settings.Uri, out var newsUri ) )
             {
                 viewModel = null;
 

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
@@ -87,11 +87,22 @@ internal static class ViewModelBuilder
         }
         else if ( settings.Kind == ToastNotificationKinds.News.Name )
         {
+            // Defense in depth: ensure the URI uses a safe (http/https) scheme before it reaches Windows protocol
+            // activation. The primary validation is in RssClient, but the URI is server-controlled, so we re-check here.
+            // See issue #1647.
+            if ( !Uri.TryCreate( settings.Uri, UriKind.Absolute, out var newsUri )
+                 || (newsUri.Scheme != Uri.UriSchemeHttp && newsUri.Scheme != Uri.UriSchemeHttps) )
+            {
+                viewModel = null;
+
+                return false;
+            }
+
             viewModel = new NotificationViewModel(
                 settings.Kind,
                 "Metalama Blog Update",
                 settings.Title,
-                new UriActionViewModel( "Read", settings.Uri! ),
+                new UriActionViewModel( "Read", newsUri ),
                 new CommandActionViewModel( "Options", activationArguments.OpenRssOptions ) ) { CanMute = false, CanSnooze = false };
 
             return true;

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
@@ -221,8 +221,20 @@ internal sealed class RssClient : IRssClient
             return false;
         }
 
+        // Validate that the link is an absolute http/https URI. A hijacked or MITM'd feed could otherwise supply a dangerous
+        // scheme (e.g. 'ms-msdt:', 'search-ms:', 'file://') that would be passed to Windows protocol activation when the user
+        // clicks the toast. See issue #1647.
+        if ( !Uri.TryCreate( url, UriKind.Absolute, out var linkUri )
+             || (linkUri.Scheme != Uri.UriSchemeHttp && linkUri.Scheme != Uri.UriSchemeHttps) )
+        {
+            this._logger.Warning?.Log( $"RSS item link '{url}' does not use the http or https scheme. Skipping." );
+            pubDate = null;
+
+            return false;
+        }
+
         // Append tracking query string parameters using UriBuilder for robustness.
-        var uriBuilder = new UriBuilder( url );
+        var uriBuilder = new UriBuilder( linkUri );
 
         if ( string.IsNullOrEmpty( uriBuilder.Query ) )
         {

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
@@ -8,6 +8,7 @@ using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Infrastructure;
 using Metalama.Backstage.Telemetry;
 using Metalama.Backstage.UserInterface.Toasts;
+using Metalama.Backstage.Utilities;
 using System;
 using System.IO;
 using System.Linq;
@@ -224,8 +225,7 @@ internal sealed class RssClient : IRssClient
         // Validate that the link is an absolute http/https URI. A hijacked or MITM'd feed could otherwise supply a dangerous
         // scheme (e.g. 'ms-msdt:', 'search-ms:', 'file://') that would be passed to Windows protocol activation when the user
         // clicks the toast. See issue #1647.
-        if ( !Uri.TryCreate( url, UriKind.Absolute, out var linkUri )
-             || (linkUri.Scheme != Uri.UriSchemeHttp && linkUri.Scheme != Uri.UriSchemeHttps) )
+        if ( !UrlHelper.IsSafe( url, out var linkUri ) )
         {
             this._logger.Warning?.Log( $"RSS item link '{url}' does not use the http or https scheme. Skipping." );
             pubDate = null;

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
@@ -227,7 +227,7 @@ internal sealed class RssClient : IRssClient
         // clicks the toast. See issue #1647.
         if ( !UrlHelper.IsSafe( url, out var linkUri ) )
         {
-            this._logger.Warning?.Log( $"RSS item link '{url}' does not use the http or https scheme. Skipping." );
+            this._logger.Warning?.Log( $"RSS item link '{url}' is not a valid absolute http or https URL. Skipping." );
             pubDate = null;
 
             return false;

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/UrlHelper.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/UrlHelper.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Diagnostics.CodeAnalysis;
+
+namespace Metalama.Backstage.Utilities;
+
+internal static class UrlHelper
+{
+    /// <summary>
+    /// Determines whether the given <paramref name="url"/> is a safe absolute URL, i.e. one that uses the <c>http</c> or
+    /// <c>https</c> scheme. This prevents a hijacked or MITM'd feed from supplying a dangerous scheme (e.g. <c>ms-msdt:</c>,
+    /// <c>search-ms:</c>, <c>file://</c>) that would be passed to Windows protocol activation. See issue #1647.
+    /// </summary>
+    public static bool IsSafe( [NotNullWhen( true )] string? url, [NotNullWhen( true )] out Uri? uri )
+    {
+        if ( !Uri.TryCreate( url, UriKind.Absolute, out uri )
+             || uri.Scheme is not ("http" or "https") )
+        {
+            uri = null;
+
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/UrlHelper.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/UrlHelper.cs
@@ -7,7 +7,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Metalama.Backstage.Utilities;
 
-internal static class UrlHelper
+public static class UrlHelper
 {
     /// <summary>
     /// Determines whether the given <paramref name="url"/> is a safe absolute URL, i.e. one that uses the <c>http</c> or

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/UrlHelper.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/UrlHelper.cs
@@ -17,7 +17,7 @@ public static class UrlHelper
     public static bool IsSafe( [NotNullWhen( true )] string? url, [NotNullWhen( true )] out Uri? uri )
     {
         if ( !Uri.TryCreate( url, UriKind.Absolute, out uri )
-             || uri.Scheme is not ("http" or "https") )
+             || (uri.Scheme != Uri.UriSchemeHttp && uri.Scheme != Uri.UriSchemeHttps) )
         {
             uri = null;
 

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/RssClientTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/RssClientTests.cs
@@ -210,18 +210,25 @@ public sealed class RssClientTests : TestsBase
     }
 
     /// <summary>
-    /// Verifies that RssClient does not display a toast notification when the newest item's link uses a non-http(s) URI scheme.
+    /// Verifies that RssClient only displays a toast notification when the newest item's link uses an http(s) URI scheme.
     /// A hijacked or MITM'd feed could otherwise supply a dangerous scheme (e.g. <c>ms-msdt:</c>, <c>search-ms:</c>, <c>file://</c>)
-    /// that would be passed to Windows protocol activation when the user clicks the toast. See issue #1647.
+    /// that would be passed to Windows protocol activation when the user clicks the toast. See issue #1647. Valid http(s)
+    /// links must still produce a notification.
     /// </summary>
     [Theory]
-    [InlineData( "file:///C:/Windows/System32/calc.exe" )]
-    [InlineData( "ms-msdt:/id PCWDiagnostic" )]
-    [InlineData( "search-ms:query=foo&crumb=location:\\\\attacker.example.com\\share" )]
-    [InlineData( "javascript:alert(1)" )]
-    [InlineData( "ftp://attacker.example.com/payload" )]
-    [InlineData( "\\\\attacker.example.com\\share\\payload" )]
-    public async Task RssClientRejectsNonHttpLinkScheme( string maliciousLink )
+
+    // Safe http(s) links must still produce a notification.
+    [InlineData( "https://metalama.net/latest-news", false )]
+    [InlineData( "http://metalama.net/latest-news", false )]
+
+    // Dangerous schemes must be rejected.
+    [InlineData( "file:///C:/Windows/System32/calc.exe", true )]
+    [InlineData( "ms-msdt:/id PCWDiagnostic", true )]
+    [InlineData( "search-ms:query=foo&crumb=location:\\\\attacker.example.com\\share", true )]
+    [InlineData( "javascript:alert(1)", true )]
+    [InlineData( "ftp://attacker.example.com/payload", true )]
+    [InlineData( "\\\\attacker.example.com\\share\\payload", true )]
+    public async Task RssClientValidatesLinkScheme( string link, bool shouldBeRejected )
     {
         var rssXml = $"""
                       <?xml version="1.0" encoding="UTF-8"?>
@@ -231,10 +238,10 @@ public sealed class RssClientTests : TestsBase
                           <link>https://metalama.net/</link>
                           <description>Test Description</description>
                           <item>
-                            <title>Malicious News Article</title>
-                            <link>{System.Security.SecurityElement.Escape( maliciousLink )}</link>
+                            <title>News Article</title>
+                            <link>{System.Security.SecurityElement.Escape( link )}</link>
                             <pubDate>Mon, 01 Nov 2025 12:00:00 GMT</pubDate>
-                            <description>This article has a dangerous link</description>
+                            <description>This article's link is under test</description>
                           </item>
                         </channel>
                       </rss>
@@ -247,8 +254,18 @@ public sealed class RssClientTests : TestsBase
         var rssClient = new RssClient( this.ServiceProvider );
         await rssClient.DisplayUnreadNewsAsync();
 
-        // No toast notification should be shown for a link with a non-http(s) scheme.
-        Assert.Empty( this.UserInterface.Notifications );
+        if ( shouldBeRejected )
+        {
+            // No toast notification should be shown for a link with a non-http(s) scheme.
+            Assert.Empty( this.UserInterface.Notifications );
+        }
+        else
+        {
+            // A safe http(s) link produces a notification with the tracking query string appended.
+            var notification = Assert.Single( this.UserInterface.Notifications );
+            Assert.Equal( "News Article", notification.Title );
+            Assert.Equal( link + "?" + WebLinks.TrackingQueryString, notification.Uri );
+        }
     }
 
     /// <summary>

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/RssClientTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/RssClientTests.cs
@@ -210,6 +210,48 @@ public sealed class RssClientTests : TestsBase
     }
 
     /// <summary>
+    /// Verifies that RssClient does not display a toast notification when the newest item's link uses a non-http(s) URI scheme.
+    /// A hijacked or MITM'd feed could otherwise supply a dangerous scheme (e.g. <c>ms-msdt:</c>, <c>search-ms:</c>, <c>file://</c>)
+    /// that would be passed to Windows protocol activation when the user clicks the toast. See issue #1647.
+    /// </summary>
+    [Theory]
+    [InlineData( "file:///C:/Windows/System32/calc.exe" )]
+    [InlineData( "ms-msdt:/id PCWDiagnostic" )]
+    [InlineData( "search-ms:query=foo&crumb=location:\\\\attacker.example.com\\share" )]
+    [InlineData( "javascript:alert(1)" )]
+    [InlineData( "ftp://attacker.example.com/payload" )]
+    [InlineData( "\\\\attacker.example.com\\share\\payload" )]
+    public async Task RssClientRejectsNonHttpLinkScheme( string maliciousLink )
+    {
+        var rssXml = $"""
+                      <?xml version="1.0" encoding="UTF-8"?>
+                      <rss version="2.0">
+                        <channel>
+                          <title>Test Feed</title>
+                          <link>https://metalama.net/</link>
+                          <description>Test Description</description>
+                          <item>
+                            <title>Malicious News Article</title>
+                            <link>{System.Security.SecurityElement.Escape( maliciousLink )}</link>
+                            <pubDate>Mon, 01 Nov 2025 12:00:00 GMT</pubDate>
+                            <description>This article has a dangerous link</description>
+                          </item>
+                        </channel>
+                      </rss>
+                      """;
+
+        this.RegisterResponse( RssClient.BriefsUrl, rssXml );
+        this.Time.Set( new DateTime( 2025, 11, 2, 0, 0, 0, DateTimeKind.Utc ) );
+        this.EnsureNewsWillBeChecked();
+
+        var rssClient = new RssClient( this.ServiceProvider );
+        await rssClient.DisplayUnreadNewsAsync();
+
+        // No toast notification should be shown for a link with a non-http(s) scheme.
+        Assert.Empty( this.UserInterface.Notifications );
+    }
+
+    /// <summary>
     /// Verifies that RssClient logs a warning and returns false when the RSS feed XML does not contain a channel element.
     /// </summary>
     [Fact]


### PR DESCRIPTION
## Security fix ΓÇö #1647

Restricts the URI scheme accepted from the RSS news feed so that a hijacked/MITM'd `metalama.net` feed cannot trigger Windows protocol activation with a dangerous scheme (`ms-msdt:`, `search-ms:`, `file://` UNC, custom handlers, ΓÇª).

### Changes
- **`RssClient.TryParseContent`** (primary): validate the newest item's `<link>` with `Uri.TryCreate(..., UriKind.Absolute, ...)` and require `Scheme == http`/`https` before building the toast. Otherwise log a warning and skip the notification.
- **`ViewModelBuilder` (News branch)** (defense in depth): re-check the server-controlled URI scheme before it reaches `SetProtocolActivation`; return `false` (no notification) on a bad scheme.
- **`RssClientTests.RssClientValidatesLinkScheme`**: regression `[Theory]` covering `file://`, `ms-msdt:`, `search-ms:`, `javascript:`, `ftp://`, and a UNC path.

Matches the existing scheme-check convention in `App.xaml.cs` (`uri.Scheme == Uri.UriSchemeHttp || Uri.UriSchemeHttps`).

### Verification
- `Build.ps1 build` (whole product): **0 warnings, 0 errors**.
- Full `Metalama.Backstage.Tests` suite: **net8.0 1256 passed**, **net472 1255 passed**, 0 failed.
- Regression test fails before the fix (6/6 malicious schemes produced a toast) and passes after.

### Checklist
- [x] Reproduce bug (failing regression test)
- [x] Implement fix (RssClient + defensive ViewModelBuilder)
- [x] Build changed repo (zero warnings)
- [x] Run tests (all green, both frameworks)
- [x] Finalize / mark ready

ΓÇö Claude for Gael
