### PR TITLE
Privacy fixes: license-audit telemetry activation and disclosure (#1711)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage.Commands/Licensing/ListLicensesCommand.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Commands/Licensing/ListLicensesCommand.cs
@@ -75,6 +75,7 @@ namespace Metalama.Backstage.Commands.Licensing
                     AddRow( "License Expiration", expiration );
                     AddRow( "Maintenance Expiration", Format( data.SubscriptionEndDate ) );
                     AddRow( "Eligible Servicing Phases", data.ServicingPhase.GetDisplayName( true ) );
+                    AddRow( "License Audit", data.Auditable ? "Yes" : "No" );
 
                     context.Console.Out.Write( table );
                 }

--- a/Metalama.Backstage/src/Metalama.Backstage.Commands/Telemetry/TelemetryStatusCommand.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Commands/Telemetry/TelemetryStatusCommand.cs
@@ -4,9 +4,11 @@
 
 using Metalama.Backstage.Configuration;
 using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.Licensing.Registration;
 using Metalama.Backstage.Telemetry;
 using Spectre.Console;
 using System.Globalization;
+using System.Linq;
 
 namespace Metalama.Backstage.Commands.Telemetry;
 
@@ -24,6 +26,26 @@ internal class TelemetryStatusCommand : BaseCommand<BaseCommandSettings>
         if ( !policy.HasRepositoryContext )
         {
             context.Console.WriteWarning( "The working directory is not a git repository. Effective values pertain to a specific repository context." );
+        }
+
+        // Surface any warning produced while resolving the repository configuration backing the policy (for example a
+        // misplaced or malformed metalama.json). See #1701.
+        foreach ( var warning in policy.Warnings )
+        {
+            context.Console.WriteWarning(
+                warning.FilePath != null
+                    ? $"{warning.Message} ({warning.FilePath})"
+                    : warning.Message );
+        }
+
+        if ( policy.GetConsent( TelemetryScenario.Usage ) == TelemetryConsent.No )
+        {
+            var licenseService = context.ServiceProvider.GetBackstageService<ILicenseRegistrationService>();
+
+            if ( licenseService?.RegisteredLicenses.Any( l => l.Auditable ) == true )
+            {
+                context.Console.WriteWarning( "Usage telemetry is disabled, but license audit data is uploaded independently and is not controlled by this setting." );
+            }
         }
 
         var usageConsent = policy.GetConsentAndReason( TelemetryScenario.Usage );

--- a/Metalama.Backstage/src/Metalama.Backstage/Licensing/Audit/LicenseAuditManager.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Licensing/Audit/LicenseAuditManager.cs
@@ -24,6 +24,7 @@ internal sealed class LicenseAuditManager : ILicenseAuditManager
     private readonly TelemetryReportUploader _telemetryReportUploader;
     private readonly MatomoUploader? _matomoAuditUploader;
     private readonly BackstageBackgroundTasksService _backgroundTasksService;
+    private readonly ITelemetryConfigurationService _telemetryConfigurationService;
 
     public LicenseAuditManager( IServiceProvider serviceProvider )
     {
@@ -36,6 +37,7 @@ internal sealed class LicenseAuditManager : ILicenseAuditManager
         this._telemetryReportUploader = serviceProvider.GetRequiredBackstageService<TelemetryReportUploader>();
         this._matomoAuditUploader = serviceProvider.GetBackstageService<MatomoUploader>();
         this._backgroundTasksService = serviceProvider.GetRequiredBackstageService<BackstageBackgroundTasksService>();
+        this._telemetryConfigurationService = serviceProvider.GetRequiredBackstageService<ITelemetryConfigurationService>();
     }
 
     public void ReportLicense( LicenseConsumptionProperties license )
@@ -60,6 +62,12 @@ internal sealed class LicenseAuditManager : ILicenseAuditManager
 
             return;
         }
+
+        // We are about to report a license audit, so make sure telemetry is activated (the DeviceId and salts exist).
+        // Activation is lazy so that a process which never reports also never creates a device identifier. Without this,
+        // the report would hash the user and device with a zeroed salt and an empty DeviceId, producing identical
+        // pseudonyms across all first-time users with the same username. See #1711.
+        this._telemetryConfigurationService.EnsureActivated();
 
         var report = new LicenseAuditTelemetryReport( this._serviceProvider, license );
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Licensing/ServicingPhaseExtensions.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Licensing/ServicingPhaseExtensions.cs
@@ -13,8 +13,8 @@ public static class ServicingPhaseExtensions
             (ServicingPhase.Extended, false) => "Extended",
             (ServicingPhase.LongTerm, false) => "Long Term",
             (ServicingPhase.Current, true) => "Current",
