### PR TITLE
Stop RSS feed fetch when telemetry is disabled in-product (#1670)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage.Commands/Rss/EnableRssClientCommand.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Commands/Rss/EnableRssClientCommand.cs
@@ -12,7 +12,14 @@ public class EnableRssClientCommand : BaseCommand<BaseCommandSettings>
     protected override void Execute( ExtendedCommandContext context, BaseCommandSettings settings )
     {
         var rssClient = context.ServiceProvider.GetRequiredBackstageService<IRssClient>();
-        rssClient.Enable();
+
+        if ( !rssClient.TryEnable() )
+        {
+            throw new CommandException(
+                "Cannot enable the news feed because telemetry is disabled. Enable telemetry first by running 'metalama telemetry enable'." );
+        }
+
+        context.Console.WriteSuccess( "The news feed has been enabled." );
     }
 
     protected override BackstageInitializationOptions AddBackstageOptions( BackstageInitializationOptions options )

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
@@ -191,7 +191,10 @@ internal sealed class TelemetryConfigurationService : ITelemetryConfigurationSer
             TelemetryScenario.Exception => this._isExceptionTelemetryEnabled,
             TelemetryScenario.Performance => this._isPerformanceTelemetryEnabled,
             TelemetryScenario.Usage => this._isUsageTelemetryEnabled,
-            TelemetryScenario.Rss => this._isGloballyEnabled,
+
+            // The news feed counts as usage telemetry for opt-out purposes: an in-product opt-out
+            // (SetStatus(false)) must stop the RSS fetch, just like the opt-out environment variable. See #1670.
+            TelemetryScenario.Rss => this._isGloballyEnabled && this._isUsageTelemetryEnabled,
             _ => throw new ArgumentOutOfRangeException()
         };
     }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
@@ -194,7 +194,9 @@ internal sealed class TelemetryConfigurationService : ITelemetryConfigurationSer
 
             // The news feed counts as usage telemetry for opt-out purposes: an in-product opt-out
             // (SetStatus(false)) must stop the RSS fetch, just like the opt-out environment variable. See #1670.
-            TelemetryScenario.Rss => this._isGloballyEnabled && this._isUsageTelemetryEnabled,
+            // _isUsageTelemetryEnabled already implies _isGloballyEnabled, because it is only ever set to true
+            // when _isGloballyEnabled is true (see ReadConfiguration and SetStatus).
+            TelemetryScenario.Rss => this._isUsageTelemetryEnabled,
             _ => throw new ArgumentOutOfRangeException()
         };
     }

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/IRssClient.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/IRssClient.cs
@@ -15,5 +15,10 @@ public interface IRssClient : IBackstageService
 
     void Disable();
 
-    void Enable();
+    /// <summary>
+    /// Enables the news feed by setting the preferred feed to <see cref="RssFeed.Briefs"/>, unless telemetry is disabled,
+    /// in which case the news feed cannot be enabled (because it would otherwise contact <c>metalama.net</c>). See issue #1670.
+    /// </summary>
+    /// <returns><c>true</c> if the news feed was enabled, or <c>false</c> if it could not be enabled because telemetry is disabled.</returns>
+    bool TryEnable();
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/IRssClient.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/IRssClient.cs
@@ -16,9 +16,10 @@ public interface IRssClient : IBackstageService
     void Disable();
 
     /// <summary>
-    /// Enables the news feed by setting the preferred feed to <see cref="RssFeed.Briefs"/>, unless telemetry is disabled,
-    /// in which case the news feed cannot be enabled (because it would otherwise contact <c>metalama.net</c>). See issue #1670.
+    /// Enables the news feed by setting the preferred feed to <see cref="RssFeed.Briefs"/>, unless telemetry is disabled.
+    /// When telemetry is disabled, the feed is not enabled, because the daily fetch from <c>metalama.net</c> is gated on the
+    /// telemetry setting and would never run, so enabling the feed would have no effect. See issue #1670.
     /// </summary>
