### PR TITLE
Serialize in-process telemetry config updates (#1696)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Configuration/ConfigurationManagerExtensions.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Configuration/ConfigurationManagerExtensions.cs
@@ -51,8 +51,10 @@ namespace Metalama.Backstage.Configuration
                     // We no longer throw an exception here because we have a known random issue and throwing an exception seems to be worse
                     // than ignoring it.
 
+                    // Include the call stack so that, if this recurs, the contending caller can be identified from the log.
                     configurationManager.Logger.Error?.Log(
-                        $"Too many attempts to update the configuration {typeof(T).Name}. There must be an unaddressed race condition." );
+                        $"Too many attempts to update the configuration {typeof(T).Name}. There must be an unaddressed race condition.{
+                            Environment.NewLine}{Environment.StackTrace}" );
 
                     return false;
                 }
@@ -100,8 +102,10 @@ namespace Metalama.Backstage.Configuration
                     // We no longer throw an exception here because we have a known random issue and throwing an exception seems to be worse
                     // than ignoring it.
 
+                    // Include the call stack so that, if this recurs, the contending caller can be identified from the log.
                     configurationManager.Logger.Error?.Log(
-                        $"Too many attempts to update the configuration {typeof(T).Name}. There must be an unaddressed race condition." );
+                        $"Too many attempts to update the configuration {typeof(T).Name}. There must be an unaddressed race condition.{
+                            Environment.NewLine}{Environment.StackTrace}" );
 
                     return false;
                 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/UsageReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/UsageReporter.cs
@@ -21,7 +21,9 @@ internal sealed class UsageReporter : IUsageReporter
     // Serializes the in-process callers of ShouldCollectMetrics. This service is a per-process singleton, so when a
     // single process compiles many projects concurrently (e.g. the design-time analysis service or an in-process build),
     // all those threads would otherwise race on the shared TelemetryConfiguration timestamp and exhaust the
-    // optimistic-concurrency retries in UpdateIf. Serializing them lets each read-modify-write complete on its first attempt.
+    // optimistic-concurrency retries in UpdateIf. Serializing them removes this self-contention, which is the dominant
+    // source. It is not a full guarantee: occasional retries remain possible from other (infrequent) TelemetryConfiguration
+    // writers in the same process, or from other processes (still bounded by the cross-process mutex in ConfigurationManager).
     private readonly object _sync = new();
 
     public bool IsUsageReportingEnabled => this._telemetryConfigurationService.IsEnabled( TelemetryScenario.Usage );

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/UsageReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/UsageReporter.cs
@@ -18,6 +18,12 @@ internal sealed class UsageReporter : IUsageReporter
     private readonly IDateTimeProvider _time;
     private readonly ILogger _logger;
 
+    // Serializes the in-process callers of ShouldCollectMetrics. This service is a per-process singleton, so when a
+    // single process compiles many projects concurrently (e.g. the design-time analysis service or an in-process build),
+    // all those threads would otherwise race on the shared TelemetryConfiguration timestamp and exhaust the
+    // optimistic-concurrency retries in UpdateIf. Serializing them lets each read-modify-write complete on its first attempt.
+    private readonly object _sync = new();
+
     public bool IsUsageReportingEnabled => this._telemetryConfigurationService.IsEnabled( TelemetryScenario.Usage );
 
     public UsageReporter( IServiceProvider serviceProvider )
@@ -31,44 +37,48 @@ internal sealed class UsageReporter : IUsageReporter
 
     private bool ShouldCollectMetrics( string projectName )
     {
-        var now = this._time.UtcNow;
-
         if ( !this.IsUsageReportingEnabled )
         {
             return false;
         }
 
-        var configuration = this._configurationManager.Get<TelemetryConfiguration>();
-
-        if ( configuration.Sessions.TryGetValue( projectName, out var lastReported ) && lastReported.AddDays( 1 ) > now )
+        // Serialize the read-modify-write so concurrent in-process compilations do not race on the configuration timestamp.
+        lock ( this._sync )
         {
-            this._logger.Trace?.Log( $"Session of project '{projectName}' should not be reported because it has been reported on {lastReported}." );
+            var now = this._time.UtcNow;
 
-            return false;
-        }
+            var configuration = this._configurationManager.Get<TelemetryConfiguration>();
 
-        return this._configurationManager.UpdateIf<TelemetryConfiguration>(
-            c =>
+            if ( configuration.Sessions.TryGetValue( projectName, out var lastReported ) && lastReported.AddDays( 1 ) > now )
             {
-                if ( c.Sessions.TryGetValue( projectName, out var raceReported ) && raceReported.AddDays( 1 ) > now )
+                this._logger.Trace?.Log( $"Session of project '{projectName}' should not be reported because it has been reported on {lastReported}." );
+
+                return false;
+            }
+
+            return this._configurationManager.UpdateIf<TelemetryConfiguration>(
+                c =>
                 {
-                    this._logger.Trace?.Log(
-                        $"Session of project '{projectName}' should not be reported because it is being reported by a concurrent process." );
+                    if ( c.Sessions.TryGetValue( projectName, out var raceReported ) && raceReported.AddDays( 1 ) > now )
+                    {
+                        this._logger.Trace?.Log(
+                            $"Session of project '{projectName}' should not be reported because it is being reported by a concurrent process." );
 
-                    return false;
-                }
+                        return false;
+                    }
 
-                return true;
-            },
-            c =>
-            {
-                this._logger.Trace?.Log( $"Session of project '{projectName}' should be reported." );
+                    return true;
+                },
+                c =>
+                {
+                    this._logger.Trace?.Log( $"Session of project '{projectName}' should be reported." );
 
-                c = c.CleanUp( now.AddDays( -1 ) );
-                c = c with { Sessions = c.Sessions.SetItem( projectName, now ) };
+                    c = c.CleanUp( now.AddDays( -1 ) );
+                    c = c with { Sessions = c.Sessions.SetItem( projectName, now ) };
 
-                return c;
-            } );
+                    return c;
+                } );
+        }
     }
 
     public IUsageSession StartSession( string kind, string? projectName = null )


### PR DESCRIPTION
Fixes #1696.

## Problem

Building a solution with many projects (e.g. `Metalama.Samples`) logs:

```
ERROR, Configuration: Too many attempts to update the configuration TelemetryConfiguration. There must be an unaddressed race condition.
```

`UsageReporter` is a per-process singleton that reports a usage session per project via `UpdateIf<TelemetryConfiguration>` (optimistic read-modify-write). The cross-process mutex only guards the check+write in `TryUpdate`, so the read and write are not atomic. Many concurrent in-process compilations bump the file timestamp under each other, invalidating in-flight reads, so the 10-attempt retry budget is exhausted and the session is silently not deduplicated.

## Fix

- Serialize the in-process callers with a `lock` in the `UsageReporter` singleton, so each read-modify-write completes on its first attempt. This removes the in-process thread storm (the driver). Cross-process contention stays bounded by the existing cross-process mutex and has far fewer contenders.
- Include `Environment.StackTrace` in the "too many attempts" error (cold path only) so any future recurrence is self-diagnosing from the log.

## Validation

`Metalama.Backstage` builds with 0 warnings; all 13 `UsageReporterTests` pass on net8.0 and net472 (including the concurrent-sessions test).

— Claude for @gfraiteur