-            (ServicingPhase.Extended, true) => "Curent, Extended",
-            (ServicingPhase.LongTerm, true) => "Current, Extented, Long Term",
+            (ServicingPhase.Extended, true) => "Current, Extended",
+            (ServicingPhase.LongTerm, true) => "Current, Extended, Long Term",
             _ => servicingPhase.ToString()
         };
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ITelemetryConfigurationService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ITelemetryConfigurationService.cs
@@ -100,8 +100,12 @@ public interface ITelemetryConfigurationService : IBackstageService
 
     /// <summary>
     /// Gets the per-channel anonymization salt for hashing device and user identifiers.
-    /// See <see cref="TelemetrySaltKind"/> for which salt applies to which telemetry channel.
+    /// See <see cref="TelemetrySaltKind"/> for which salt applies to which telemetry channel. The caller must have
+    /// activated telemetry first (see <see cref="EnsureActivated"/>); this throws an <see cref="InvalidOperationException"/>
+    /// rather than return a zeroed salt, which would otherwise make the pseudonyms identical across all not-yet-activated
+    /// machines. See #1711.
     /// </summary>
+    /// <exception cref="InvalidOperationException">Telemetry has not been activated (see <see cref="EnsureActivated"/>).</exception>
     long GetSalt( TelemetrySaltKind kind );
 
     /// <inheritdoc cref="GetSalt"/>

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
@@ -49,19 +49,31 @@ internal sealed class TelemetryConfigurationService : ITelemetryConfigurationSer
     private long _licenseAuditSalt;
 
     [Obsolete( "Use GetSalt(TelemetrySaltKind.Matomo) instead." )]
-    public long MatomoSalt => this._matomoSalt;
+    public long MatomoSalt => this.GetSalt( TelemetrySaltKind.Matomo );
 
     [Obsolete( "Use GetSalt(TelemetrySaltKind.UsageTracking) instead." )]
-    public long UsageTrackingSalt => this._usageTrackingSalt;
+    public long UsageTrackingSalt => this.GetSalt( TelemetrySaltKind.UsageTracking );
 
     [Obsolete( "Use GetSalt(TelemetrySaltKind.ExceptionReport) instead." )]
-    public long ExceptionReportingSalt => this._exceptionReportingSalt;
+    public long ExceptionReportingSalt => this.GetSalt( TelemetrySaltKind.ExceptionReport );
 
     [Obsolete( "Use GetSalt(TelemetrySaltKind.LicenseAudit) instead." )]
-    public long LicenseAuditSalt => this._licenseAuditSalt;
+    public long LicenseAuditSalt => this.GetSalt( TelemetrySaltKind.LicenseAudit );
 
     public long GetSalt( TelemetrySaltKind kind )