-    /// <returns><c>true</c> if the news feed was enabled, or <c>false</c> if it could not be enabled because telemetry is disabled.</returns>
+    /// <returns><c>true</c> if the news feed was enabled, or <c>false</c> if it was not enabled because telemetry is disabled.</returns>
     bool TryEnable();
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClient.cs
@@ -54,7 +54,21 @@ internal sealed class RssClient : IRssClient
 
     public void Disable() => this._configurationManager.Update<RssClientConfiguration>( c => c with { PreferredFeed = RssFeed.None } );
 
-    public void Enable() => this._configurationManager.Update<RssClientConfiguration>( c => c with { PreferredFeed = RssFeed.Briefs } );
+    public bool TryEnable()
+    {
+        // The news feed rides the usage-telemetry opt-out (see #1670), so enabling it while telemetry is disabled would
+        // have no effect — the feed would never be fetched. Report the error instead of silently enabling a dead feed.
+        if ( !this._telemetryConfigurationService.IsEnabled( TelemetryScenario.Rss ) )
+        {
+            this._logger.Trace?.Log( "Cannot enable the news feed because telemetry is disabled." );
+
+            return false;
+        }
+
+        this._configurationManager.Update<RssClientConfiguration>( c => c with { PreferredFeed = RssFeed.Briefs } );
+
+        return true;
+    }
 
     internal async Task DisplayUnreadNewsAsync( bool skipPreconditions = false )
     {

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -25,10 +25,22 @@ public sealed class TelemetryConfigurationTests : TestsBase
         Assert.Equal( output, this.TelemetryConfigurationService.IsEnabled( TelemetryScenario.Usage ) );
     }
 
+    [Theory]
+    [InlineData( true, true )]
+    [InlineData( false, false )]
+    public void SetStatusAffectsRss( bool input, bool output )
+    {
+        // The in-product opt-out (SetStatus) must stop the RSS feed fetch, just like the
+        // METALAMA_TELEMETRY_OPT_OUT environment variable does. See issue #1670.
+        this.TelemetryConfigurationService.SetStatus( input );
+        Assert.Equal( output, this.TelemetryConfigurationService.IsEnabled( TelemetryScenario.Rss ) );
+    }
+
     [Fact]
     public void EnabledByDefault()
     {
         Assert.True( this.TelemetryConfigurationService.IsEnabled( TelemetryScenario.Usage ) );
+        Assert.True( this.TelemetryConfigurationService.IsEnabled( TelemetryScenario.Rss ) );
     }
 
     [Theory]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -61,6 +61,7 @@ public sealed class TelemetryConfigurationTests : TestsBase
 
         this.TelemetryConfigurationService.SetStatus( true );
         Assert.Equal( isEnabled, this.TelemetryConfigurationService.IsEnabled( TelemetryScenario.Usage ) );
+        Assert.Equal( isEnabled, this.TelemetryConfigurationService.IsEnabled( TelemetryScenario.Rss ) );
     }
 
     [Fact]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/RssClientTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/RssClientTests.cs
@@ -719,7 +719,7 @@ public sealed class RssClientTests : TestsBase
     // Enable/Disable Tests
 
     /// <summary>
-    /// Verifies that RssClient.Enable sets PreferredFeed to Briefs and RssClient.Disable sets PreferredFeed to None.
+    /// Verifies that RssClient.TryEnable sets PreferredFeed to Briefs and RssClient.Disable sets PreferredFeed to None.
     /// </summary>
     [Fact]
     public async Task RssClientEnableAndDisableTogglePreferredFeed()
@@ -727,7 +727,7 @@ public sealed class RssClientTests : TestsBase
         var rssClient = new RssClient( this.ServiceProvider );
 
         // Enable RSS client
-        rssClient.Enable();
+        Assert.True( rssClient.TryEnable() );
         var enabledConfiguration = this.ConfigurationManager!.Get<RssClientConfiguration>();
         Assert.Equal( RssFeed.Briefs, enabledConfiguration.PreferredFeed );
 
