### PR TITLE
Throttle the VSX-install toast behind other notifications (#1692)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKind.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKind.cs
@@ -16,4 +16,11 @@ public sealed record ToastNotificationKind( string Name )
     internal TimeSpan AutoSnoozePeriod { get; init; } = TimeSpan.FromHours( 1 );
 
     public TimeSpan ManualSnoozePeriod { get; init; } = TimeSpan.FromDays( 1 );
+
+    /// <summary>
+    /// Gets a value indicating whether this is a low-priority notification that should not be displayed shortly after
+    /// another notification was displayed (see <c>ToastNotificationStatusService</c>). Blocking or urgent notifications
+    /// (e.g. a required license, which fails the build, or an exception) are not throttled. The default is <c>false</c>.
+    /// </summary>
+    internal bool IsThrottled { get; init; }
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKinds.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKinds.cs
@@ -11,7 +11,10 @@ public static class ToastNotificationKinds
 {
     public static ToastNotificationKind RequiresLicense { get; } = new( nameof(RequiresLicense) ) { AutoSnoozePeriod = TimeSpan.FromMinutes( 1 ) };
 
-    public static ToastNotificationKind VsxNotInstalled { get; } = new( nameof(VsxNotInstalled) ) { AutoSnoozePeriod = TimeSpan.FromHours( 1 ) };
+    // Throttled: the VSX-install prompt is low-priority, so it is deferred when another notification (e.g. the
+    // first-run telemetry notice) was shown recently, to avoid showing two toasts at once. See #1692.
+    public static ToastNotificationKind VsxNotInstalled { get; } =
+        new( nameof(VsxNotInstalled) ) { AutoSnoozePeriod = TimeSpan.FromHours( 1 ), IsThrottled = true };
 
     public static ToastNotificationKind SubscriptionExpiring { get; } =
         new( nameof(SubscriptionExpiring) ) { AutoSnoozePeriod = TimeSpan.FromDays( 1 ), ManualSnoozePeriod = TimeSpan.FromDays( 7 ) };

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationStatusService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationStatusService.cs
@@ -19,6 +19,10 @@ namespace Metalama.Backstage.UserInterface.Toasts;
 [PublicAPI]
 public sealed class ToastNotificationStatusService : IToastNotificationStatusService
 {
+    // A throttled (low-priority) notification is not displayed while another notification was displayed within this
+    // period, so that e.g. the VSX-install prompt does not appear together with the first-run telemetry notice (#1692).
+    private static readonly TimeSpan _throttlePeriod = TimeSpan.FromMinutes( 15 );
+
     private readonly IConfigurationManager _configurationManager;
     private readonly IDateTimeProvider _dateTimeProvider;
     private readonly ILogger _logger;
@@ -33,6 +37,16 @@ public sealed class ToastNotificationStatusService : IToastNotificationStatusSer
 
     private bool IsEnabled( ToastNotificationKind kind, ToastNotificationsConfiguration configuration )
     {
+        if ( kind.IsThrottled
+             && configuration.LastNotificationTime != null
+             && configuration.LastNotificationTime.Value + _throttlePeriod > this._dateTimeProvider.UtcNow )
+        {
+            this._logger.Trace?.Log(
+                $"The notification kind {kind.Name} is throttled because another notification was displayed at {configuration.LastNotificationTime}." );
+
+            return false;
+        }
+
         if ( !configuration.Notifications.TryGetValue( kind.Name, out var kindConfiguration ) )
         {
             this._logger.Trace?.Log( $"The notification kind {kind.Name} is not configured." );
@@ -73,6 +87,8 @@ public sealed class ToastNotificationStatusService : IToastNotificationStatusSer
             c => this.IsEnabled( kind, c ),
             c => c with
             {
+                // Record the time so that throttled (low-priority) notifications are deferred after any notification.
+                LastNotificationTime = this._dateTimeProvider.UtcNow,
                 Notifications = c.Notifications.SetItem(
                     kind.Name,
                     new ToastNotificationConfiguration() { SnoozeUntil = this._dateTimeProvider.UtcNow + kind.AutoSnoozePeriod } )
@@ -107,7 +123,9 @@ public sealed class ToastNotificationStatusService : IToastNotificationStatusSer
             config => config with
             {
                 Pauses = config.Pauses
-                    .RemoveRange( config.Pauses.Where( c => c.Value < this._dateTimeProvider.UtcNow ).Select( c => c.Key ) )
+                    // Use '<=' so a pause that expires exactly at the current time is cleaned up. This matches the
+                    // 'IsPaused' check (which treats 'Value > now' as active) and avoids accumulating stale pauses.
+                    .RemoveRange( config.Pauses.Where( c => c.Value <= this._dateTimeProvider.UtcNow ).Select( c => c.Key ) )
                     .Add( id, this._dateTimeProvider.UtcNow.Add( timeSpan ) )
             } );
 

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationsConfiguration.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationsConfiguration.cs
@@ -22,4 +22,12 @@ public sealed record ToastNotificationsConfiguration : ConfigurationFile
     [JsonConverter( typeof(CaseInsensitiveImmutableDictionaryConverterFactory<ToastNotificationConfiguration>) )]
     public ImmutableDictionary<string, ToastNotificationConfiguration> Notifications { get; init; } =
         ImmutableDictionary<string, ToastNotificationConfiguration>.Empty.WithComparers( StringComparer.OrdinalIgnoreCase );
+
+    /// <summary>
+    /// Gets the time when any toast notification was last displayed. Used to throttle low-priority notifications
+    /// (see <see cref="ToastNotificationKind.IsThrottled"/>). Must be public so it is persisted by the source-generated
+    /// JSON context (which serializes public properties only), and stored here so the throttle works across processes.
+    /// </summary>
+    [JsonPropertyName( "lastNotificationTime" )]
+    public DateTime? LastNotificationTime { get; init; }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
@@ -292,6 +292,7 @@ public sealed class ConfigurationFileSerializationTests : JsonSerializationTests
                                           "disabled": false
                                         }
                                       },
+                                      "lastNotificationTime": null,
                                       "version": 1
                                     }
                                     """;

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationDetectionServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationDetectionServiceTests.cs
@@ -160,6 +160,15 @@ public sealed class ToastNotificationDetectionServiceTests : LicensingTestsBase
         this._backstageServicesInitializer.Initialize();
         await this.DetectToastNotificationsAsync();
 
+        // On the first run the VSX prompt is throttled behind the first-run telemetry notice (#1692), so it is not
+        // shown yet regardless of whether the extension is installed.
+        Assert.DoesNotContain( this.UserInterface.Notifications, n => n.Kind == ToastNotificationKinds.VsxNotInstalled );
+
+        // After the throttle period, the VSX prompt is shown unless the extension is already installed.
+        this.UserInterface.Notifications.Clear();
+        this.Time.AddTime( TimeSpan.FromMinutes( 15 ) + TimeSpan.FromSeconds( 1 ) );
+        await this.DetectToastNotificationsAsync();
+
         if ( extensionInstalled )
         {
             Assert.DoesNotContain( this.UserInterface.Notifications, n => n.Kind == ToastNotificationKinds.VsxNotInstalled );
@@ -168,6 +177,31 @@ public sealed class ToastNotificationDetectionServiceTests : LicensingTestsBase
         {
             Assert.Single( this.UserInterface.Notifications, n => n.Kind == ToastNotificationKinds.VsxNotInstalled );
         }
+    }
+
+    [Fact]
+    public async Task FirstRunShowsTelemetryNoticeAndDefersVsxPromptAsync()
+    {
+        // Regression test for #1692: the VSX-install prompt must not appear together with the first-run telemetry notice.
+        this.UserDeviceDetection.IsInteractiveDevice = true;
+        this.UserDeviceDetection.IsVisualStudioInstalled = true;
+        this.ServiceProvider.GetRequiredBackstageService<IIdeExtensionStatusService>().IsVisualStudioExtensionInstalled = false;
+        Assert.True( this.LicenseRegistrationService.RegisterTrialEdition().IsSuccess );
+
+        this._backstageServicesInitializer.Initialize();
+        await this.DetectToastNotificationsAsync();
+
+        // First run: only the telemetry notice; the VSX prompt is deferred.
+        Assert.Single( this.UserInterface.Notifications, n => n.Kind == ToastNotificationKinds.TelemetryNotice );
+        Assert.DoesNotContain( this.UserInterface.Notifications, n => n.Kind == ToastNotificationKinds.VsxNotInstalled );
+
+        // After the throttle period, the VSX prompt appears (and the once-only telemetry notice does not repeat).
+        this.UserInterface.Notifications.Clear();
+        this.Time.AddTime( TimeSpan.FromMinutes( 15 ) + TimeSpan.FromSeconds( 1 ) );
+        await this.DetectToastNotificationsAsync();
+
+        Assert.Single( this.UserInterface.Notifications, n => n.Kind == ToastNotificationKinds.VsxNotInstalled );
+        Assert.DoesNotContain( this.UserInterface.Notifications, n => n.Kind == ToastNotificationKinds.TelemetryNotice );
     }
 
     [Theory]
@@ -216,6 +250,10 @@ public sealed class ToastNotificationDetectionServiceTests : LicensingTestsBase
 
         // Initialize
         this._backstageServicesInitializer.Initialize();
+        await this.DetectToastNotificationsAsync();
+
+        // The VSX prompt is throttled behind the first-run telemetry notice (#1692), so advance past the throttle.
+        this.Time.AddTime( TimeSpan.FromMinutes( 15 ) + TimeSpan.FromSeconds( 1 ) );
         await this.DetectToastNotificationsAsync();
 
         var notification = this.UserInterface.Notifications.Single( n => n.Kind == ToastNotificationKinds.VsxNotInstalled );

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationStatusServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationStatusServiceTests.cs
@@ -40,6 +40,23 @@ public sealed class ToastNotificationStatusServiceTests : TestsBase
     }
 
     [Fact]
+    public void ThrottledNotificationIsDeferredAfterAnotherNotification()
+    {
+        // Regression test for #1692. A non-throttled notification is displayed and records the last-notification time.
+        Assert.True( this._toastService.TryAcquire( ToastNotificationKinds.TelemetryNotice ) );
+
+        // A throttled (low-priority) notification is suppressed because another notification was just displayed.
+        Assert.False( this._toastService.TryAcquire( ToastNotificationKinds.VsxNotInstalled ) );
+
+        // An urgent, non-throttled notification (e.g. a required license, which fails the build) is NOT throttled.
+        Assert.True( this._toastService.TryAcquire( ToastNotificationKinds.RequiresLicense ) );
+
+        // After the throttle period elapses, the throttled notification is displayed.
+        this.Time.AddTime( TimeSpan.FromMinutes( 15 ) + TimeSpan.FromSeconds( 1 ) );
+        Assert.True( this._toastService.TryAcquire( ToastNotificationKinds.VsxNotInstalled ) );
+    }
+
+    [Fact]
     public void Disable()
     {
         this._toastService.Mute( ToastNotificationKinds.LicenseExpiring );


### PR DESCRIPTION
## Summary
- Add `ToastNotificationKind.IsThrottled` (set on `VsxNotInstalled`) and a persisted, cross-process `ToastNotificationsConfiguration.LastNotificationTime`.
- A throttled (low-priority) notification is not displayed within **15 minutes** of any other notification, re-evaluated each detection cycle. Urgent notifications are not throttled: `RequiresLicense` (the build fails, so it must be immediate), `Exception`, and the first-run `TelemetryNotice`.
- Net effect: the first run shows the telemetry notice (and a blocking license toast, if any) immediately, while the VSX-install prompt is deferred — instead of showing two toasts at once.
- The timestamp is public so the source-gen JSON context persists it (cf. #1690), and stored in `toastNotifications.json` so the throttle works across the many short-lived/concurrent compiler processes.
- Drive-by fix: `PauseAll` cleanup used `c.Value < now`, which left a pause expiring exactly at `now` uncleaned (inconsistent with `IsPaused`, which treats `Value > now` as active). Changed to `<=`, fixing a pre-existing flaky `ToastNotificationStatusServiceTests.PauseCleanUp`.

## Tests
- New `ToastNotificationStatusServiceTests.ThrottledNotificationIsDeferredAfterAnotherNotification`.
- New `ToastNotificationDetectionServiceTests.FirstRunShowsTelemetryNoticeAndDefersVsxPromptAsync`.
- Updated `IsVsxInstallationSuggestedAsync` and `VsxNotInstalledNotificationHasUri` to advance past the throttle.
- Updated the `ToastNotificationsConfiguration` serialization test for the new field.

## Notes
- Observable only once #1687 (toast detection wiring, PR #1688) is merged; the throttle logic is independently unit-tested with the test clock.

## Issues Fixed
Closes #1692

— Claude for @gfraiteur