### PR TITLE
Persist RssClientConfiguration.LastFetchTime (#1690)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClientConfiguration.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Rss/RssClientConfiguration.cs
@@ -12,7 +12,10 @@ namespace Metalama.Backstage.UserInterface.Rss;
 [Description( "Toast notifications for product news." )]
 public sealed record RssClientConfiguration : ConfigurationFile
 {
-    internal DateTime? LastFetchTime { get; init; }
+    // Must be public so that it is serialized by the source-generated JSON context (BackstageJsonContext),
+    // which only emits public properties. When this was internal, LastFetchTime was silently dropped on every
+    // write, so the RSS feed was permanently stuck in its "first fetch" state and never showed news (#1690).
+    public DateTime? LastFetchTime { get; init; }
 
     public RssFeed? PreferredFeed { get; init; }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
@@ -401,11 +401,11 @@ public sealed class ConfigurationFileSerializationTests : JsonSerializationTests
     [Fact]
     public void RssClientConfiguration_Serialization()
     {
-        // Note: LastFetchTime is internal so it won't be serialized by ToJson()
         var input = new RssClientConfiguration { PreferredFeed = RssFeed.Posts, Version = 1 };
 
         const string expectedJson = """
                                     {
+                                      "LastFetchTime": null,
                                       "PreferredFeed": 1,
                                       "version": 1
                                     }
@@ -416,6 +416,38 @@ public sealed class ConfigurationFileSerializationTests : JsonSerializationTests
             expectedJson,
             obj => this.JsonService.Serialize( obj, typeof(RssClientConfiguration) ),
             json => JsonSerializer.Deserialize<RssClientConfiguration>( json, this.JsonOptions ) );
+    }
+
+    [Fact]
+    public void RssClientConfiguration_LastFetchTime_RoundTrip()
+    {
+        // Regression test for #1690: LastFetchTime was internal and therefore silently dropped by the
+        // source-generated JSON context, so the RSS feed was stuck in its "first fetch" state forever.
+        var input = new RssClientConfiguration
+        {
+            PreferredFeed = RssFeed.Briefs,
+            LastFetchTime = new DateTime( 2025, 6, 1, 12, 0, 0, DateTimeKind.Utc ),
+            Version = 1
+        };
+
+        const string expectedJson = """
+                                    {
+                                      "LastFetchTime": "2025-06-01T12:00:00Z",
+                                      "PreferredFeed": 2,
+                                      "version": 1
+                                    }
+                                    """;
+
+        this.TestSerialization(
+            input,
+            expectedJson,
+            obj => this.JsonService.Serialize( obj, typeof(RssClientConfiguration) ),
+            json => JsonSerializer.Deserialize<RssClientConfiguration>( json, this.JsonOptions ) );
+
+        // Assert that the round-tripped value is preserved (the core of the regression).
+        var deserialized = JsonSerializer.Deserialize<RssClientConfiguration>( expectedJson, this.JsonOptions );
+        Assert.NotNull( deserialized );
+        Assert.Equal( input.LastFetchTime, deserialized.LastFetchTime );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
- Make `RssClientConfiguration.LastFetchTime` **public** so it is serialized by the source-generated JSON context (`BackstageJsonContext`), which only emits public properties.
- Previously it was `internal`, so it was silently dropped on every write to `rss.json`. The RSS feed therefore stayed permanently in its "first fetch" state (`RssClient.cs:94`) and **never displayed a news toast**; the cross-process once-per-day throttle was also ineffective.
- Added a serialize/deserialize round-trip regression test (`RssClientConfiguration_LastFetchTime_RoundTrip`) asserting a non-null `LastFetchTime` survives, and updated the existing `RssClientConfiguration_Serialization` test (whose payload previously omitted `LastFetchTime` and whose comment documented the bug as intended behavior).

## Issues Fixed
Closes #1690

— Claude for @gfraiteur