### PR TITLE
Fix InvalidCastException in MetadataReader for assembly-level generic attributes (#1664)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MetadataReader.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MetadataReader.cs
@@ -97,6 +97,16 @@ namespace Metalama.Framework.Engine.Utilities
                 if ( attribute.Constructor.Kind == HandleKind.MemberReference )
                 {
                     var constructor = metadataReader.GetMemberReference( (MemberReferenceHandle) (Handle) attribute.Constructor );
+
+                    // CompileTimeAttribute is non-generic, so its constructor is always referenced through a
+                    // TypeReference. Any other parent kind (e.g. a TypeSpecification for a constructed generic
+                    // attribute like [assembly: SomeAttribute<int>]) cannot be CompileTimeAttribute and would
+                    // make the cast below throw InvalidCastException, so we can safely skip it (#1664).
+                    if ( constructor.Parent.Kind != HandleKind.TypeReference )
+                    {
+                        continue;
+                    }
+
                     var type = metadataReader.GetTypeReference( (TypeReferenceHandle) constructor.Parent );
                     var typeName = metadataReader.GetString( type.Name );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/MetadataReaderTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/MetadataReaderTests.cs
@@ -8,31 +8,31 @@ using Metalama.Testing.UnitTesting;
 using System.IO;
 using Xunit;
 
-namespace Metalama.Framework.Tests.UnitTests.Utilities
+namespace Metalama.Framework.Tests.UnitTests.Utilities;
+
+public sealed class MetadataReaderTests : UnitTestClass
 {
-    public sealed class MetadataReaderTests : UnitTestClass
+    // Regression test for #1664. Reading the metadata of an assembly that has an assembly-level
+    // generic attribute (C# 11) used to throw InvalidCastException in MetadataReader.GetMetadataCore,
+    // because the constructor of a constructed generic attribute is referenced through a
+    // TypeSpecification, while the code cast MemberReference.Parent to TypeReferenceHandle unconditionally.
+    [Theory]
+
+    // Parameterless constructor of a constructed generic attribute.
+    [InlineData( "[assembly: GenAttribute<int>]" )]
+
+    // Constructor with an argument, which exercises a different member-reference signature.
+    [InlineData( "[assembly: GenAttribute<int>( 42 )]" )]
+
+    // A generic attribute placed before a regular attribute, to ensure the scan continues past it.
+    [InlineData( "[assembly: GenAttribute<int>]\n[assembly: System.CLSCompliant( false )]" )]
+    public void AssemblyLevelGenericAttributeDoesNotThrow( string assemblyAttributes )
     {
-        // Regression test for #1664. Reading the metadata of an assembly that has an assembly-level
-        // generic attribute (C# 11) used to throw InvalidCastException in MetadataReader.GetMetadataCore,
-        // because the constructor of a constructed generic attribute is referenced through a
-        // TypeSpecification, while the code cast MemberReference.Parent to TypeReferenceHandle unconditionally.
-        [Theory]
+        using var testContext = this.CreateTestContext();
 
-        // Parameterless constructor of a constructed generic attribute.
-        [InlineData( "[assembly: GenAttribute<int>]" )]
-
-        // Constructor with an argument, which exercises a different member-reference signature.
-        [InlineData( "[assembly: GenAttribute<int>( 42 )]" )]
-
-        // A generic attribute placed before a regular attribute, to ensure the scan continues past it.
-        [InlineData( "[assembly: GenAttribute<int>]\n[assembly: System.CLSCompliant( false )]" )]
-        public void AssemblyLevelGenericAttributeDoesNotThrow( string assemblyAttributes )
-        {
-            using var testContext = this.CreateTestContext();
-
-            var compilation = testContext.CreateCSharpCompilation(
-                assemblyAttributes +
-                @"
+        var compilation = testContext.CreateCSharpCompilation(
+            assemblyAttributes +
+            @"
 
 [System.AttributeUsage( System.AttributeTargets.Assembly, AllowMultiple = true )]
 public class GenAttribute<T> : System.Attribute
@@ -43,30 +43,29 @@ public class GenAttribute<T> : System.Attribute
 }
 " );
 
-            var assemblyPath = MetalamaPathUtilities.GetTempFileName();
+        var assemblyPath = MetalamaPathUtilities.GetTempFileName();
 
-            try
+        try
+        {
+            // We must create the dll on disk because MetadataReader reads from a file path.
+            using ( var stream = File.Create( assemblyPath ) )
             {
-                // We must create the dll on disk because MetadataReader reads from a file path.
-                using ( var stream = File.Create( assemblyPath ) )
-                {
-                    var emitResult = compilation.Emit( stream );
-                    Assert.True( emitResult.Success );
-                }
-
-                // This used to throw InvalidCastException before the fix for #1664.
-                Assert.True( MetadataReader.TryGetMetadata( assemblyPath, out var metadata ) );
-                Assert.NotNull( metadata );
-
-                // The generic attribute is not [CompileTime], so the assembly must not be flagged as compile-time.
-                Assert.False( metadata.HasCompileTimeAttribute );
+                var emitResult = compilation.Emit( stream );
+                Assert.True( emitResult.Success );
             }
-            finally
+
+            // This used to throw InvalidCastException before the fix for #1664.
+            Assert.True( MetadataReader.TryGetMetadata( assemblyPath, out var metadata ) );
+            Assert.NotNull( metadata );
+
+            // The generic attribute is not [CompileTime], so the assembly must not be flagged as compile-time.
+            Assert.False( metadata.HasCompileTimeAttribute );
+        }
+        finally
+        {
+            if ( File.Exists( assemblyPath ) )
             {
-                if ( File.Exists( assemblyPath ) )
-                {
-                    File.Delete( assemblyPath );
-                }
+                File.Delete( assemblyPath );
             }
         }
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/MetadataReaderTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/MetadataReaderTests.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Utilities;
+using Metalama.Framework.Engine.Utilities;
+using Metalama.Testing.UnitTesting;
+using System.IO;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Utilities
+{
+    public sealed class MetadataReaderTests : UnitTestClass
+    {
+        // Regression test for #1664. Reading the metadata of an assembly that has an assembly-level
+        // generic attribute (C# 11) used to throw InvalidCastException in MetadataReader.GetMetadataCore,
+        // because the constructor of a constructed generic attribute is referenced through a
+        // TypeSpecification, while the code cast MemberReference.Parent to TypeReferenceHandle unconditionally.
+        [Fact]
+        public void AssemblyLevelGenericAttributeDoesNotThrow()
+        {
+            using var testContext = this.CreateTestContext();
+
+            var compilation = testContext.CreateCSharpCompilation(
+                @"
+[assembly: GenAttribute<int>]
+
+[System.AttributeUsage( System.AttributeTargets.Assembly, AllowMultiple = true )]
+public class GenAttribute<T> : System.Attribute
+{
+    public GenAttribute() { }
+}
+" );
+
+            var assemblyPath = MetalamaPathUtilities.GetTempFileName();
+
+            try
+            {
+                // We must create the dll on disk because MetadataReader reads from a file path.
+                using ( var stream = File.Create( assemblyPath ) )
+                {
+                    var emitResult = compilation.Emit( stream );
+                    Assert.True( emitResult.Success );
+                }
+
+                // This used to throw InvalidCastException before the fix for #1664.
+                Assert.True( MetadataReader.TryGetMetadata( assemblyPath, out var metadata ) );
+                Assert.NotNull( metadata );
+            }
+            finally
+            {
+                if ( File.Exists( assemblyPath ) )
+                {
+                    File.Delete( assemblyPath );
+                }
+            }
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/MetadataReaderTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/MetadataReaderTests.cs
@@ -16,19 +16,30 @@ namespace Metalama.Framework.Tests.UnitTests.Utilities
         // generic attribute (C# 11) used to throw InvalidCastException in MetadataReader.GetMetadataCore,
         // because the constructor of a constructed generic attribute is referenced through a
         // TypeSpecification, while the code cast MemberReference.Parent to TypeReferenceHandle unconditionally.
-        [Fact]
-        public void AssemblyLevelGenericAttributeDoesNotThrow()
+        [Theory]
+
+        // Parameterless constructor of a constructed generic attribute.
+        [InlineData( "[assembly: GenAttribute<int>]" )]
+
+        // Constructor with an argument, which exercises a different member-reference signature.
+        [InlineData( "[assembly: GenAttribute<int>( 42 )]" )]
+
+        // A generic attribute placed before a regular attribute, to ensure the scan continues past it.
+        [InlineData( "[assembly: GenAttribute<int>]\n[assembly: System.CLSCompliant( false )]" )]
+        public void AssemblyLevelGenericAttributeDoesNotThrow( string assemblyAttributes )
         {
             using var testContext = this.CreateTestContext();
 
             var compilation = testContext.CreateCSharpCompilation(
+                assemblyAttributes +
                 @"
-[assembly: GenAttribute<int>]
 
 [System.AttributeUsage( System.AttributeTargets.Assembly, AllowMultiple = true )]
 public class GenAttribute<T> : System.Attribute
 {
     public GenAttribute() { }
+
+    public GenAttribute( int x ) { }
 }
 " );
 
@@ -46,6 +57,9 @@ public class GenAttribute<T> : System.Attribute
                 // This used to throw InvalidCastException before the fix for #1664.
                 Assert.True( MetadataReader.TryGetMetadata( assemblyPath, out var metadata ) );
                 Assert.NotNull( metadata );
+
+                // The generic attribute is not [CompileTime], so the assembly must not be flagged as compile-time.
+                Assert.False( metadata.HasCompileTimeAttribute );
             }
             finally
             {


### PR DESCRIPTION
Fixes #1664.

`MetadataReader.GetMetadataCore` scans assembly-level custom attributes of referenced assemblies to detect `[CompileTime]`. For each attribute whose constructor is a `MemberReference`, it cast `constructor.Parent` to `TypeReferenceHandle` **without checking the handle kind**. When a scanned assembly has an **assembly-level generic attribute** (C# 11, e.g. `[assembly: GenAttribute<int>]`), the constructor of the constructed generic type is referenced through a `TypeSpecification`, so the cast threw `InvalidCastException` (surfaced as `LAMA0601`).

### Fix
Guard the cast: since `CompileTimeAttribute` is non-generic, any non-`TypeReference` parent kind can be safely skipped.

### Tests
`MetadataReaderTests.AssemblyLevelGenericAttributeDoesNotThrow` (`[Theory]`) emits an assembly with an assembly-level generic attribute (parameterless ctor, ctor with argument, and one followed by another assembly attribute) and asserts `MetadataReader.TryGetMetadata` does not throw. All cases failed with `InvalidCastException` before the fix and pass after.

### Verification
- `Build.ps1 build`: success, no new warnings.
- `Metalama.Framework.Tests.UnitTests`: net8.0 → 1897 passed / 6 skipped / 0 failed; net48 → 1842 passed / 3 skipped / 0 failed.

### Checklist
- [x] Phase 1 — Understand the issue
- [x] Phase 2 — Failing regression test
- [x] Phase 3 — Implement the fix
- [x] Phase 4 — Build & test (zero new warnings)
- [x] Phase 5 — Finalize (ready, review requested)

— Claude for @gfraiteur