### PR TITLE
Fix toast notification detection never called (#1687)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/IToastNotificationDetectionService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/IToastNotificationDetectionService.cs
@@ -7,8 +7,8 @@ using Metalama.Backstage.Extensibility;
 
 namespace Metalama.Backstage.UserInterface.Toasts;
 
-// This service is used in Metalama.Framework.Engine.
-// The detection is not called when a project has no aspects or validators.
+// This service is used in Metalama.Framework.Engine: SourceTransformer.InitializeServices calls Detect()
+// once the backstage services are initialized for a Metalama-enabled compilation.
 [PublicAPI]
 public interface IToastNotificationDetectionService : IBackstageService
 {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/SourceTransformer.cs
@@ -5,6 +5,7 @@
 using JetBrains.Annotations;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.UserInterface.Toasts;
 using Metalama.Backstage.Welcome;
 using Metalama.Compiler;
 using Metalama.Framework.Engine.AdditionalOutputs;
@@ -52,7 +53,14 @@ public sealed partial class SourceTransformer : ISourceTransformerWithServices
 
                 if ( BackstageServiceFactoryInitializer.Initialize( backstageOptions ) )
                 {
-                    BackstageServiceFactory.ServiceProvider.GetRequiredBackstageService<WelcomeService>().OpenWelcomePageIfRequired();
+                    var serviceProvider = BackstageServiceFactory.ServiceProvider;
+
+                    serviceProvider.GetRequiredBackstageService<WelcomeService>().OpenWelcomePageIfRequired();
+
+                    // Detect toast notifications (e.g. the first-run telemetry notice). This was previously triggered
+                    // by LicenseVerifier, which was removed when licensing moved out of the engine, leaving the
+                    // detection service with no caller (#1687).
+                    serviceProvider.GetBackstageService<IToastNotificationDetectionService>()?.Detect();
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Re-trigger toast-notification detection from `SourceTransformer.InitializeServices`, next to the existing welcome-page trigger, so the first-run telemetry notice (and other detected toasts) display again.
- The detection call was previously hosted in `LicenseVerifier`, which was removed when licensing moved out of the engine; this left `IToastNotificationDetectionService.Detect()` with no production caller in build or design-time. As a result the first-run telemetry notice (#1672), as well as license-expiry / VsxNotInstalled toasts, never appeared.
- Resolved with the nullable `GetBackstageService<IToastNotificationDetectionService>()?.Detect()` so it safely no-ops when toast detection is disabled.
- Updated the now-accurate comment on `IToastNotificationDetectionService`.

## Issues Fixed
Closes #1687

— Claude for @gfraiteur