### PR TITLE
Validate reCAPTCHA site key format before reflecting into setup page (#1649)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Services/RecaptchaService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Services/RecaptchaService.cs
@@ -19,8 +19,12 @@ internal sealed class RecaptchaService( IHttpClientFactory httpClientFactory, We
                 try
                 {
                     using var httpClient = httpClientFactory.Create();
-                    var recaptchaSiteKey = await httpClient.GetStringAsync( webLinks.NewsletterGetCaptchaSiteKeyApi );
-                    this._recaptchaSiteKeyTcs.SetResult( recaptchaSiteKey );
+                    var recaptchaSiteKey = (await httpClient.GetStringAsync( webLinks.NewsletterGetCaptchaSiteKeyApi ))?.Trim();
+
+                    // The site key comes from the backend server, which is outside our trust boundary. It is reflected
+                    // into the setup page, so we validate its format before using it and treat a malformed key the same
+                    // as a missing one (i.e. the device is considered offline and no reCAPTCHA is rendered). See #1649.
+                    this._recaptchaSiteKeyTcs.SetResult( RecaptchaSiteKeyValidator.IsValid( recaptchaSiteKey ) ? recaptchaSiteKey : null );
                 }
                 catch
                 {

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Services/RecaptchaSiteKeyValidator.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Services/RecaptchaSiteKeyValidator.cs
@@ -1,0 +1,21 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Text.RegularExpressions;
+
+namespace Metalama.Backstage.Services;
+
+/// <summary>
+/// Validates the format of a reCAPTCHA site key received from the backend server before it is reflected into the
+/// setup page. The site key is outside our trust boundary (a hijacked or MITM'd key endpoint could return a
+/// malicious value), so we accept it only if it matches the documented reCAPTCHA key format, i.e. a non-empty
+/// string of ASCII letters, digits, '-' and '_'. This is belt-and-suspenders hardening on top of Razor's
+/// HTML-attribute auto-encoding (see #1649).
+/// </summary>
+internal static class RecaptchaSiteKeyValidator
+{
+    private static readonly Regex _siteKeyRegex = new( "^[A-Za-z0-9_-]+$", RegexOptions.CultureInvariant );
+
+    public static bool IsValid( string? siteKey ) => !string.IsNullOrEmpty( siteKey ) && _siteKeyRegex.IsMatch( siteKey );
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/RecaptchaServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/RecaptchaServiceTests.cs
@@ -1,0 +1,72 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Services;
+using Metalama.Backstage.Testing;
+using Metalama.Backstage.UserInterface;
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Metalama.Backstage.Worker.Tests;
+
+// Regression tests for #1649, at the level of the service that fetches the reCAPTCHA site key from the backend
+// server. A hijacked/MITM'd key endpoint could return a malicious value; the service must validate the format and
+// treat a malformed key the same as a missing one (null), so it is never reflected into the setup page.
+public sealed class RecaptchaServiceTests
+{
+    private static async Task<string?> GetSiteKeyFromServerResponseAsync( string serverResponse )
+    {
+        var webLinks = new WebLinks();
+        var httpClientFactory = new TestHttpClientFactory();
+
+        httpClientFactory.AddHook(
+            request => request.RequestUri!.ToString() == webLinks.NewsletterGetCaptchaSiteKeyApi,
+            ( _, _ ) => Task.FromResult( new HttpResponseMessage( HttpStatusCode.OK ) { Content = new StringContent( serverResponse ) } ) );
+
+        var service = new RecaptchaService( httpClientFactory, webLinks );
+        service.Initialize();
+
+        using var cancellationTokenSource = new CancellationTokenSource( TimeSpan.FromSeconds( 30 ) );
+
+        return await service.GetRecaptchaSiteKeyAsync().WaitAsync( cancellationTokenSource.Token );
+    }
+
+    [Theory]
+    [InlineData( "\"><script>alert(1)</script>" )]
+    [InlineData( "key\" onmouseover=\"alert(1)" )]
+    [InlineData( "javascript:alert(1)" )]
+    [InlineData( "key with spaces" )]
+    [InlineData( "" )]
+    public async Task MalformedSiteKeyFromServerIsRejected( string serverResponse )
+    {
+        var siteKey = await GetSiteKeyFromServerResponseAsync( serverResponse );
+
+        Assert.Null( siteKey );
+    }
+
+    [Fact]
+    public async Task WellFormedSiteKeyFromServerIsAccepted()
+    {
+        const string validKey = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe";
+
+        var siteKey = await GetSiteKeyFromServerResponseAsync( validKey );
+
+        Assert.Equal( validKey, siteKey );
+    }
+
+    [Fact]
+    public async Task SurroundingWhitespaceFromServerIsTrimmed()
+    {
+        const string validKey = "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe";
+
+        // A legitimate endpoint may return the key with a trailing newline; that must still be accepted.
+        var siteKey = await GetSiteKeyFromServerResponseAsync( "\n" + validKey + "\r\n" );
+
+        Assert.Equal( validKey, siteKey );
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/RecaptchaSiteKeyValidationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/RecaptchaSiteKeyValidationTests.cs
@@ -1,0 +1,50 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Worker.Services;
+using Xunit;
+
+namespace Metalama.Backstage.Worker.Tests;
+
+// Regression tests for #1649. The reCAPTCHA site key is provided by the backend server and reflected into the
+// setup page as 'data-sitekey="@Model.RecaptchaSiteKey"'. A hijacked/MITM'd key endpoint could return a value
+// crafted to break out of that attribute (or a future raw/JS context). As belt-and-suspenders hardening on top
+// of Razor's auto-encoding, the site key must be validated against the documented reCAPTCHA key format
+// ([A-Za-z0-9_-]+) before being reflected; anything else must be rejected.
+public sealed class RecaptchaSiteKeyValidationTests
+{
+    [Theory]
+
+    // Well-formed reCAPTCHA keys consist only of letters, digits, '-' and '_'.
+    [InlineData( "6LeIxAcTAAAAAGG-vFI1TnRWxMZNFuojJ4WifJWe" )]
+    [InlineData( "6Lc_aXkUAAAAANxValid_site-Key" )]
+    [InlineData( "abcDEF0123456789-_" )]
+    public void ValidSiteKeyIsAccepted( string siteKey )
+    {
+        Assert.True( RecaptchaSiteKeyValidator.IsValid( siteKey ) );
+    }
+
+    [Theory]
+
+    // Null or empty: nothing to reflect.
+    [InlineData( null )]
+    [InlineData( "" )]
+    [InlineData( " " )]
+
+    // Attribute break-out / XSS payloads a hijacked endpoint might return.
+    [InlineData( "\"><script>alert(1)</script>" )]
+    [InlineData( "key\" onmouseover=\"alert(1)" )]
+    [InlineData( "javascript:alert(1)" )]
+    [InlineData( "key<tag>" )]
+
+    // Other characters outside the allowed set.
+    [InlineData( "key with spaces" )]
+    [InlineData( "key.with.dots" )]
+    [InlineData( "key/with/slashes" )]
+    [InlineData( "key=value" )]
+    public void InvalidSiteKeyIsRejected( string? siteKey )
+    {
+        Assert.False( RecaptchaSiteKeyValidator.IsValid( siteKey ) );
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/RecaptchaSiteKeyValidationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/RecaptchaSiteKeyValidationTests.cs
@@ -2,7 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Backstage.Worker.Services;
+using Metalama.Backstage.Services;
 using Xunit;
 
 namespace Metalama.Backstage.Worker.Tests;


### PR DESCRIPTION
Fixes #1649.

## Problem

The server-provided reCAPTCHA site key is reflected into the setup page as `data-sitekey="@Model.RecaptchaSiteKey"` (`Consents.cshtml:115`). Under the threat model of a hijacked/MITM'd backend key endpoint, a malicious site key is currently neutralized only by Razor's HTML-attribute auto-encoding. This is a belt-and-suspenders hardening item (LOW): validate the key against the documented reCAPTCHA format (`[A-Za-z0-9_-]+`) before rendering, so a future refactor into a raw/JS context cannot reintroduce XSS.

## Fix

- Added `RecaptchaSiteKeyValidator` (`Metalama.Backstage.Services`) with `IsValid(string?)`, accepting only a non-empty string of ASCII letters, digits, `-` and `_`.
- `RecaptchaService.Initialize()` now trims and validates the site key fetched from the backend; a malformed key is treated the same as a missing one (`null`), so `IsDeviceOnline` stays `false` and nothing is reflected into the page. Validation happens at the untrusted network boundary.
- Surrounding whitespace (e.g. a trailing newline from a legitimate endpoint) is trimmed so valid keys keep working.

## Tests

- `RecaptchaSiteKeyValidationTests` — unit tests for the format check (valid keys accepted; XSS/break-out payloads, `javascript:`, spaces, dots, slashes, `=`, null/empty rejected).
- `RecaptchaServiceTests` — service-level wiring tests proving a malicious server response is neutralized to `null`, a well-formed key is preserved, and surrounding whitespace is trimmed.

## Checklist

- [x] Reproduce: failing regression test (site-key format validation)
- [x] Implement the format check
- [x] Wire it so an invalid key is not reflected
- [x] Build changed repo with `Build.ps1 build` (zero warnings introduced)
- [x] Run tests (30 passed)
- [x] Finalize: mark PR ready, request review

— Claude for Gael
