### PR TITLE
Harden the exception-report scrubber (#1680)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
@@ -47,6 +47,61 @@ internal sealed class ExceptionReporter : IExceptionReporter
         this._localExceptionReporter = serviceProvider.GetBackstageService<LocalExceptionReporter>();
     }
 
+    // Assembly-name prefixes considered framework/runtime, and therefore safe to disclose (name + version).
+    // Any other assembly is treated as user/third-party code: its name (even a single token), version and
+    // file version can identify the user's product or build, so they are redacted. See #1680.
+    private static readonly string[] _knownSafeAssemblyPrefixes =
+    {
+        "System", "Microsoft", "Metalama", "PostSharp", "mscorlib", "netstandard", "WindowsBase",
+        "Presentation", "EnvDTE", "Windows", "JetBrains", "Newtonsoft", "MessagePack", "StreamJsonRpc",
+        "Nerdbank", "Mono", "xunit", "testhost", "Roslyn"
+    };
+
+    internal static bool IsKnownSafeAssemblyName( string? name )
+    {
+        if ( string.IsNullOrEmpty( name ) )
+        {
+            return false;
+        }
+
+        foreach ( var prefix in _knownSafeAssemblyPrefixes )
+        {
+            // Match the prefix only at a name boundary (end of name or a non-alphanumeric separator), so that
+            // a user assembly such as "SystemwideTool" is not mistaken for a "System.*" framework assembly.
+            if ( name!.StartsWith( prefix, StringComparison.OrdinalIgnoreCase )
+                 && ( name.Length == prefix.Length || !char.IsLetterOrDigit( name[prefix.Length] ) ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    internal static void WriteAssemblyElement( XmlWriter xmlWriter, string? name, Version? version, string? fileVersion )
+    {
+        xmlWriter.WriteStartElement( "Assembly" );
+
+        if ( IsKnownSafeAssemblyName( name ) )
+        {
+            xmlWriter.WriteElementString( "Name", name );
+            xmlWriter.WriteElementString( "Version", version?.ToString() ?? "<unknown>" );
+
+            if ( !string.IsNullOrEmpty( fileVersion ) )
+            {
+                xmlWriter.WriteElementString( "FileVersion", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( fileVersion ) );
+            }
+        }
+        else
+        {
+            // User / third-party assembly: redact the name, version and file version, which can identify the
+            // user's product or build. The scrubber would not catch a single-token name on its own. See #1680.
+            xmlWriter.WriteElementString( "Name", "#user" );
+        }
+
+        xmlWriter.WriteEndElement();
+    }
+
     private IEnumerable<string?> CleanStackTrace( string stackTrace )
     {
         foreach ( Match? match in this._stackFrameRegex.Matches( stackTrace ) )
@@ -307,20 +362,19 @@ internal sealed class ExceptionReporter : IExceptionReporter
             foreach ( var assembly in AppDomain.CurrentDomain.GetAssemblies() )
             {
                 var assemblyName = assembly.GetName();
-                xmlWriter.WriteStartElement( "Assembly" );
-                xmlWriter.WriteElementString( "Name", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( assemblyName.Name ) );
-                xmlWriter.WriteElementString( "Version", assemblyName.Version?.ToString() ?? "<unknown>" );
+
+                string? fileVersion = null;
 
                 try
                 {
                     if ( !assembly.IsDynamic && !string.IsNullOrEmpty( assembly.Location ) )
                     {
-                        xmlWriter.WriteElementString( "FileVersion", FileVersionInfo.GetVersionInfo( assembly.Location ).FileVersion );
+                        fileVersion = FileVersionInfo.GetVersionInfo( assembly.Location ).FileVersion;
                     }
                 }
                 catch ( NotSupportedException ) { }
 
-                xmlWriter.WriteEndElement();
+                WriteAssemblyElement( xmlWriter, assemblyName.Name, assemblyName.Version, fileVersion );
             }
 
             xmlWriter.WriteEndElement();

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionSensitiveDataHelper.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionSensitiveDataHelper.cs
@@ -21,6 +21,19 @@ namespace Metalama.Backstage.Telemetry
             new(
                 @"(?<![\.\^0-9a-zA-Z<>_`])(?![0-9]|Microsoft\.|MS\.|System\.|PostSharp\.|Metalama\.|Presentation|EnvDTE|Windows|`)[a-zA-Z0-9\$`@_\?]+(?:\.(?![0-9])\.?[a-zA-Z0-9\$`@<>_]+)+(?![\.\^0-9a-zA-Z`@_\$])" );
 
+        // Redacts the value following an HTTP "Bearer" authentication scheme (e.g. "Bearer eyJ...").
+        // These tokens are non-dotted and would otherwise pass through the heuristic above. See #1680.
+        private static readonly Regex _bearerTokenRegEx =
+            new( @"(?<scheme>\bBearer\s+)(?<value>[A-Za-z0-9\._\-\+/]+=*)", RegexOptions.IgnoreCase );
+
+        // Denylist of secret-like "key=value" / "key: value" shapes (passwords, tokens, API keys,
+        // connection-string segments, usernames). The value is redacted regardless of whether it is
+        // dotted, so secrets that the dotted-identifier heuristic misses do not leave the machine. See #1680.
+        private static readonly Regex _secretKeyValueRegEx =
+            new(
+                @"(?<key>[\w\-]*(?:password|passwd|pwd|secret|token|api[_\-]?key|access[_\-]?key|client[_\-]?secret|credentials?|signature|user(?:name|id)?|uid)[\w\-]*)(?<sep>\s*[:=]\s*)(?<value>[^\s;,""'\]\}]+)",
+                RegexOptions.IgnoreCase );
+
         private readonly Regex _pathRegex;
 
         internal ExceptionSensitiveDataHelper( bool? isWindows = null )
@@ -41,7 +54,11 @@ namespace Metalama.Backstage.Telemetry
                 return "";
             }
 
-            return this._pathRegex.Replace( _userNameRegEx.Replace( input, "#user" ), "#path" );
+            // Redact secret-like values first, so the resulting "#secret" markers are not themselves
+            // mistaken for user identifiers or paths by the heuristics below.
+            var withoutSecrets = _secretKeyValueRegEx.Replace( _bearerTokenRegEx.Replace( input, "${scheme}#secret" ), "${key}${sep}#secret" );
+
+            return this._pathRegex.Replace( _userNameRegEx.Replace( withoutSecrets, "#user" ), "#path" );
         }
     }
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
@@ -17,7 +17,11 @@ namespace Metalama.Backstage.Telemetry
         public static void WriteException( XmlWriter writer, Exception e )
         {
             writer.WriteElementString( "Type", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( e.GetType().FullName ) );
-            writer.WriteElementString( "Message", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( e.Message ) );
+
+            // Exception.Message is an arbitrary, often interpolated string that frequently embeds user input,
+            // file paths, connection strings or other secrets. For safety we never serialize it into the
+            // uploaded report — the exception type and stack trace are enough to diagnose. See #1680.
+
             writer.WriteElementString( "Source", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( e.Source ) );
 
             // Exception.Data is an arbitrary, developer-populated bag that may hold secrets, connection

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Xml;
 using JetBrains.Annotations;
 
@@ -15,6 +16,14 @@ namespace Metalama.Backstage.Telemetry
     [PublicAPI]
     public static class ExceptionXmlFormatter
     {
+        // Exception.Data is an arbitrary, developer-populated bag that may hold secrets, connection
+        // strings or PII. We therefore redact the value of every key by default and only serialize the
+        // values of keys explicitly allow-listed here as known-safe. The (scrubbed) key is always emitted
+        // so reviewers can see which entries were present. This list is intentionally conservative. See #1680.
+        private static readonly HashSet<string> _allowedDataKeys = new( StringComparer.OrdinalIgnoreCase );
+
+        private static bool IsAllowedDataKey( string? key ) => key != null && _allowedDataKeys.Contains( key );
+
         public static void WriteException( XmlWriter writer, Exception e )
         {
             writer.WriteElementString( "Type", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( e.GetType().FullName ) );
@@ -29,59 +38,19 @@ namespace Metalama.Backstage.Telemetry
 
                 if ( data != null )
                 {
-                    writer.WriteElementString( "Key", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( data.Value.Key.ToString() ) );
+                    var key = data.Value.Key.ToString();
+                    writer.WriteElementString( "Key", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( key ) );
 
                     if ( data.Value.Value != null )
                     {
-                        switch ( data.Value.Value )
+                        if ( IsAllowedDataKey( key ) )
                         {
-                            case Array array:
-                                {
-                                    writer.WriteStartElement( "Array" );
-
-                                    for ( var i = 0; i < array.Length; i++ )
-                                    {
-                                        var value = array.GetValue( i );
-
-                                        switch ( value )
-                                        {
-                                            case Exception exception:
-                                                writer.WriteStartElement( "Item" );
-                                                WriteException( writer, exception );
-                                                writer.WriteEndElement();
-
-                                                break;
-
-                                            case null:
-                                                writer.WriteElementString( "Item", "<null>" );
-
-                                                break;
-
-                                            default:
-                                                writer.WriteElementString(
-                                                    "Item",
-                                                    ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( value.ToString() ) );
-
-                                                break;
-                                        }
-                                    }
-
-                                    writer.WriteEndElement();
-
-                                    break;
-                                }
-
-                            case Exception exception:
-                                writer.WriteStartElement( "Value" );
-                                WriteException( writer, exception );
-                                writer.WriteEndElement();
-
-                                break;
-
-                            default:
-                                writer.WriteElementString( "Value", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( data.Value.ToString() ) );
-
-                                break;
+                            WriteDataValue( writer, data.Value.Value );
+                        }
+                        else
+                        {
+                            // The key is not on the allow-list: redact the value rather than serializing it. See #1680.
+                            writer.WriteElementString( "Value", "#redacted" );
                         }
                     }
                 }
@@ -114,6 +83,60 @@ namespace Metalama.Backstage.Telemetry
                 }
 
                 writer.WriteEndElement();
+            }
+        }
+
+        private static void WriteDataValue( XmlWriter writer, object value )
+        {
+            switch ( value )
+            {
+                case Array array:
+                    {
+                        writer.WriteStartElement( "Array" );
+
+                        for ( var i = 0; i < array.Length; i++ )
+                        {
+                            var item = array.GetValue( i );
+
+                            switch ( item )
+                            {
+                                case Exception exception:
+                                    writer.WriteStartElement( "Item" );
+                                    WriteException( writer, exception );
+                                    writer.WriteEndElement();
+
+                                    break;
+
+                                case null:
+                                    writer.WriteElementString( "Item", "<null>" );
+
+                                    break;
+
+                                default:
+                                    writer.WriteElementString(
+                                        "Item",
+                                        ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( item.ToString() ) );
+
+                                    break;
+                            }
+                        }
+
+                        writer.WriteEndElement();
+
+                        break;
+                    }
+
+                case Exception exception:
+                    writer.WriteStartElement( "Value" );
+                    WriteException( writer, exception );
+                    writer.WriteEndElement();
+
+                    break;
+
+                default:
+                    writer.WriteElementString( "Value", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( value.ToString() ) );
+
+                    break;
             }
         }
     }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
@@ -3,8 +3,6 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using System;
-using System.Collections;
-using System.Collections.Generic;
 using System.Xml;
 using JetBrains.Annotations;
 
@@ -16,49 +14,14 @@ namespace Metalama.Backstage.Telemetry
     [PublicAPI]
     public static class ExceptionXmlFormatter
     {
-        // Exception.Data is an arbitrary, developer-populated bag that may hold secrets, connection
-        // strings or PII. We therefore redact the value of every key by default and only serialize the
-        // values of keys explicitly allow-listed here as known-safe. The (scrubbed) key is always emitted
-        // so reviewers can see which entries were present. This list is intentionally conservative. See #1680.
-        private static readonly HashSet<string> _allowedDataKeys = new( StringComparer.OrdinalIgnoreCase );
-
-        private static bool IsAllowedDataKey( string? key ) => key != null && _allowedDataKeys.Contains( key );
-
         public static void WriteException( XmlWriter writer, Exception e )
         {
             writer.WriteElementString( "Type", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( e.GetType().FullName ) );
             writer.WriteElementString( "Message", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( e.Message ) );
             writer.WriteElementString( "Source", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( e.Source ) );
 
-            writer.WriteStartElement( "Data" );
-
-            foreach ( DictionaryEntry? data in e.Data )
-            {
-                writer.WriteStartElement( "Item" );
-
-                if ( data != null )
-                {
-                    var key = data.Value.Key.ToString();
-                    writer.WriteElementString( "Key", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( key ) );
-
-                    if ( data.Value.Value != null )
-                    {
-                        if ( IsAllowedDataKey( key ) )
-                        {
-                            WriteDataValue( writer, data.Value.Value );
-                        }
-                        else
-                        {
-                            // The key is not on the allow-list: redact the value rather than serializing it. See #1680.
-                            writer.WriteElementString( "Value", "#redacted" );
-                        }
-                    }
-                }
-
-                writer.WriteEndElement();
-            }
-
-            writer.WriteEndElement();
+            // Exception.Data is an arbitrary, developer-populated bag that may hold secrets, connection
+            // strings or PII. We never serialize it into the uploaded report. See #1680.
 
             writer.WriteElementString(
                 "StackTrace",
@@ -83,60 +46,6 @@ namespace Metalama.Backstage.Telemetry
                 }
 
                 writer.WriteEndElement();
-            }
-        }
-
-        private static void WriteDataValue( XmlWriter writer, object value )
-        {
-            switch ( value )
-            {
-                case Array array:
-                    {
-                        writer.WriteStartElement( "Array" );
-
-                        for ( var i = 0; i < array.Length; i++ )
-                        {
-                            var item = array.GetValue( i );
-
-                            switch ( item )
-                            {
-                                case Exception exception:
-                                    writer.WriteStartElement( "Item" );
-                                    WriteException( writer, exception );
-                                    writer.WriteEndElement();
-
-                                    break;
-
-                                case null:
-                                    writer.WriteElementString( "Item", "<null>" );
-
-                                    break;
-
-                                default:
-                                    writer.WriteElementString(
-                                        "Item",
-                                        ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( item.ToString() ) );
-
-                                    break;
-                            }
-                        }
-
-                        writer.WriteEndElement();
-
-                        break;
-                    }
-
-                case Exception exception:
-                    writer.WriteStartElement( "Value" );
-                    WriteException( writer, exception );
-                    writer.WriteEndElement();
-
-                    break;
-
-                default:
-                    writer.WriteElementString( "Value", ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( value.ToString() ) );
-
-                    break;
             }
         }
     }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LocalExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LocalExceptionReporter.cs