@@ -742,7 +742,7 @@ public sealed class RssClientTests : TestsBase
         Assert.Empty( this.HttpClientFactory.ProcessedRequests );
 
         // Enable again and verify it can fetch
-        rssClient.Enable();
+        Assert.True( rssClient.TryEnable() );
 
         const string rssXml = """
                               <?xml version="1.0" encoding="UTF-8"?>
@@ -765,6 +765,24 @@ public sealed class RssClientTests : TestsBase
         Assert.Single( this.HttpClientFactory.ProcessedRequests );
         var notification = Assert.Single( this.UserInterface.Notifications );
         Assert.Equal( "Test Article After Enable", notification.Title );
+    }
+
+    /// <summary>
+    /// Verifies that <see cref="RssClient.TryEnable"/> refuses to enable the news feed (returns false and leaves
+    /// PreferredFeed unchanged) when telemetry is disabled, because the feed rides the telemetry opt-out (#1670).
+    /// </summary>
+    [Fact]
+    public void RssClientTryEnableFailsWhenTelemetryIsDisabled()
+    {
+        this.EnvironmentVariableProvider.Environment[Backstage.Telemetry.TelemetryConfigurationService.OptOutEnvironmentVariable] = "1";
+
+        var rssClient = new RssClient( this.ServiceProvider );
+
+        Assert.False( rssClient.TryEnable() );
+
+        // The feed must not have been enabled.
+        var configuration = this.ConfigurationManager!.Get<RssClientConfiguration>();
+        Assert.NotEqual( RssFeed.Briefs, configuration.PreferredFeed );
     }
 
     // DisplayLatestNewsAsync Tests


### PR DESCRIPTION
Fixes #1670.

## Problem

The in-product telemetry opt-out (`metalama telemetry disable` / `ITelemetryConfigurationService.SetStatus(false)`) did not stop the daily RSS feed fetch to `metalama.net`. `IsEnabled(TelemetryScenario.Rss)` returned the *global* flag (`_isGloballyEnabled`), which `SetStatus` never touches — so a user who opted out kept making a once-per-day outbound request that leaks their IP and a liveness signal. Only the `METALAMA_TELEMETRY_OPT_OUT` env var stopped it.

## Fix

In `TelemetryConfigurationService.IsEnabled`, the `Rss` scenario now honors the usage-telemetry flag:

```csharp
TelemetryScenario.Rss => this._isUsageTelemetryEnabled,
```

This treats the news feed as part of usage telemetry for opt-out purposes, making the in-product opt-out equivalent in coverage to the env-var opt-out. (`_isUsageTelemetryEnabled` already implies `_isGloballyEnabled`, since it is only ever set true while the global flag is true.) `RssClient.DisplayUnreadNewsAsync` gates on this same flag, so the fetch is now suppressed.

Additionally, `IRssClient.Enable` is renamed to **`TryEnable()`** returning `bool`: it refuses to enable the news feed when telemetry is disabled (the feed would never fetch). `EnableRssClientCommand` reports this to the user via a `CommandException` with an actionable message, or writes a success message otherwise.

## Tests

- `SetStatusAffectsRss` (new): asserts `IsEnabled(Rss)` follows `SetStatus`.
- `EnabledByDefault` / `DisabledWithEnvironmentVariable` (extended): assert RSS default-on and env-var opt-out also disables RSS.
- `RssClientTryEnableFailsWhenTelemetryIsDisabled` (new): `TryEnable()` returns false and leaves the feed disabled when telemetry is off.
- `RssClientEnableAndDisableTogglePreferredFeed` (updated): new `TryEnable()` API.

Full Backstage suite: 1267 passed / 1 skipped (net8.0). RSS + telemetry tests pass on net8.0 and net472. Zero warnings in the Backstage build.

## Progress checklist

- [x] Phase 1 — Understand the issue
- [x] Phase 2 — Failing regression test
- [x] Phase 3 — Implement fix
- [x] Phase 4 — Build & test (zero warnings)
- [x] Phase 5 — Finalize

— Claude for Gael