### PR TITLE
Resolve telemetry temp directory without backstage static init

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
@@ -127,7 +127,7 @@ public static class RegisterServiceExtensions
             .AddSingleton<IApplicationInfoProvider>( new ApplicationInfoProvider( applicationInfo ) )
             .AddSingleton<IUserDeviceDetectionService>( serviceProvider => new WindowsUserDeviceDetectionService( serviceProvider ) )
             .AddSingleton<IDateTimeProvider>( new CurrentDateTimeProvider() )
-            .AddSingleton<IFileSystem>( new FileSystem() )
+            .AddSingleton<IFileSystem>( serviceProvider => new FileSystem( serviceProvider ) )
             .AddSingleton<IStandardDirectories>( serviceProvider => new StandardDirectories( serviceProvider ) )
             .AddSingleton<IProcessExecutor>( new ProcessExecutor() )
             .AddSingleton<IHttpClientFactory>( new HttpClientFactory() )

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/FileSystem.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/FileSystem.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Utilities;
 using System;
 using System.Collections.Generic;
@@ -18,6 +19,16 @@ namespace Metalama.Backstage.Infrastructure
     /// </summary>
     internal sealed class FileSystem : IFileSystem
     {
+        private readonly IServiceProvider? _serviceProvider;
+        private IStandardDirectories? _standardDirectories;
+
+        public FileSystem() { }
+
+        public FileSystem( IServiceProvider serviceProvider )
+        {
+            this._serviceProvider = serviceProvider;
+        }
+
         public string? SynchronizationPrefix => null;
 
         /// <inheritdoc />
@@ -173,6 +184,15 @@ namespace Metalama.Backstage.Infrastructure
         /// <inheritdoc />
         public string GetTempFileName()
         {
+            // When this service has its own service provider (e.g. in the worker process, which never initializes the
+            // global BackstageServiceFactory), resolve the temp directory from it instead of relying on the static accessor.
+            if ( this._serviceProvider != null )
+            {
+                this._standardDirectories ??= this._serviceProvider.GetRequiredBackstageService<IStandardDirectories>();
+
+                return MetalamaPathUtilities.GetTempFileName( this._standardDirectories.TempDirectory );
+            }
+
             return MetalamaPathUtilities.GetTempFileName();
         }
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
@@ -34,9 +34,15 @@ public static class MetalamaPathUtilities
     public static string GetTempDirectory()
         => BackstageServiceFactory.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>().TempDirectory;
 
-    public static string GetTempFileName()
+    public static string GetTempFileName() => GetTempFileName( GetTempDirectory() );
+
+    /// <summary>
+    /// Creates a uniquely-named, empty temporary file in the given <paramref name="directory" /> and returns its full path.
+    /// Callers that have a service provider at hand should resolve <see cref="IStandardDirectories.TempDirectory" /> themselves
+    /// and pass it here, rather than relying on the parameterless overload, which requires the backstage services to be initialized.
+    /// </summary>
+    public static string GetTempFileName( string directory )
     {
-        var directory = GetTempDirectory();
         Directory.CreateDirectory( directory );
 
         // https://stackoverflow.com/a/10152460/4100001


### PR DESCRIPTION
## Problem

The `Metalama.Backstage.Worker upload` process crashed while packing queued telemetry, once per file:

```
Telemetry: Cannot pack file '...\UploadQueue\Usage-*.log':
System.InvalidOperationException: BackstageServiceFactory.Initialize method has not been called.
   at Metalama.Backstage.Utilities.MetalamaPathUtilities.GetTempDirectory()
   at Metalama.Backstage.Infrastructure.FileSystem.GetTempFileName()
   at Metalama.Backstage.Telemetry.TelemetryUploader.TryCreatePackage(...)
```

Regression from #1650: `MetalamaPathUtilities.GetTempFileName()` was changed to resolve the temp directory through the global static `BackstageServiceFactory.ServiceProvider`. The worker process builds its services through MS DI and never calls `BackstageServiceFactory.Initialize()`, so that static is unset and `FileSystem.GetTempFileName()` throws.

## Fix

`FileSystem` is itself a DI service, so it should use its own provider rather than the global static. It now takes a service provider and resolves `IStandardDirectories.TempDirectory` from it; a `GetTempFileName(string directory)` overload on `MetalamaPathUtilities` lets it supply the directory. The parameterless path (and the static fallback for callers without a provider) is unchanged.

## Validation

Reproduced and fixed end-to-end against the real `worker upload` CLI (seeded queue + `METALAMA_DIAGNOSTICS` trace): without the fix the exact reported exception/stack occurs and nothing packs; with the fix all files pack, the package is created, and the queue drains.

— Claude for @gfraiteur