@@ -81,7 +81,10 @@ internal sealed class LocalExceptionReporter : IBackstageService
                 AppendLineSafe( "Processor Architecture", () => $" {RuntimeInformation.ProcessArchitecture}" );
                 AppendLineSafe( "OS Description", () => $"{RuntimeInformation.OSDescription}" );
                 AppendLineSafe( "OS Architecture", () => $"{RuntimeInformation.OSArchitecture}" );
-                AppendLineSafe( "Process", () => $"{Process.GetCurrentProcess().ProcessName} {Environment.CommandLine}" );
+                AppendLineSafe(
+                    "Process",
+                    () =>
+                        $"{Process.GetCurrentProcess().ProcessName} {ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( Environment.CommandLine )}" );
 
                 AppendLineSafe(
                     "Managed thread",
@@ -90,12 +93,12 @@ internal sealed class LocalExceptionReporter : IBackstageService
 
                 AppendLineSafe( "Synchronization context", () => $"{SynchronizationContext.Current}" );
                 AppendLineSafe( "Exception type", () => $"{exception.GetType()}" );
-                AppendLineSafe( "Exception message", () => $"{exception.Message}" );
+                AppendLineSafe( "Exception message", () => ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( exception.Message ) );
 
                 try
                 {
                     // The next line may fail.
-                    var exceptionToString = exception.ToString();
+                    var exceptionToString = ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( exception.ToString() );
                     exceptionText.AppendLine( "===== Exception ===== " );
                     exceptionText.AppendLine( exceptionToString );
                 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionReportContentTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionReportContentTests.cs
@@ -1,0 +1,126 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Telemetry;
+using System;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Metalama.Backstage.Tests.Telemetry
+{
+    // Unit tests for the conservative redaction applied to the remote exception report payload (#1680).
+    public sealed class ExceptionReportContentTests
+    {
+        private static string WriteExceptionXml( Exception exception )
+        {
+            var builder = new StringBuilder();
+
+            using ( var writer = XmlWriter.Create( builder, new XmlWriterSettings { Indent = true } ) )
+            {
+                writer.WriteStartElement( "Exception" );
+                ExceptionXmlFormatter.WriteException( writer, exception );
+                writer.WriteEndElement();
+            }
+
+            return builder.ToString();
+        }
+
+        [Fact]
+        public void ExceptionDataValuesAreRedactedButKeysAreKept()
+        {
+            var exception = new InvalidOperationException( "test" );
+            exception.Data["ConnectionString"] = "Server=db;Password=p@ssw0rd;User=sa";
+            exception.Data["CustomerName"] = "Jane Doe";
+
+            var xml = WriteExceptionXml( exception );
+
+            // The XML must be well-formed.
+            _ = XDocument.Parse( xml );
+
+            // Values of non-allow-listed keys must be redacted, whatever their shape.
+            Assert.DoesNotContain( "p@ssw0rd", xml, StringComparison.Ordinal );
+            Assert.DoesNotContain( "Jane Doe", xml, StringComparison.Ordinal );
+            Assert.Contains( "#redacted", xml, StringComparison.Ordinal );
+
+            // The (scrubbed) keys are preserved so reviewers can see which entries existed.
+            Assert.Contains( "ConnectionString", xml, StringComparison.Ordinal );
+            Assert.Contains( "CustomerName", xml, StringComparison.Ordinal );
+        }
+
+        [Fact]
+        public void ExceptionMessageSecretsAreRedacted()
+        {
+            var exception = new InvalidOperationException( "Login failed: password=SuperSecret123" );
+
+            var xml = WriteExceptionXml( exception );
+
+            Assert.DoesNotContain( "SuperSecret123", xml, StringComparison.Ordinal );
+            Assert.Contains( "#secret", xml, StringComparison.Ordinal );
+        }
+
+        [Theory]
+        [InlineData( "System.Private.CoreLib", true )]
+        [InlineData( "System", true )]
+        [InlineData( "Microsoft.CodeAnalysis", true )]
+        [InlineData( "Metalama.Framework", true )]
+        [InlineData( "mscorlib", true )]
+        [InlineData( "netstandard", true )]
+        [InlineData( "PostSharp.Patterns.Common", true )]
+        [InlineData( "MyCompany.MyProduct", false )]
+        [InlineData( "MyApp", false )]
+        [InlineData( "SystemwideTool", false )]
+        [InlineData( "", false )]
+        [InlineData( null, false )]
+        public void AssemblyNameClassification( string? name, bool expectedSafe )
+            => Assert.Equal( expectedSafe, ExceptionReporter.IsKnownSafeAssemblyName( name ) );
+
+        [Fact]
+        public void UserAssemblyDetailsAreRedacted()
+        {
+            var builder = new StringBuilder();
+
+            using ( var writer = XmlWriter.Create( builder, new XmlWriterSettings { Indent = true } ) )
+            {
+                writer.WriteStartElement( "Assemblies" );
+
+                // A single-token user assembly name with a version and a file version.
+                ExceptionReporter.WriteAssemblyElement( writer, "MyApp", new Version( 1, 2, 3, 4 ), "1.2.3.4-customer" );
+
+                writer.WriteEndElement();
+            }
+
+            var xml = builder.ToString();
+            var doc = XDocument.Parse( xml );
+
+            Assert.DoesNotContain( "MyApp", xml, StringComparison.Ordinal );
+            Assert.DoesNotContain( "1.2.3.4", xml, StringComparison.Ordinal );
+            Assert.DoesNotContain( "customer", xml, StringComparison.Ordinal );
+            Assert.Equal( "#user", doc.Descendants( "Name" ).Single().Value );
+            Assert.Empty( doc.Descendants( "Version" ) );
+            Assert.Empty( doc.Descendants( "FileVersion" ) );
+        }
+
+        [Fact]
+        public void FrameworkAssemblyDetailsArePreserved()
+        {
+            var builder = new StringBuilder();
+
+            using ( var writer = XmlWriter.Create( builder, new XmlWriterSettings { Indent = true } ) )
+            {
+                writer.WriteStartElement( "Assemblies" );
+                ExceptionReporter.WriteAssemblyElement( writer, "System.Private.CoreLib", new Version( 8, 0, 0, 0 ), "8.0.0.0" );
+                writer.WriteEndElement();
+            }
+
+            var xml = builder.ToString();
+            var doc = XDocument.Parse( xml );
+
+            Assert.Equal( "System.Private.CoreLib", doc.Descendants( "Name" ).Single().Value );
+            Assert.Equal( "8.0.0.0", doc.Descendants( "Version" ).Single().Value );
+        }
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionReportContentTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionReportContentTests.cs
@@ -51,14 +51,20 @@ namespace Metalama.Backstage.Tests.Telemetry
         }
 
         [Fact]
-        public void ExceptionMessageSecretsAreRedacted()
+        public void ExceptionMessageIsNotSentAtAll()
         {
-            var exception = new InvalidOperationException( "Login failed: password=SuperSecret123" );
+            var exception = new InvalidOperationException( "Login failed: password=SuperSecret123 for user jane.doe" );
 
             var xml = WriteExceptionXml( exception );
 
+            // The XML must be well-formed.
+            var doc = XDocument.Parse( xml );
+
+            // Exception.Message is never serialized: it frequently embeds user input, paths or secrets, so neither
+            // the message text nor a Message element leaves the machine. See #1680.
             Assert.DoesNotContain( "SuperSecret123", xml, StringComparison.Ordinal );
-            Assert.Contains( "#secret", xml, StringComparison.Ordinal );
+            Assert.DoesNotContain( "Login failed", xml, StringComparison.Ordinal );
+            Assert.Empty( doc.Descendants( "Message" ) );
         }
 
         [Theory]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionReportContentTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionReportContentTests.cs
@@ -30,7 +30,7 @@ namespace Metalama.Backstage.Tests.Telemetry
         }
 
         [Fact]
-        public void ExceptionDataValuesAreRedactedButKeysAreKept()
+        public void ExceptionDataIsNotSentAtAll()
         {
             var exception = new InvalidOperationException( "test" );
             exception.Data["ConnectionString"] = "Server=db;Password=p@ssw0rd;User=sa";
@@ -39,16 +39,15 @@ namespace Metalama.Backstage.Tests.Telemetry
             var xml = WriteExceptionXml( exception );
 
             // The XML must be well-formed.
-            _ = XDocument.Parse( xml );
+            var doc = XDocument.Parse( xml );
 
-            // Values of non-allow-listed keys must be redacted, whatever their shape.
+            // Exception.Data is never serialized: neither values nor keys leave the machine, and no
+            // Data element is emitted at all. See #1680.
             Assert.DoesNotContain( "p@ssw0rd", xml, StringComparison.Ordinal );
             Assert.DoesNotContain( "Jane Doe", xml, StringComparison.Ordinal );
-            Assert.Contains( "#redacted", xml, StringComparison.Ordinal );
-
-            // The (scrubbed) keys are preserved so reviewers can see which entries existed.
-            Assert.Contains( "ConnectionString", xml, StringComparison.Ordinal );
-            Assert.Contains( "CustomerName", xml, StringComparison.Ordinal );
+            Assert.DoesNotContain( "ConnectionString", xml, StringComparison.Ordinal );
+            Assert.DoesNotContain( "CustomerName", xml, StringComparison.Ordinal );
+            Assert.Empty( doc.Descendants( "Data" ) );
         }
 
         [Fact]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionSensitiveDataHelperTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionSensitiveDataHelperTests.cs
@@ -99,6 +99,34 @@ namespace Metalama.Backstage.Tests.Telemetry
             Assert.Equal( input, actualOutput );
         }
 
+        [Theory]
+
+        // key=value secret shapes (denylist applied regardless of dotting).
+        [InlineData( "password=hunter2", "password=#secret" )]
+        [InlineData( "Password=hunter2", "Password=#secret" )]
+        [InlineData( "pwd=hunter2", "pwd=#secret" )]
+        [InlineData( "token=abc123def456", "token=#secret" )]
+        [InlineData( "secret=topsecretvalue", "secret=#secret" )]
+        [InlineData( "apikey=AKIAIOSFODNN7EXAMPLE", "apikey=#secret" )]
+        [InlineData( "api_key=AKIAIOSFODNN7EXAMPLE", "api_key=#secret" )]
+        [InlineData( "access_token=ya29.A0ARrdaM", "access_token=#secret" )]
+
+        // key: value secret shapes.
+        [InlineData( "apikey: AKIAIOSFODNN7EXAMPLE", "apikey: #secret" )]
+        [InlineData( "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "Authorization: Bearer #secret" )]
+
+        // Bearer token without a preceding key.
+        [InlineData( "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "Bearer #secret" )]
+
+        // Connection-string segments.
+        [InlineData( "Server=myserver;Password=p@ssw0rd;Database=db", "Server=myserver;Password=#secret;Database=db" )]
+        public void SecretsAreRedacted( string input, string expectedOutput )
+        {
+            var actualOutput = ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData( input );
+
+            Assert.Equal( expectedOutput, actualOutput );
+        }
+
         // Always solve failures of the other tests before solving failures of this one.
         [Fact]
         public void SensitiveDataIsRemovedFromMultilineInput()

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionSensitiveDataHelperTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ExceptionSensitiveDataHelperTests.cs
@@ -111,6 +111,9 @@ namespace Metalama.Backstage.Tests.Telemetry
         [InlineData( "api_key=AKIAIOSFODNN7EXAMPLE", "api_key=#secret" )]
         [InlineData( "access_token=ya29.A0ARrdaM", "access_token=#secret" )]
 
+        // Non-dotted username.
+        [InlineData( "username=jdoe", "username=#secret" )]
+
         // key: value secret shapes.
         [InlineData( "apikey: AKIAIOSFODNN7EXAMPLE", "apikey: #secret" )]
         [InlineData( "Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9", "Authorization: Bearer #secret" )]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/LocalExceptionReporterTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/LocalExceptionReporterTests.cs
@@ -61,4 +61,32 @@ public sealed class LocalExceptionReporterTests : TestsBase
         Assert.Contains( "===== Reporting Call Stack =====", content, StringComparison.Ordinal );
         Assert.Contains( "ReportException", content, StringComparison.Ordinal );
     }
+
+    [Fact]
+    public void CrashReportScrubsSecretsInExceptionMessage()
+    {
+        // The exception message (emitted both standalone and via Exception.ToString()) must be scrubbed. See #1680.
+        var reporter = new LocalExceptionReporter( this.ServiceProvider );
+        reporter.ReportException( new InvalidOperationException( "Login failed for password=SuperSecret123" ), null );
+
+        var content = this.FileSystem.ReadAllText( this.FileSystem.EnumerateFiles( this._crashReportsDirectory, "*.txt" ).Single() );
+        this.Logger.WriteLine( content );
+
+        Assert.DoesNotContain( "SuperSecret123", content, StringComparison.Ordinal );
+        Assert.Contains( "#secret", content, StringComparison.Ordinal );
+    }
+
+    [Fact]
+    public void CrashReportScrubsCommandLine()
+    {
+        // The local crash report records Environment.CommandLine, which contains absolute host paths (and
+        // potentially the OS user name). It must be scrubbed rather than written verbatim. See #1680.
+        var reporter = new LocalExceptionReporter( this.ServiceProvider );
+        reporter.ReportException( new InvalidOperationException( "test" ), null );
+
+        var content = this.FileSystem.ReadAllText( this.FileSystem.EnumerateFiles( this._crashReportsDirectory, "*.txt" ).Single() );
+        this.Logger.WriteLine( content );
+
+        Assert.DoesNotContain( Environment.CommandLine, content, StringComparison.Ordinal );
+    }
 }


### PR DESCRIPTION
## Summary

Hardens the remote exception-report scrubber (`ExceptionSensitiveDataHelper`) and the exception reporters per #1680 (part of the privacy/telemetry hardening epic #1678).

Closes #1680.

## What changed

- **Secret denylist** (`ExceptionSensitiveDataHelper`): redacts secret-like `key=value` / `key: value` shapes (`password`/`passwd`/`pwd`/`secret`/`token`/`api[_-]key`/`access[_-]key`/`client[_-]secret`/`credentials`/`signature`/`username`/`userid`/`uid`) and `Bearer <token>` to `#secret`, regardless of whether the value is dotted. Applied before the existing dotted-identifier and path heuristics so the resulting markers are not re-processed.
- **Remote report payload** (`ExceptionXmlFormatter`): `Exception.Message` and `Exception.Data` are **no longer serialized into the uploaded report at all**. Both are arbitrary, developer-populated values that frequently embed user input, paths, connection strings or other secrets; the exception type and the (scrubbed) stack trace are sufficient to diagnose. The payload still contains the scrubbed `Type`, `Source` and `StackTrace`, plus inner exceptions handled the same way.
- **Assembly enumeration** (`ExceptionReporter`): only framework/runtime assemblies (allow-listed name prefixes, matched at a name boundary so e.g. `SystemwideTool` is not treated as `System.*`) emit Name/Version/FileVersion (FileVersion scrubbed); user/third-party assemblies — including single-token names the scrubber cannot catch — are redacted to `#user` with no version/file-version.
- **Local crash report** (`LocalExceptionReporter`): `Environment.CommandLine`, `exception.Message` and `exception.ToString()` are now scrubbed before being written to the local crash `.txt`.

## Acceptance criteria

- [x] Known secret patterns (bearer token, `password=`, API key, connection-string segment, non-dotted username) are redacted by the scrubber.
- [x] `Exception.Message` and `Exception.Data` are never serialized into the uploaded report.
- [x] Framework assembly version/file-version are disclosed (file-version scrubbed) while user/third-party and single-token assembly names are redacted to `#user`.
- [x] The local crash report scrubs the command line, the exception message and `ToString()`.

## Tests

- `ExceptionSensitiveDataHelperTests`: new `key=value` / `key: value` / `Bearer` denylist cases.
- `ExceptionReportContentTests` (new): `Exception.Message` and `Exception.Data` are absent from the XML; framework-vs-user assembly classification; user assembly details redacted; framework assembly details preserved.
- `LocalExceptionReporterTests`: crash report scrubs secrets in the exception message and scrubs the command line.

— Claude for @gfraiteur