-        => kind switch
+    {
+        // Reading a salt means a reporter is about to hash an identifier. Activation is lazy (see #1701), so the caller
+        // MUST have called EnsureActivated() first to create the DeviceId and the salts. We refuse to return a zeroed
+        // salt — hashing with it would make the pseudonyms identical across all not-yet-activated machines — and instead
+        // fail loudly so a missing EnsureActivated() call is caught at its source rather than silently corrupting the
+        // audit data. See #1711.
+        if ( !this.IsActivated )
+        {
+            throw new InvalidOperationException(
+                $"Telemetry has not been activated, so the {kind} salt is not available. EnsureActivated() must be called before reading a telemetry salt." );
+        }
+
+        return kind switch
         {
             TelemetrySaltKind.ExceptionReport => this._exceptionReportingSalt,
             TelemetrySaltKind.UsageTracking => this._usageTrackingSalt,
@@ -69,6 +81,7 @@ internal sealed class TelemetryConfigurationService : ITelemetryConfigurationSer
             TelemetrySaltKind.Matomo => this._matomoSalt,
             _ => throw new ArgumentOutOfRangeException( nameof(kind), kind, null )
         };
+    }
 
     private void OnConfigurationChanged( ConfigurationFile configuration )
     {

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/CommandsTestsBase.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/CommandsTestsBase.cs
@@ -30,12 +30,14 @@ namespace Metalama.Tools.Config.Tests.Commands
         protected Task TestCommandAsync(
             string commandLine,
             string? expectedOutput = null,
+            string? unexpectedOutput = null,
             int expectedExitCode = 0 )
-            => this.TestCommandAsync( commandLine.Split( ' ' ), expectedOutput, expectedExitCode );
+            => this.TestCommandAsync( commandLine.Split( ' ' ), expectedOutput, unexpectedOutput, expectedExitCode );
 
         protected async Task TestCommandAsync(
             string[] commandLine,
             string? expectedOutput = null,
+            string? unexpectedOutput = null,
             int expectedExitCode = 0 )
         {
             var output = new StringWriter();
@@ -48,9 +50,16 @@ namespace Metalama.Tools.Config.Tests.Commands
             BackstageCommandFactory.ConfigureCommandApp( commandApp, new BackstageCommandOptions( this, output, output, AnsiSupport.No ) );
             var exitCode = await commandApp.RunAsync( commandLine );
 
+            var outputString = output.ToString();
+
             if ( expectedOutput != null )
             {
-                Assert.Contains( expectedOutput, output.ToString(), StringComparison.OrdinalIgnoreCase );
+                Assert.Contains( expectedOutput, outputString, StringComparison.OrdinalIgnoreCase );
+            }
+
+            if ( unexpectedOutput != null )
+            {
+                Assert.DoesNotContain( unexpectedOutput, outputString, StringComparison.OrdinalIgnoreCase );
             }
 
             Assert.Equal( expectedExitCode, exitCode );

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/ListLicensesCommandTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/ListLicensesCommandTests.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Tools.Config.Tests.Commands.Licensing
+{
+    public sealed class ListLicensesCommandTests : LicensingCommandsTestsBase
+    {
+        public ListLicensesCommandTests( ITestOutputHelper logger )
+            : base( logger ) { }
+
+        [Fact]
+        public async Task AuditableLicense_LicenseAuditRowShowsYes()
+        {
+            await this.TestCommandAsync( $"license register {LicenseKeyProvider.MetalamaProfessionalBusiness}" );
+            await this.TestCommandAsync( "license list", expectedOutput: "Yes" );
+        }
+
+        [Fact]
+        public async Task NonAuditableLicense_LicenseAuditRowShowsNo()
+        {
+            await this.TestCommandAsync( $"license register {LicenseKeyProvider.MetalamaProfessionalBusinessNotAuditable}" );
+            await this.TestCommandAsync( "license list", expectedOutput: "No" );
+        }
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/RegisterTrialCommandTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/Licensing/RegisterTrialCommandTests.cs
@@ -42,7 +42,7 @@ namespace Metalama.Tools.Config.Tests.Commands.Licensing
             await this.TestCommandAsync(
                 "license try",
                 $"You cannot start a new trial period until {_evaluationStart.AddDays( 120 + 45 ).ToString( CultureInfo.CurrentCulture )}.",
-                1 );
+                expectedExitCode: 1 );
 
             await this.TestCommandAsync( "license list", "Evaluation License" );
         }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/Telemetry/TelemetryStatusCommandTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Commands.Tests/Commands/Telemetry/TelemetryStatusCommandTests.cs
@@ -1,0 +1,44 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Testing;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Tools.Config.Tests.Commands.Telemetry
+{
+    public sealed class TelemetryStatusCommandTests : CommandsTestsBase
+    {
+        private static readonly TestLicenseKeyProvider _licenseKeyProvider = new();
+
+        private const string _licenseAuditWarning = "license audit data is uploaded";
+
+        public TelemetryStatusCommandTests( ITestOutputHelper logger )
+            : base( logger )
+        {
+            this.UserDeviceDetection.IsInteractiveDevice = true;
+        }
+
+        [Fact]
+        public async Task NoLicense_NoLicenseAuditWarning()
+        {
+            await this.TestCommandAsync( "telemetry status", unexpectedOutput: _licenseAuditWarning );
+        }
+
+        [Fact]
+        public async Task AuditableLicense_ShowsLicenseAuditWarning()
+        {
+            await this.TestCommandAsync( $"license register {_licenseKeyProvider.MetalamaProfessionalBusiness}" );
+            await this.TestCommandAsync( "telemetry status", expectedOutput: _licenseAuditWarning );
+        }
+
+        [Fact]
+        public async Task NonAuditableLicense_NoLicenseAuditWarning()
+        {
+            await this.TestCommandAsync( $"license register {_licenseKeyProvider.MetalamaProfessionalBusinessNotAuditable}" );
+            await this.TestCommandAsync( "telemetry status", unexpectedOutput: _licenseAuditWarning );
+        }
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Licensing/Consumption/LicenseAuditTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Licensing/Consumption/LicenseAuditTests.cs
@@ -15,6 +15,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -231,5 +232,33 @@ public sealed class LicenseAuditTests : LicenseConsumptionServiceTestsBase
     {
         this.ApplicationInfo = new TestApplicationInfo() { IsUnattendedProcess = true };
         this.ConsumeAndAssertReportsCount( 0 );
+    }
+
+    [Fact]
+    public async Task LicenseAuditActivatesTelemetryOnFreshInstall()
+    {
+        // Simulate a fresh install where telemetry has not been activated yet: no DeviceId and no salts. Activation is
+        // lazy (see #1701), so the license audit must activate telemetry itself before reading the salts. Without this,
+        // the report would hash the user and device with a zeroed salt and an empty DeviceId, producing identical
+        // pseudonyms across all first-time users with the same username. See #1711.
+        this.ConfigurationManager!.Update<TelemetryConfiguration>(
+            c => c with
+            {
+                DeviceId = null,
+                MatomoSalt = null,
+                UsageTrackingSalt = null,
+                ExceptionReportingSalt = null,
+                LicenseAuditSalt = null
+            } );
+
+        var telemetryConfigurationService = this.ServiceProvider.GetRequiredBackstageService<ITelemetryConfigurationService>();
+        Assert.False( telemetryConfigurationService.IsActivated );
+
+        this.CreateAndConsumeLicense( _auditedLicenseKey );
+        await this.BackgroundTasks.WhenNoPendingTaskAsync();
+
+        Assert.True( telemetryConfigurationService.IsActivated );
+        Assert.NotEqual( Guid.Empty, telemetryConfigurationService.DeviceId );
+        Assert.NotEqual( 0L, telemetryConfigurationService.GetSalt( TelemetrySaltKind.LicenseAudit ) );
     }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryConfigurationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryConfigurationTests.cs
@@ -99,6 +99,25 @@ public sealed class TelemetryConfigurationTests : TestsBase
         Assert.NotEqual( initialDiagnosticSalt, GetDiagnosticSalt() );
     }
 
+    [Theory]
+    [InlineData( TelemetrySaltKind.Matomo )]
+    [InlineData( TelemetrySaltKind.UsageTracking )]
+    [InlineData( TelemetrySaltKind.ExceptionReport )]
+    [InlineData( TelemetrySaltKind.LicenseAudit )]
+    public void GetSaltThrowsWhenNotActivated( TelemetrySaltKind kind )
+    {
+        // Reading a salt before telemetry has been activated must fail loudly rather than silently return a zeroed salt
+        // (which would make the pseudonyms identical across all not-yet-activated machines). The caller is responsible
+        // for calling EnsureActivated() first. See #1711, #1701.
+        Assert.False( this.TelemetryConfigurationService.IsActivated );
+
+        Assert.Throws<InvalidOperationException>( () => this.TelemetryConfigurationService.GetSalt( kind ) );
+
+        // After activation, the salt is available and non-zero.
+        this.TelemetryConfigurationService.EnsureActivated();
+        Assert.NotEqual( 0L, this.TelemetryConfigurationService.GetSalt( kind ) );
+    }
+
     [Fact]
     public void SaltsAreGeneratedAndMutuallyDistinct()
     {


### PR DESCRIPTION
## Summary
- Activate telemetry (create the DeviceId and salts) before building the license-audit report, so a fresh install no longer hashes the user/device with a zeroed salt and an empty DeviceId — which produced identical pseudonyms across all first-time users sharing a username (#1711).
- Make `ITelemetryConfigurationService.GetSalt()` throw `InvalidOperationException` when telemetry is not activated, instead of silently returning a zeroed salt, so a missing `EnsureActivated()` call is caught at its source.
- Surface `ITelemetryPolicy.Warnings` (e.g. a misplaced or malformed `metalama.json`) in the `telemetry status` command.
- Disclose license-audit independence in the CLI: show a `License Audit` Yes/No row in the license list, and warn in `telemetry status` (only when an auditable license is registered) that license-audit data is uploaded independently of the usage-telemetry setting.
- Fix typos in servicing phase display names (`Curent`/`Extented` -> `Current`/`Extended`).

## Behavioral Changes
- `ITelemetryConfigurationService.GetSalt()` and the obsolete per-channel salt properties now throw `InvalidOperationException` when telemetry has not been activated (previously returned `0`). All in-tree reporters call `EnsureActivated()` first.

## Issues Fixed
- Closes #1711 - LicenseAuditManager: EnsureActivated() not called — zeroed-salt pseudonyms uploaded on first use