### PR TITLE
Backport security fixes #1650 and #1651 to 2025.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,4 @@ global.json
 **/.idea/workspace.xml
 **/.idea/copilot.data.*.xml
 eng/docket-context/.g/
+.g/

--- a/Metalama.Backstage/src/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Extensibility/RegisterServiceExtensions.cs
@@ -124,6 +124,7 @@ public static class RegisterServiceExtensions
             .AddSingleton<IUserDeviceDetectionService>( serviceProvider => new WindowsUserDeviceDetectionService( serviceProvider ) )
             .AddSingleton<IDateTimeProvider>( new CurrentDateTimeProvider() )
             .AddSingleton<IFileSystem>( new FileSystem() )
+            .AddSingleton<IRuntimeInformation>( new RuntimeInformationProvider() )
             .AddSingleton<IStandardDirectories>( serviceProvider => new StandardDirectories( serviceProvider ) )
             .AddSingleton<IProcessExecutor>( new ProcessExecutor() )
             .AddSingleton<IHttpClientFactory>( new HttpClientFactory() )

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IRuntimeInformation.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IRuntimeInformation.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using Metalama.Backstage.Diagnostics;
+using Metalama.Backstage.Extensibility;
+using System.Runtime.InteropServices;
+
+// ReSharper disable InconsistentNaming
+
+namespace Metalama.Backstage.Infrastructure;
+
+/// <summary>
+/// Provides runtime information about the current platform and process.
+/// </summary>
+[PublicAPI]
+public interface IRuntimeInformation : IBackstageService
+{
+    /// <summary>
+    /// Gets the platform on which the application is running.
+    /// </summary>
+    /// <param name="osPlatform">The platform to check.</param>
+    /// <returns>True if the application is running on the specified platform; otherwise, false.</returns>
+    bool IsOSPlatform( OSPlatform osPlatform );
+
+    /// <summary>
+    /// Gets the architecture of the running process.
+    /// </summary>
+    Architecture ProcessArchitecture { get; }
+
+    /// <summary>
+    /// Gets the architecture of the operating system.
+    /// </summary>
+
+    Architecture OSArchitecture { get; }
+
+    /// <summary>
+    /// Gets the kind of the current process (e.g. <see cref="Diagnostics.ProcessKind.Rider"/>),
+    /// abstracted so test doubles can simulate hosts without depending on the real process name.
+    /// </summary>
+    ProcessKind ProcessKind { get; }
+}

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IStandardDirectories.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/IStandardDirectories.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Backstage.Extensibility;
+using System.Collections.Generic;
 
 namespace Metalama.Backstage.Infrastructure
 {
@@ -17,9 +18,18 @@ namespace Metalama.Backstage.Infrastructure
         string ApplicationDataDirectory { get; }
 
         /// <summary>
-        /// Gets the path of the current user's application temporary folder.
+        /// Gets the path of the current user's application temporary folder. Unless overridden by the
+        /// <c>METALAMA_TEMP</c> environment variable, on Unix this lives under <see cref="ApplicationDataDirectory"/>
+        /// and not under the world-writable <c>/tmp</c> (issue #1650), because this directory holds assemblies
+        /// that Metalama loads and executes.
         /// </summary>
         string TempDirectory { get; }
+
+        /// <summary>
+        /// Gets temp directories used by previous versions of Metalama but no longer used by this one, so that the
+        /// cache clean-up can remove them. Empty unless the temp location has changed across versions.
+        /// </summary>
+        IReadOnlyList<string> LegacyTempDirectories { get; }
 
         /// <summary>
         /// Gets the directory where telemetry logs are written.

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/RuntimeInformationProvider.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/RuntimeInformationProvider.cs
@@ -1,0 +1,23 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Diagnostics;
+using Metalama.Backstage.Utilities;
+using System.Runtime.InteropServices;
+
+namespace Metalama.Backstage.Infrastructure;
+
+/// <summary>
+/// Wraps the <see cref="RuntimeInformation"/> class as an <see cref="IRuntimeInformation"/>.
+/// </summary>
+internal sealed class RuntimeInformationProvider : IRuntimeInformation
+{
+    public bool IsOSPlatform( OSPlatform osPlatform ) => RuntimeInformation.IsOSPlatform( osPlatform );
+
+    public Architecture ProcessArchitecture => RuntimeInformation.ProcessArchitecture;
+
+    public Architecture OSArchitecture => RuntimeInformation.OSArchitecture;
+
+    public ProcessKind ProcessKind => ProcessUtilities.ProcessKind;
+}

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/StandardDirectories.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/StandardDirectories.cs
@@ -5,8 +5,8 @@
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Maintenance;
-using Metalama.Backstage.Utilities;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Runtime.InteropServices;
 
@@ -20,6 +20,8 @@ namespace Metalama.Backstage.Infrastructure
     internal sealed class StandardDirectories : IStandardDirectories
     {
         private readonly IServiceProvider _serviceProvider;
+        private readonly IRuntimeInformation _runtimeInformation;
+        private readonly string? _overriddenTempPath;
 
         /// <summary>
         /// Initializes a new instance of the <see cref="StandardDirectories"/> class.
@@ -36,6 +38,10 @@ namespace Metalama.Backstage.Infrastructure
             // which leads to accessing different directories in each part.
 
             this._serviceProvider = serviceProvider;
+            this._runtimeInformation = serviceProvider.GetRequiredBackstageService<IRuntimeInformation>();
+
+            var overriddenTempPath = serviceProvider.GetRequiredBackstageService<IEnvironmentVariableProvider>().GetEnvironmentVariable( "METALAMA_TEMP" );
+            this._overriddenTempPath = string.IsNullOrEmpty( overriddenTempPath ) ? null : overriddenTempPath;
 
             var logger = serviceProvider.GetBackstageService<EarlyLoggerFactory>()?.GetLogger( nameof( StandardDirectories ) );
 
@@ -121,8 +127,37 @@ namespace Metalama.Backstage.Infrastructure
         /// <inheritdoc />
         public string ApplicationDataDirectory { get; }
 
+        // The Metalama temp directory holds assemblies that Metalama loads and executes, so it must be writable only by
+        // the current user. On Unix, Path.GetTempPath() (/tmp) is world-writable and would allow DLL planting (#1650),
+        // so we use the per-user application-data directory there. On Windows the temp directory is already per-user.
+        // The OS and environment are read through injected services so both branches are unit-testable on any platform.
+
         /// <inheritdoc />
-        public string TempDirectory { get; } = Path.Combine( MetalamaPathUtilities.GetTempPath(), "Metalama" );
+        public string TempDirectory
+        {
+            get
+            {
+                if ( this._overriddenTempPath != null )
+                {
+                    return Path.Combine( this._overriddenTempPath, "Metalama" );
+                }
+
+                if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+                {
+                    return Path.Combine( Path.GetTempPath(), "Metalama" );
+                }
+
+                return Path.Combine( this.ApplicationDataDirectory, "Temp" );
+            }
+        }
+
+        /// <inheritdoc />
+        public IReadOnlyList<string> LegacyTempDirectories
+            => this._overriddenTempPath != null || this._runtimeInformation.IsOSPlatform( OSPlatform.Windows )
+                ? Array.Empty<string>()
+
+                // The pre-#1650 location on Unix, e.g. '/tmp/Metalama'.
+                : new[] { Path.Combine( Path.GetTempPath(), "Metalama" ) };
 
         /// <inheritdoc />
         public string TelemetryLogsDirectory => Path.Combine( this.ApplicationDataDirectory, "Telemetry", "Logs" );

--- a/Metalama.Backstage/src/Metalama.Backstage/Maintenance/TempFileManager.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Maintenance/TempFileManager.cs
@@ -91,11 +91,51 @@ public sealed class TempFileManager : ITempFileManager
 
             // Go through all cache directories in temp directory (i.e. CrashReports, ExtractExceptions, Logs etc.)
             this.CleanUpDirectory( this._standardDirectories.TempDirectory, all );
+
+            // Also clean directories used by previous Metalama versions but no longer used by this one
+            // (e.g. the pre-#1650 '/tmp/Metalama' on Unix, now relocated under the user's application-data directory).
+            this.CleanUpLegacyDirectories( all );
         }
         finally
         {
             mutex.Dispose();
             this._configurationManager.Update<CleanUpConfiguration>( c => c with { LastCleanUpTime = this._time.UtcNow } );
+        }
+    }
+
+    private void CleanUpLegacyDirectories( bool all )
+    {
+        foreach ( var legacyDirectory in this._standardDirectories.LegacyTempDirectories )
+        {
+            if ( string.Equals( legacyDirectory, this._standardDirectories.TempDirectory, StringComparison.Ordinal )
+                 || !this._fileSystem.DirectoryExists( legacyDirectory ) )
+            {
+                continue;
+            }
+
+            // Use a mutex keyed on the legacy directory so we don't race an older Metalama version that may still be cleaning it.
+            var mutex = MutexHelper.WithLock(
+                legacyDirectory,
+                this._fileSystem.SynchronizationPrefix,
+                TimeSpan.FromMilliseconds( 1 ),
+                this._logger );
+
+            if ( mutex == null )
+            {
+                this._logger.Warning?.Log( $"Clean-up of the legacy directory '{legacyDirectory}' is already running." );
+
+                continue;
+            }
+
+            try
+            {
+                this._logger.Trace?.Log( $"Cleaning up the legacy temporary directory '{legacyDirectory}'." );
+                this.CleanUpDirectory( legacyDirectory, all );
+            }
+            finally
+            {
+                mutex.Dispose();
+            }
         }
     }
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/MetalamaPathUtilities.cs
@@ -4,11 +4,15 @@
 
 // There is a copy of this code in Metalama.Compiler.Shared and partially in Metalama ResourceExtractor.
 
+using JetBrains.Annotations;
+using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.Infrastructure;
 using System;
 using System.IO;
 
 namespace Metalama.Backstage.Utilities;
 
+[PublicAPI]
 public static class MetalamaPathUtilities
 {
     private static readonly string? _overriddenTempPath;
@@ -19,21 +23,34 @@ public static class MetalamaPathUtilities
         _overriddenTempPath = string.IsNullOrEmpty( overriddenTempPath ) ? null : overriddenTempPath;
     }
 
+    [Obsolete( "Use GetTempDirectory() or IStandardDirectories.TempDirectory. GetTempPath() is rooted in the world-writable /tmp on Unix (issue #1650)." )]
     public static string GetTempPath() => _overriddenTempPath ?? Path.GetTempPath();
 
-    public static string GetTempFileName()
+    /// <summary>
+    /// Gets the Metalama temporary directory. The actual logic lives in <see cref="IStandardDirectories.TempDirectory" />;
+    /// this static accessor delegates to it for callers that do not have a service provider at hand. It therefore requires
+    /// the backstage services to be initialized.
+    /// </summary>
+    public static string GetTempDirectory()
+        => BackstageServiceFactory.ServiceProvider.GetRequiredBackstageService<IStandardDirectories>().TempDirectory;
+
+    public static string GetTempFileName() => GetTempFileName( GetTempDirectory() );
+
+    /// <summary>
+    /// Creates a uniquely-named, empty temporary file in the given <paramref name="directory" /> and returns its full path.
+    /// Callers that have a service provider at hand should resolve <see cref="IStandardDirectories.TempDirectory" /> themselves
+    /// and pass it here, rather than relying on the parameterless overload, which requires the backstage services to be initialized.
+    /// </summary>
+    public static string GetTempFileName( string directory )
     {
-        if ( _overriddenTempPath == null )
-        {
-            return Path.GetTempFileName();
-        }
+        Directory.CreateDirectory( directory );
 
         // https://stackoverflow.com/a/10152460/4100001
         var attempt = 0;
 
         while ( true )
         {
-            var path = Path.Combine( _overriddenTempPath, $"{Guid.NewGuid()}.tmp" );
+            var path = Path.Combine( directory, $"{Guid.NewGuid()}.tmp" );
 
             try
             {

--- a/Metalama.Backstage/src/Metalama.Backstage/Utilities/ProcessUtilities.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Utilities/ProcessUtilities.cs
@@ -44,6 +44,7 @@ public static class ProcessUtilities
 
             case "servicehub.roslyncodeanalysisservice":
             case "servicehub.roslyncodeanalysisservices":
+            case "devhub":
                 return ProcessKind.RoslynCodeAnalysisService;
 
             case "servicehub.host":

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestRuntimeInformation.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestRuntimeInformation.cs
@@ -1,0 +1,39 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Diagnostics;
+using Metalama.Backstage.Infrastructure;
+using System.Runtime.InteropServices;
+
+namespace Metalama.Backstage.Testing;
+
+public sealed class TestRuntimeInformation : IRuntimeInformation
+{
+    private readonly RuntimeInformationProvider _defaultValues = new();
+
+    public OSPlatform? Platform { get; set; }
+
+    public Architecture? TestProcessArchitecture { get; set; }
+
+    // ReSharper disable once InconsistentNaming
+    public Architecture? TestOSArchitecture { get; set; }
+
+    public ProcessKind? TestProcessKind { get; set; }
+
+    public bool IsOSPlatform( OSPlatform osPlatform )
+    {
+        if ( this.Platform == null )
+        {
+            return this._defaultValues.IsOSPlatform( osPlatform );
+        }
+
+        return this.Platform.Value.Equals( osPlatform );
+    }
+
+    public Architecture ProcessArchitecture => this.TestProcessArchitecture ?? this._defaultValues.ProcessArchitecture;
+
+    public Architecture OSArchitecture => this.TestOSArchitecture ?? this._defaultValues.OSArchitecture;
+
+    public ProcessKind ProcessKind => this.TestProcessKind ?? this._defaultValues.ProcessKind;
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestsBase.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestsBase.cs
@@ -34,6 +34,8 @@ namespace Metalama.Backstage.Testing
 
         protected TestEnvironmentVariableProvider EnvironmentVariableProvider { get; } = new();
 
+        protected TestRuntimeInformation RuntimeInformation { get; } = new();
+
         protected TestLoggerFactory Log { get; }
 
         protected IServiceProvider ServiceProvider => this._defaultTestContext.Value.ServiceProvider;
@@ -206,6 +208,7 @@ namespace Metalama.Backstage.Testing
                 // We must always have a single instance of the file system even if we use CloneServiceCollection.
                 .AddSingleton<IFileSystem>( serviceProvider => this._uniqueFileSystem ??= new TestFileSystem( serviceProvider ) )
                 .AddSingleton<IEnvironmentVariableProvider>( this.EnvironmentVariableProvider )
+                .AddSingleton<IRuntimeInformation>( this.RuntimeInformation )
                 .AddSingleton<IRecoverableExceptionService>( new TestRecoverableExceptionService() )
                 .AddSingleton<IUserDeviceDetectionService>( this.UserDeviceDetection )
                 .AddSingleton<IConfigurationManager>( serviceProvider => new InMemoryConfigurationManager( serviceProvider ) )

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/ConfigurationManager/ConfigurationManagerLoadTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/ConfigurationManager/ConfigurationManagerLoadTests.cs
@@ -31,6 +31,7 @@ public sealed class ConfigurationManagerLoadTests : TestsBase
         services.AddSingleton<IDateTimeProvider>( this.Time );
         services.AddSingleton<IEnvironmentVariableProvider>( this.EnvironmentVariableProvider );
         services.AddSingleton<EarlyLoggerFactory>();
+        services.AddSingleton<IRuntimeInformation>( new RuntimeInformationProvider() );
         services.AddSingleton<IStandardDirectories>( s => new StandardDirectories( s ) );
         var serviceProvider = services.BuildServiceProvider();
 

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/StandardDirectoriesTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/StandardDirectoriesTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Infrastructure;
+using Metalama.Backstage.Testing;
+using System;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Tests.Infrastructure;
+
+// Tests for the temp-directory location introduced by issue #1650. Metalama loads and executes assemblies from its
+// temp directory, so on Unix it must live under the user-private application-data directory, not the world-writable
+// /tmp. The OS is driven by the injected IRuntimeInformation (TestRuntimeInformation.Platform), so both the Windows and
+// Unix branches are exercised regardless of the platform the test runs on.
+public sealed class StandardDirectoriesTests : TestsBase
+{
+    public StandardDirectoriesTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    [Fact]
+    public void Windows_TempDirectoryIsUnderUserTempPath_AndHasNoLegacyDirectories()
+    {
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+
+        var directories = new StandardDirectories( this.ServiceProvider );
+
+        // On Windows the user temp directory is already private to the current user.
+        Assert.Equal( Path.Combine( Path.GetTempPath(), "Metalama" ), directories.TempDirectory );
+        Assert.Empty( directories.LegacyTempDirectories );
+    }
+
+    [Fact]
+    public void Unix_TempDirectoryIsUnderApplicationData_AndLegacyIsTmp()
+    {
+        this.RuntimeInformation.Platform = OSPlatform.Linux;
+
+        var directories = new StandardDirectories( this.ServiceProvider );
+
+        // Must be under the user-private application-data directory, and never under the world-writable /tmp (#1650).
+        Assert.Equal( Path.Combine( directories.ApplicationDataDirectory, "Temp" ), directories.TempDirectory );
+        Assert.False( directories.TempDirectory.StartsWith( Path.GetTempPath(), StringComparison.Ordinal ) );
+
+        // The pre-#1650 location must be offered to the cache clean-up.
+        var legacy = Assert.Single( directories.LegacyTempDirectories );
+        Assert.Equal( Path.Combine( Path.GetTempPath(), "Metalama" ), legacy );
+    }
+
+    [Fact]
+    public void Override_TempDirectoryIsUnderOverride_AndHasNoLegacyDirectories()
+    {
+        // METALAMA_TEMP takes precedence on any platform, and there is then no legacy location.
+        this.RuntimeInformation.Platform = OSPlatform.Linux;
+        var overridePath = Path.Combine( Path.GetTempPath(), "CustomMetalamaTemp" );
+        this.EnvironmentVariableProvider.Environment["METALAMA_TEMP"] = overridePath;
+
+        var directories = new StandardDirectories( this.ServiceProvider );
+
+        Assert.Equal( Path.Combine( overridePath, "Metalama" ), directories.TempDirectory );
+        Assert.Empty( directories.LegacyTempDirectories );
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Maintenance/CleanUpTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Maintenance/CleanUpTests.cs
@@ -14,6 +14,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -142,6 +143,34 @@ public sealed class CleanUpTests : TestsBase
 
         // Assert every cache directory is deleted.
         Assert.False( this.FileSystem.DirectoryExists( this._standardDirectories.TempDirectory ) );
+    }
+
+    [Fact]
+    public void Clean_LegacyDirectory()
+    {
+        // Regression test for #1650: after relocating the Unix temp directory off the world-writable /tmp,
+        // the clean-up must also remove the legacy location used by previous versions. We simulate Unix (we don't
+        // run tests on Linux) so the legacy '/tmp/Metalama' location applies.
+        this.RuntimeInformation.Platform = OSPlatform.Linux;
+
+        var legacyDirectory = Assert.Single( this._standardDirectories.LegacyTempDirectories );
+
+        // The legacy directory differs from the current temp directory.
+        Assert.NotEqual( this._standardDirectories.TempDirectory, legacyDirectory );
+
+        // Populate the legacy directory in the (mock) file system.
+        var subdirectory = Path.Combine( legacyDirectory, "Logs", "0.1.42-test" );
+        this.FileSystem.CreateDirectory( subdirectory );
+        var cleanUpFile = JsonConvert.SerializeObject( new CleanUpFile { Strategy = CleanUpStrategy.Always } );
+        this.FileSystem.WriteAllText( Path.Combine( subdirectory, "cleanup.json" ), cleanUpFile );
+
+        Assert.True( this.FileSystem.DirectoryExists( legacyDirectory ) );
+
+        // Clean everything.
+        var tempFileManager = new TempFileManager( this.ServiceProvider );
+        tempFileManager.CleanTempDirectories( force: true, all: true );
+
+        Assert.False( this.FileSystem.DirectoryExists( legacyDirectory ) );
     }
 
     [Fact]

--- a/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ProcessKindHelper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ProcessKindHelper.cs
@@ -23,6 +23,7 @@ public static class ProcessKindHelper
 
             case "servicehub.roslyncodeanalysisservice":
             case "servicehub.roslyncodeanalysisservices":
+            case "devhub":
                 return ProcessKind.RoslynCodeAnalysisService;
 
             case "csc":

--- a/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ResourceExtractor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ResourceExtractor.cs
@@ -62,14 +62,40 @@ public static class ResourceExtractor
         _buildId = assemblyVersion.ToString( 4 ) + "-" +
                    string.Join( "", moduleId.ToByteArray().Take( 4 ).Select( i => i.ToString( "x2", CultureInfo.InvariantCulture ) ) );
 
-        _snapshotDirectory = GetTempDirectory( "Extract" );
-
+        // Read the METALAMA_TEMP override before computing any path that depends on it.
         var overriddenTempPath = Environment.GetEnvironmentVariable( "METALAMA_TEMP" );
         _overriddenTempPath = string.IsNullOrEmpty( overriddenTempPath ) ? null : overriddenTempPath;
+
+        _snapshotDirectory = GetTempDirectory( "Extract" );
     }
 
     private static string GetTempDirectory( string purpose )
-        => Path.Combine( _overriddenTempPath ?? Path.GetTempPath(), "Metalama", purpose, _buildId, _isNetFramework ? "desktop" : "core" );
+        => Path.Combine( GetTempBaseDirectory(), purpose, _buildId, _isNetFramework ? "desktop" : "core" );
+
+    // Mirrors Metalama.Backstage.Utilities.MetalamaPathUtilities.GetTempDirectory (we cannot reference Metalama.Backstage here).
+    // The directory holds assemblies that Metalama loads and executes, so on Unix it must not live under the world-writable
+    // /tmp (issue #1650); we use the per-user application-data directory instead. On Windows the temp directory is already
+    // specific to the current user.
+    private static string GetTempBaseDirectory()
+    {
+        if ( _overriddenTempPath != null )
+        {
+            return Path.Combine( _overriddenTempPath, "Metalama" );
+        }
+
+        if ( RuntimeInformation.IsOSPlatform( OSPlatform.Windows ) )
+        {
+            return Path.Combine( Path.GetTempPath(), "Metalama" );
+        }
+
+        var localApplicationData = Environment.GetFolderPath( Environment.SpecialFolder.LocalApplicationData );
+
+        var applicationDataDirectory = !string.IsNullOrEmpty( localApplicationData )
+            ? Path.Combine( localApplicationData, "Metalama" )
+            : Path.Combine( Environment.GetFolderPath( Environment.SpecialFolder.UserProfile ), ".metalama" );
+
+        return Path.Combine( applicationDataDirectory, "Temp" );
+    }
 
     private static void Initialize()
     {

--- a/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ResourceExtractor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.CompilerExtensions/ResourceExtractor.cs
@@ -504,10 +504,14 @@ public static class ResourceExtractor
                 log?.AppendLine( $"Loading the embedded assembly '{embeddedAssembly.Path}'." );
 
                 // It seems assemblies loaded into an ALC don't participate in COM type equivalence.
-                // Since we need that for the DesignTime.Contracts assembly, load it without using ALC.
+                // Since we need that for the DesignTime.Contracts assembly in devenv.exe, load it without using ALC.
+                // However, in other processes (DevHub, ServiceHub, compiler), COM type equivalence is not needed
+                // and Assembly.LoadFile causes Microsoft.CodeAnalysis to resolve from the wrong ALC in DevHub,
+                // leading to MissingMethodException/TypeLoadException (#1461).
 
                 // ReSharper disable once StringStartsWithIsCultureSpecific
-                if ( name.StartsWith( $"{_designTimeContractsAssemblyName}," ) )
+                if ( name.StartsWith( $"{_designTimeContractsAssemblyName}," )
+                     && ProcessKindHelper.CurrentProcessKind == ProcessKind.DevEnv )
                 {
                     return Assembly.LoadFile( embeddedAssembly.Path );
                 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationAllowList.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationAllowList.cs
@@ -3,47 +3,61 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using System.Collections.Concurrent;
+using System.Collections.Generic;
 
 namespace Metalama.Framework.DesignTime.Rpc;
 
 /// <summary>
-/// A closed, per-type allow-list of CLR types that may be deserialized over the design-time RPC channel.
+/// A closed allow-list of CLR types, identified by full name, that may be deserialized over the design-time RPC channel.
 /// See issue #1651 (GHSA-h26j-4vp7-x9w2): the JSON wire format uses <see cref="Newtonsoft.Json.TypeNameHandling.All"/>,
 /// which embeds a CLR type name on the wire for every non-primitive object and reconstructs it on read. Without a
-/// per-type restriction, any type in an allow-listed assembly (including <c>System.Private.CoreLib</c>) could be
-/// instantiated before any application logic runs — an unsafe-deserialization / gadget-chain RCE primitive, the
-/// Newtonsoft analogue of <c>BinaryFormatter</c>. The check is enforced by <see cref="JsonSerializationBinder.BindToType"/>,
-/// the untrusted deserialization boundary.
+/// per-type restriction, any resolvable type (including <c>System.Private.CoreLib</c> gadgets) could be instantiated
+/// before any application logic runs — an unsafe-deserialization / gadget-chain RCE primitive, the Newtonsoft analogue
+/// of <c>BinaryFormatter</c>. The check is enforced by <see cref="JsonSerializationBinder.BindToType"/>, the untrusted
+/// deserialization boundary.
 /// </summary>
+/// <remarks>
+/// <para>
+/// Types are matched by <see cref="System.Type.FullName"/> only, NOT by assembly identity. This is required by the
+/// multi-version design-time scenario (issue #31075): the same logical contract type is shipped in version-suffixed
+/// assemblies (e.g. <c>Metalama.Framework.DesignTime.4.8.0</c> vs <c>4.12.0</c>) and is repacked into
+/// <c>Metalama.Repacked</c> in the VS extension, so its assembly identity differs between the communicating processes
+/// while its full name is stable. Matching by full name also lets the allow-list be populated <em>without loading</em>
+/// the contract types — see <see cref="Add(string,bool)"/>. Loading them eagerly (e.g. via <c>typeof</c>) crashes in the
+/// multi-version scenario, because a contract type that implements a shared <c>Metalama.Framework.DesignTime.Contracts</c>
+/// interface fails to load when a different version of that Contracts assembly is already loaded in the process.
+/// </para>
+/// <para>
+/// Security is preserved because only the small, fixed set of contract full names is accepted: realistic deserialization
+/// gadgets (whose full names are never one of our contracts) are rejected, as are all unregistered types. Generic type
+/// arguments and array elements are validated recursively; scalar primitives and enums are always allowed.
+/// </para>
+/// </remarks>
 internal sealed class JsonSerializationAllowList
 {
-    // Keyed by (assembly simple name, type full name). Pinning by assembly name as well as full name prevents a
-    // same-named gadget from a different assembly from slipping through. The key always uses the *resolved* type's
-    // assembly, which is the runtime that will actually instantiate the object.
-    private readonly HashSet<(string AssemblyName, string FullName)> _allowedTypes = new();
+    private readonly HashSet<string> _allowedTypeNames = new( StringComparer.Ordinal );
 
-    // Open generic definitions that may appear on the wire (e.g. ImmutableArray<>); their type arguments are
-    // validated separately and recursively.
-    private readonly HashSet<(string AssemblyName, string FullName)> _allowedGenericDefinitions = new();
+    // Full names of open generic definitions that may appear on the wire (e.g. "System.Collections.Immutable.ImmutableArray`1");
+    // their type arguments are validated separately and recursively.
+    private readonly HashSet<string> _allowedGenericDefinitionNames = new( StringComparer.Ordinal );
 
     private readonly ConcurrentDictionary<Type, bool> _cache = new();
 
     /// <summary>
-    /// Adds a type to the allow-list. Open generic definitions (e.g. <c>typeof(ImmutableArray&lt;&gt;)</c>) are recorded
-    /// as generic definitions. Prefer this overload for any type we can reference, so the key uses the resolved
-    /// assembly identity (important under the <c>Metalama.Repacked</c> ILMerge in the VS extension).
+    /// Adds a type to the allow-list, by full name. Open generic definitions (e.g. <c>typeof(ImmutableArray&lt;&gt;)</c>)
+    /// are recorded as generic definitions. This overload loads the type, so use it only for types that are always safe to
+    /// load in any process (e.g. the framework's own RPC types and BCL types). For contract types that implement shared
+    /// <c>Metalama.Framework.DesignTime.Contracts</c> interfaces, use <see cref="Add(string,bool)"/> to avoid loading them.
     /// </summary>
     public void Add( Type type )
     {
-        var key = GetKey( type );
-
         if ( type.IsGenericTypeDefinition )
         {
-            this._allowedGenericDefinitions.Add( key );
+            this._allowedGenericDefinitionNames.Add( GetName( type ) );
         }
         else
         {
-            this._allowedTypes.Add( key );
+            this._allowedTypeNames.Add( GetName( type ) );
         }
 
         // A type registered here may already have a cached 'false' decision (its own, or that of an array/generic that
@@ -53,18 +67,19 @@ internal sealed class JsonSerializationAllowList
     }
 
     /// <summary>
-    /// Adds a type to the allow-list by name, for types that cannot be referenced at compile time (e.g. types owned by
-    /// another assembly we do not depend on). Use <see cref="Add(System.Type)"/> whenever the type can be referenced.
+    /// Adds a type to the allow-list by full name, <em>without loading it</em>. This is the preferred overload for contract
+    /// DTO types: it avoids the eager type-loading that crashes in the multi-version design-time scenario (see the remarks
+    /// on <see cref="JsonSerializationAllowList"/>).
     /// </summary>
-    public void Add( string assemblyName, string fullName, bool isGenericDefinition = false )
+    public void Add( string fullName, bool isGenericDefinition = false )
     {
         if ( isGenericDefinition )
         {
-            this._allowedGenericDefinitions.Add( (assemblyName, fullName) );
+            this._allowedGenericDefinitionNames.Add( fullName );
         }
         else
         {
-            this._allowedTypes.Add( (assemblyName, fullName) );
+            this._allowedTypeNames.Add( fullName );
         }
 
         // See Add(Type): invalidate cached decisions that may predate this registration.
@@ -88,9 +103,7 @@ internal sealed class JsonSerializationAllowList
         // independently, so a smuggled type argument can only be caught here.
         if ( type.IsGenericType && !type.IsGenericTypeDefinition )
         {
-            var definition = type.GetGenericTypeDefinition();
-
-            if ( !this._allowedGenericDefinitions.Contains( GetKey( definition ) ) )
+            if ( !this._allowedGenericDefinitionNames.Contains( GetName( type.GetGenericTypeDefinition() ) ) )
             {
                 return false;
             }
@@ -115,9 +128,8 @@ internal sealed class JsonSerializationAllowList
             return true;
         }
 
-        return this._allowedTypes.Contains( GetKey( type ) );
+        return this._allowedTypeNames.Contains( GetName( type ) );
     }
 
-    private static (string AssemblyName, string FullName) GetKey( Type type )
-        => (type.Assembly.GetName().Name ?? "", type.FullName ?? type.Name);
+    private static string GetName( Type type ) => type.FullName ?? type.Name;
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationAllowList.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationAllowList.cs
@@ -1,0 +1,115 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Collections.Concurrent;
+
+namespace Metalama.Framework.DesignTime.Rpc;
+
+/// <summary>
+/// A closed, per-type allow-list of CLR types that may be deserialized over the design-time RPC channel.
+/// See issue #1651 (GHSA-h26j-4vp7-x9w2): the JSON wire format uses <see cref="Newtonsoft.Json.TypeNameHandling.All"/>,
+/// which embeds a CLR type name on the wire for every non-primitive object and reconstructs it on read. Without a
+/// per-type restriction, any type in an allow-listed assembly (including <c>System.Private.CoreLib</c>) could be
+/// instantiated before any application logic runs — an unsafe-deserialization / gadget-chain RCE primitive, the
+/// Newtonsoft analogue of <c>BinaryFormatter</c>. The check is enforced by <see cref="JsonSerializationBinder.BindToType"/>,
+/// the untrusted deserialization boundary.
+/// </summary>
+internal sealed class JsonSerializationAllowList
+{
+    // Keyed by (assembly simple name, type full name). Pinning by assembly name as well as full name prevents a
+    // same-named gadget from a different assembly from slipping through. The key always uses the *resolved* type's
+    // assembly, which is the runtime that will actually instantiate the object.
+    private readonly HashSet<(string AssemblyName, string FullName)> _allowedTypes = new();
+
+    // Open generic definitions that may appear on the wire (e.g. ImmutableArray<>); their type arguments are
+    // validated separately and recursively.
+    private readonly HashSet<(string AssemblyName, string FullName)> _allowedGenericDefinitions = new();
+
+    private readonly ConcurrentDictionary<Type, bool> _cache = new();
+
+    /// <summary>
+    /// Adds a type to the allow-list. Open generic definitions (e.g. <c>typeof(ImmutableArray&lt;&gt;)</c>) are recorded
+    /// as generic definitions. Prefer this overload for any type we can reference, so the key uses the resolved
+    /// assembly identity (important under the <c>Metalama.Repacked</c> ILMerge in the VS extension).
+    /// </summary>
+    public void Add( Type type )
+    {
+        var key = GetKey( type );
+
+        if ( type.IsGenericTypeDefinition )
+        {
+            this._allowedGenericDefinitions.Add( key );
+        }
+        else
+        {
+            this._allowedTypes.Add( key );
+        }
+    }
+
+    /// <summary>
+    /// Adds a type to the allow-list by name, for types that cannot be referenced at compile time (e.g. types owned by
+    /// another assembly we do not depend on). Use <see cref="Add(System.Type)"/> whenever the type can be referenced.
+    /// </summary>
+    public void Add( string assemblyName, string fullName, bool isGenericDefinition = false )
+    {
+        if ( isGenericDefinition )
+        {
+            this._allowedGenericDefinitions.Add( (assemblyName, fullName) );
+        }
+        else
+        {
+            this._allowedTypes.Add( (assemblyName, fullName) );
+        }
+    }
+
+    public bool IsAllowed( Type type ) => this._cache.GetOrAdd( type, this.IsAllowedCore );
+
+    private bool IsAllowedCore( Type type )
+    {
+        // Arrays: T[] is allowed iff the element type is allowed.
+        if ( type.IsArray )
+        {
+            var elementType = type.GetElementType();
+
+            return elementType != null && this.IsAllowed( elementType );
+        }
+
+        // Constructed generics: the open definition must be allow-listed AND every type argument must be allowed.
+        // This is necessary as well as sufficient: for an empty ImmutableArray<Gadget> the element is never resolved
+        // independently, so a smuggled type argument can only be caught here.
+        if ( type.IsGenericType && !type.IsGenericTypeDefinition )
+        {
+            var definition = type.GetGenericTypeDefinition();
+
+            if ( !this._allowedGenericDefinitions.Contains( GetKey( definition ) ) )
+            {
+                return false;
+            }
+
+            foreach ( var argument in type.GetGenericArguments() )
+            {
+                if ( !this.IsAllowed( argument ) )
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        // Primitive scalar types (int, bool, long, double, char, ...) and enums carry no behavior on deserialization and
+        // can never be a gadget, so they are always allowed (this also covers primitive/enum array elements and type
+        // arguments). Nullable<T> arrives as a constructed generic and is handled above. Dangerous reference types and
+        // unrecognized value types (e.g. System.Type) still require explicit registration.
+        if ( type.IsPrimitive || type.IsEnum )
+        {
+            return true;
+        }
+
+        return this._allowedTypes.Contains( GetKey( type ) );
+    }
+
+    private static (string AssemblyName, string FullName) GetKey( Type type )
+        => (type.Assembly.GetName().Name ?? "", type.FullName ?? type.Name);
+}

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationAllowList.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationAllowList.cs
@@ -45,6 +45,11 @@ internal sealed class JsonSerializationAllowList
         {
             this._allowedTypes.Add( key );
         }
+
+        // A type registered here may already have a cached 'false' decision (its own, or that of an array/generic that
+        // references it as an element/argument), e.g. if it was deserialized before an extension registered it through
+        // the late-registration seam. Drop the cache so those decisions are recomputed against the updated allow-list.
+        this._cache.Clear();
     }
 
     /// <summary>
@@ -61,6 +66,9 @@ internal sealed class JsonSerializationAllowList
         {
             this._allowedTypes.Add( (assemblyName, fullName) );
         }
+
+        // See Add(Type): invalidate cached decisions that may predate this registration.
+        this._cache.Clear();
     }
 
     public bool IsAllowed( Type type ) => this._cache.GetOrAdd( type, this.IsAllowedCore );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinder.cs
@@ -24,6 +24,13 @@ public sealed class JsonSerializationBinder : DefaultSerializationBinder
     /// </summary>
     internal JsonSerializationAllowList AllowList => this._allowList;
 
+    /// <summary>
+    /// Registers a type on the RPC deserialization allow-list (#1651) after construction. Used by design-time extensions
+    /// (including Premium) to allow-list the contract types they send over the RPC channel. Always pass <c>typeof(...)</c>
+    /// so the resolved assembly identity matches under the <c>Metalama.Repacked</c> ILMerge in the VS extension.
+    /// </summary>
+    public void AddContractType( Type type ) => this._allowList.Add( type );
+
     public JsonSerializationBinder( Action<JsonSerializationBinderConfiguration>? configure = null )
     {
         var configuration = new JsonSerializationBinderConfiguration( this );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinder.cs
@@ -17,6 +17,12 @@ public sealed class JsonSerializationBinder : DefaultSerializationBinder
 {
     private readonly ConcurrentDictionary<string, Assembly> _assemblies = new();
     private readonly Dictionary<string, string> _assemblyNames = new();
+    private readonly JsonSerializationAllowList _allowList = new();
+
+    /// <summary>
+    /// Gets the per-type allow-list enforced by <see cref="BindToType"/> (security fix #1651 / GHSA-h26j-4vp7-x9w2).
+    /// </summary>
+    internal JsonSerializationAllowList AllowList => this._allowList;
 
     public JsonSerializationBinder( Action<JsonSerializationBinderConfiguration>? configure = null )
     {
@@ -33,7 +39,25 @@ public sealed class JsonSerializationBinder : DefaultSerializationBinder
         configuration.AddSystemLibrary( "System.Private.CoreLib" );
         configuration.AddSystemLibrary( "mscorlib" );
 
-        // Add additional assemblies.
+        // SECURITY (#1651 / GHSA-h26j-4vp7-x9w2): in addition to the assembly-level checks above, BindToType enforces a
+        // per-type allow-list. The wire uses TypeNameHandling.All, so without this an attacker who can write to the
+        // design-time pipe could name any type in an allow-listed assembly (e.g. System.Private.CoreLib) and have it
+        // instantiated before any application logic runs (an unsafe-deserialization / gadget-chain RCE primitive).
+        // System / collection / protocol types that legitimately travel on the wire:
+        configuration.AddType( typeof(ImmutableArray<>) );
+        configuration.AddType( typeof(ImmutableDictionary<,>) );
+        configuration.AddType( typeof(string) );
+        configuration.AddType( typeof(CommonErrorData) );
+
+        // RPC contract types defined in this assembly. Types from higher-level assemblies (Metalama.Framework.DesignTime,
+        // .Engine and core Metalama.Framework) are registered by the IJsonSerializationBinderProvider via 'configure' below.
+        configuration.AddType( typeof(ProjectKey) );
+        configuration.AddType( typeof(RpcEventEnvelope) );
+        configuration.AddType( typeof(RpcEventData) );
+        configuration.AddType( typeof(Notifications.CompilationResultChangedEventData) );
+        configuration.AddType( typeof(Notifications.EndpointChangedEventData) );
+
+        // Add additional assemblies and allow-listed types.
         configure?.Invoke( configuration );
     }
 
@@ -66,6 +90,17 @@ public sealed class JsonSerializationBinder : DefaultSerializationBinder
         var modifiedTypeName = JsonSerializationBinderHelper.QualifyAssemblies( typeName, this._assemblyNames );
 
         var type = assembly.GetType( modifiedTypeName );
+
+        // SECURITY (#1651 / GHSA-h26j-4vp7-x9w2): the wire uses TypeNameHandling.All, so an attacker who can write to the
+        // design-time named pipe can name an arbitrary loadable type and have it instantiated before any application logic
+        // runs. Assembly-level allow-listing is insufficient because allow-listed assemblies (e.g. Metalama.Framework.Engine,
+        // System.Private.CoreLib) contain dangerous types. Enforce the per-type allow-list here, the untrusted boundary.
+        if ( type != null && !this._allowList.IsAllowed( type ) )
+        {
+            throw new InvalidOperationException(
+                $"For security reasons, the type '{type.FullName}' from assembly '{assemblyName}' cannot be deserialized "
+                + "over the design-time RPC channel because it is not on the RPC type allow-list. See issue #1651." );
+        }
 
         return type;
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinderConfiguration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinderConfiguration.cs
@@ -64,9 +64,12 @@ public sealed class JsonSerializationBinderConfiguration
     public void AddType( Type type ) => this._binder.AllowList.Add( type );
 
     /// <summary>
-    /// Adds a type to the RPC deserialization allow-list (#1651) by name, for types that cannot be referenced at compile
-    /// time. Prefer <see cref="AddType(System.Type)"/> whenever the type can be referenced.
+    /// Adds a type to the RPC deserialization allow-list (#1651) by full name, <em>without loading it</em>. This is the
+    /// preferred overload for contract DTO types that implement a shared <c>Metalama.Framework.DesignTime.Contracts</c>
+    /// interface: loading such a type eagerly (via <c>typeof</c>) crashes in the multi-version design-time scenario when a
+    /// different version of the Contracts assembly is loaded in the process (issue #31075). The allow-list matches by full
+    /// name only, so the assembly is irrelevant.
     /// </summary>
-    public void AddType( string assemblyName, string fullName, bool isGenericDefinition = false )
-        => this._binder.AllowList.Add( assemblyName, fullName, isGenericDefinition );
+    public void AddType( string fullName, bool isGenericDefinition = false )
+        => this._binder.AllowList.Add( fullName, isGenericDefinition );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinderConfiguration.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/JsonSerializationBinderConfiguration.cs
@@ -55,4 +55,18 @@ public sealed class JsonSerializationBinderConfiguration
 
         this._binder.TryAddAssembly( assemblyName, assembly );
     }
+
+    /// <summary>
+    /// Adds a type to the RPC deserialization allow-list (#1651). Open generic definitions (e.g.
+    /// <c>typeof(ImmutableArray&lt;&gt;)</c>) are recorded as generic definitions; their type arguments are validated
+    /// recursively at deserialization time.
+    /// </summary>
+    public void AddType( Type type ) => this._binder.AllowList.Add( type );
+
+    /// <summary>
+    /// Adds a type to the RPC deserialization allow-list (#1651) by name, for types that cannot be referenced at compile
+    /// time. Prefer <see cref="AddType(System.Type)"/> whenever the type can be referenced.
+    /// </summary>
+    public void AddType( string assemblyName, string fullName, bool isGenericDefinition = false )
+        => this._binder.AllowList.Add( assemblyName, fullName, isGenericDefinition );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Extensibility/DesignTimeInitializationContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Extensibility/DesignTimeInitializationContext.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.DesignTime.CodeFixes;
+using Metalama.Framework.DesignTime.Rpc;
 using Metalama.Framework.DesignTime.Services;
 using Metalama.Framework.DesignTime.VisualStudio.ServiceProvider;
 using Metalama.Framework.Engine.Services;
@@ -40,4 +41,26 @@ public sealed class DesignTimeInitializationContext
     internal IReadOnlyList<IRpcServiceFactory> RpcServices => this._rpcServices;
 
     public void AddRpcService( IRpcServiceFactory serviceFactory ) => this._rpcServices.Add( serviceFactory );
+
+    /// <summary>
+    /// Registers types on the design-time RPC deserialization allow-list (security fix #1651 / GHSA-h26j-4vp7-x9w2).
+    /// An extension must call this for every type it sends over the RPC channel that is not already allow-listed by the
+    /// core framework (e.g. its own DTOs and any collection element/base types they reference); otherwise those types are
+    /// rejected on deserialization. Always pass <c>typeof(...)</c> so the resolved assembly identity is correct under the
+    /// <c>Metalama.Repacked</c> ILMerge in the VS extension.
+    /// </summary>
+    public void AddRpcContractTypes( params Type[] types )
+    {
+        var binderProvider = (IJsonSerializationBinderProvider?) this.ServiceProvider.Underlying.GetService( typeof(IJsonSerializationBinderProvider) );
+
+        if ( binderProvider == null )
+        {
+            return;
+        }
+
+        foreach ( var type in types )
+        {
+            binderProvider.Binder.AddContractType( type );
+        }
+    }
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/Rpc/JsonSerializationBinderProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/Rpc/JsonSerializationBinderProvider.cs
@@ -3,17 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Aspects;
-using Metalama.Framework.Code;
-using Metalama.Framework.DesignTime.AspectExplorer;
-using Metalama.Framework.DesignTime.CodeLens;
-using Metalama.Framework.DesignTime.Diagnostics;
-using Metalama.Framework.DesignTime.Preview;
 using Metalama.Framework.DesignTime.Rpc;
-using Metalama.Framework.DesignTime.VisualStudio.AspectExplorer;
-using Metalama.Framework.DesignTime.VisualStudio.CompileTimeCodeEditingStatus;
-using Metalama.Framework.DesignTime.VisualStudio.ServiceProvider;
-using Metalama.Framework.DesignTime.VisualStudio.SourceGenerating;
-using Metalama.Framework.Engine.DesignTime;
 
 namespace Metalama.Framework.DesignTime.VisualStudio.Rpc;
 
@@ -26,34 +16,39 @@ internal sealed class JsonSerializationBinderProvider : IJsonSerializationBinder
 
             // SECURITY (#1651 / GHSA-h26j-4vp7-x9w2): allow-list the DesignTime / Engine / core DTO types that ride the
             // JSON wire (the Rpc-assembly types and collections are registered by the JsonSerializationBinder ctor).
-            // This is the per-type complement to the assembly-level registrations above; under TypeNameHandling.All every
-            // one of these is named on the wire and resolved through BindToType.
+            // Under TypeNameHandling.All every one of these is named on the wire and resolved through BindToType.
+            //
+            // These are registered by full NAME rather than via typeof. Several of them implement a shared
+            // Metalama.Framework.DesignTime.Contracts interface (e.g. DiagnosticData : IDiagnosticData, CodeLensSummary :
+            // ICodeLensSummary), and force-loading such a type during binder construction throws a TypeLoadException in
+            // the multi-version design-time scenario (#31075) when a different version of the Contracts assembly is already
+            // loaded in the process. The allow-list matches by full name only, so no assembly identity is needed here.
 
             // Metalama.Framework.DesignTime DTOs.
-            configuration.AddType( typeof(AspectDatabaseAspectInstance) );
-            configuration.AddType( typeof(AspectDatabaseAspectTransformation) );
-            configuration.AddType( typeof(AspectClassesChangedEventData) );
-            configuration.AddType( typeof(AspectInstancesChangedEventData) );
-            configuration.AddType( typeof(CodeLensSummary) );
-            configuration.AddType( typeof(CodeLensDetailsTable) );
-            configuration.AddType( typeof(CodeLensDetailsHeader) );
-            configuration.AddType( typeof(CodeLensDetailsEntry) );
-            configuration.AddType( typeof(CodeLensDetailsField) );
-            configuration.AddType( typeof(DiagnosticData) );
-            configuration.AddType( typeof(CompileTimeEditingStatusChangedEventData) );
-            configuration.AddType( typeof(CompileTimeErrorsChangedEventData) );
-            configuration.AddType( typeof(RpcServiceInfo) );
-            configuration.AddType( typeof(ServicesAddedEventData) );
-            configuration.AddType( typeof(GeneratedSourceChangedEventData) );
-            configuration.AddType( typeof(SerializablePreviewTransformationResult) );
+            configuration.AddType( "Metalama.Framework.DesignTime.AspectExplorer.AspectDatabaseAspectInstance" );
+            configuration.AddType( "Metalama.Framework.DesignTime.AspectExplorer.AspectDatabaseAspectTransformation" );
+            configuration.AddType( "Metalama.Framework.DesignTime.VisualStudio.AspectExplorer.AspectClassesChangedEventData" );
+            configuration.AddType( "Metalama.Framework.DesignTime.VisualStudio.AspectExplorer.AspectInstancesChangedEventData" );
+            configuration.AddType( "Metalama.Framework.DesignTime.CodeLens.CodeLensSummary" );
+            configuration.AddType( "Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsTable" );
+            configuration.AddType( "Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsHeader" );
+            configuration.AddType( "Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsEntry" );
+            configuration.AddType( "Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsField" );
+            configuration.AddType( "Metalama.Framework.DesignTime.Diagnostics.DiagnosticData" );
+            configuration.AddType( "Metalama.Framework.DesignTime.VisualStudio.CompileTimeCodeEditingStatus.CompileTimeEditingStatusChangedEventData" );
+            configuration.AddType( "Metalama.Framework.DesignTime.VisualStudio.CompileTimeCodeEditingStatus.CompileTimeErrorsChangedEventData" );
+            configuration.AddType( "Metalama.Framework.DesignTime.VisualStudio.ServiceProvider.RpcServiceInfo" );
+            configuration.AddType( "Metalama.Framework.DesignTime.VisualStudio.ServiceProvider.ServicesAddedEventData" );
+            configuration.AddType( "Metalama.Framework.DesignTime.VisualStudio.SourceGenerating.GeneratedSourceChangedEventData" );
+            configuration.AddType( "Metalama.Framework.DesignTime.Preview.SerializablePreviewTransformationResult" );
 
             // Metalama.Framework.Engine DTOs.
-            configuration.AddType( typeof(SerializableSyntaxTree) );
-            configuration.AddType( typeof(SerializableAnnotation) );
+            configuration.AddType( "Metalama.Framework.Engine.DesignTime.SerializableSyntaxTree" );
+            configuration.AddType( "Metalama.Framework.Engine.DesignTime.SerializableAnnotation" );
 
             // Metalama.Framework (core) DTOs. SerializableDeclarationId is a struct serialized as an object (it appears as
             // a CodeLens RPC parameter); SerializableTypeId only ever crosses the wire in its string form, so it is not listed.
-            configuration.AddType( typeof(SerializableDeclarationId) );
+            configuration.AddType( "Metalama.Framework.Code.SerializableDeclarationId" );
 
 #if ROSLYN_4_8_0
             configuration.AddAssemblyWithSameVersionThanType( typeof(ProjectKey), "Metalama.Framework.DesignTime.4.8.0" );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/Rpc/JsonSerializationBinderProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/Rpc/JsonSerializationBinderProvider.cs
@@ -3,7 +3,17 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.DesignTime.AspectExplorer;
+using Metalama.Framework.DesignTime.CodeLens;
+using Metalama.Framework.DesignTime.Diagnostics;
+using Metalama.Framework.DesignTime.Preview;
 using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.DesignTime.VisualStudio.AspectExplorer;
+using Metalama.Framework.DesignTime.VisualStudio.CompileTimeCodeEditingStatus;
+using Metalama.Framework.DesignTime.VisualStudio.ServiceProvider;
+using Metalama.Framework.DesignTime.VisualStudio.SourceGenerating;
+using Metalama.Framework.Engine.DesignTime;
 
 namespace Metalama.Framework.DesignTime.VisualStudio.Rpc;
 
@@ -13,6 +23,37 @@ internal sealed class JsonSerializationBinderProvider : IJsonSerializationBinder
         configuration =>
         {
             configuration.AddAssemblyOfType( typeof(IAspect) );
+
+            // SECURITY (#1651 / GHSA-h26j-4vp7-x9w2): allow-list the DesignTime / Engine / core DTO types that ride the
+            // JSON wire (the Rpc-assembly types and collections are registered by the JsonSerializationBinder ctor).
+            // This is the per-type complement to the assembly-level registrations above; under TypeNameHandling.All every
+            // one of these is named on the wire and resolved through BindToType.
+
+            // Metalama.Framework.DesignTime DTOs.
+            configuration.AddType( typeof(AspectDatabaseAspectInstance) );
+            configuration.AddType( typeof(AspectDatabaseAspectTransformation) );
+            configuration.AddType( typeof(AspectClassesChangedEventData) );
+            configuration.AddType( typeof(AspectInstancesChangedEventData) );
+            configuration.AddType( typeof(CodeLensSummary) );
+            configuration.AddType( typeof(CodeLensDetailsTable) );
+            configuration.AddType( typeof(CodeLensDetailsHeader) );
+            configuration.AddType( typeof(CodeLensDetailsEntry) );
+            configuration.AddType( typeof(CodeLensDetailsField) );
+            configuration.AddType( typeof(DiagnosticData) );
+            configuration.AddType( typeof(CompileTimeEditingStatusChangedEventData) );
+            configuration.AddType( typeof(CompileTimeErrorsChangedEventData) );
+            configuration.AddType( typeof(RpcServiceInfo) );
+            configuration.AddType( typeof(ServicesAddedEventData) );
+            configuration.AddType( typeof(GeneratedSourceChangedEventData) );
+            configuration.AddType( typeof(SerializablePreviewTransformationResult) );
+
+            // Metalama.Framework.Engine DTOs.
+            configuration.AddType( typeof(SerializableSyntaxTree) );
+            configuration.AddType( typeof(SerializableAnnotation) );
+
+            // Metalama.Framework (core) DTOs. SerializableDeclarationId is a struct serialized as an object (it appears as
+            // a CodeLens RPC parameter); SerializableTypeId only ever crosses the wire in its string form, so it is not listed.
+            configuration.AddType( typeof(SerializableDeclarationId) );
 
 #if ROSLYN_4_8_0
             configuration.AddAssemblyWithSameVersionThanType( typeof(ProjectKey), "Metalama.Framework.DesignTime.4.8.0" );

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/BaseTestRunner.cs
@@ -943,7 +943,7 @@ internal abstract partial class BaseTestRunner
             if ( ns.ContainsOrdinal( "Microsoft.CSharp.RuntimeBinder" ) &&
                  string.Equals( typeName, "CSharpArgumentInfo", StringComparison.Ordinal ) )
             {
-                var directory = Path.Combine( MetalamaPathUtilities.GetTempPath(), "Metalama", "InvalidAssemblies" );
+                var directory = Path.Combine( MetalamaPathUtilities.GetTempDirectory(), "InvalidAssemblies" );
 
                 if ( !this._fileSystem.DirectoryExists( directory ) )
                 {

--- a/Metalama.Framework/src/Metalama.Testing.UnitTesting/MemoryDumpHelper.cs
+++ b/Metalama.Framework/src/Metalama.Testing.UnitTesting/MemoryDumpHelper.cs
@@ -41,7 +41,7 @@ public static class MemoryDumpHelper
         {
             DotMemory.Init();
             var dotMemoryConfig = new DotMemory.Config();
-            var path = Path.Combine( MetalamaPathUtilities.GetTempPath(), "Metalama", "MemoryDumps" );
+            var path = Path.Combine( MetalamaPathUtilities.GetTempDirectory(), "MemoryDumps" );
             dotMemoryConfig.SaveToDir( path );
 
             DotMemory.GetSnapshotOnce( dotMemoryConfig );

--- a/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestProjectOptions.cs
+++ b/Metalama.Framework/src/Metalama.Testing.UnitTesting/TestProjectOptions.cs
@@ -54,7 +54,7 @@ internal sealed class TestProjectOptions : DefaultProjectOptions, IDisposable
         this._properties = contextOptions.Properties;
 
         // We don't use the backstage TempFileManager because it would generate paths that are too long.
-        var baseDirectory = Path.Combine( MetalamaPathUtilities.GetTempPath(), "Metalama", "Tests", Guid.NewGuid().ToString() );
+        var baseDirectory = Path.Combine( MetalamaPathUtilities.GetTempDirectory(), "Tests", Guid.NewGuid().ToString() );
 
         if ( contextOptions.TempPathLength.HasValue )
         {

--- a/Metalama.Framework/src/tests/Metalama.Framework.TestApp/Metalama.Framework.TestApp.TestRunner/Metalama.Framework.TestApp.TestRunner.csproj
+++ b/Metalama.Framework/src/tests/Metalama.Framework.TestApp/Metalama.Framework.TestApp.TestRunner/Metalama.Framework.TestApp.TestRunner.csproj
@@ -5,7 +5,7 @@
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <EnableDefaultItems>false</EnableDefaultItems>
   </PropertyGroup>
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/JsonRpcSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/JsonRpcSerializationTests.cs
@@ -1,0 +1,116 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.DesignTime.Rpc.Notifications;
+using Metalama.Framework.DesignTime.VisualStudio.Rpc;
+using Newtonsoft.Json;
+using System;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Remoting;
+
+/// <summary>
+/// Round-trip and security tests for the JSON RPC wire path (#1651 / GHSA-h26j-4vp7-x9w2). The serializer settings
+/// mirror <c>BaseEndpoint.CreateRpc</c> (<see cref="TypeNameHandling.All"/> + the production
+/// <see cref="JsonSerializationBinder"/>), so these tests exercise the real wire path and its per-type allow-list.
+/// </summary>
+public sealed class JsonRpcSerializationTests
+{
+    private static readonly JsonSerializerSettings _settings = CreateSettings();
+
+    private static JsonSerializerSettings CreateSettings()
+        => new()
+        {
+            TypeNameHandling = TypeNameHandling.All,
+            TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Simple,
+            SerializationBinder = new JsonSerializationBinderProvider().Binder
+        };
+
+    private static T Roundtrip<T>( T value ) => JsonConvert.DeserializeObject<T>( JsonConvert.SerializeObject( value, typeof(T), _settings ), _settings )!;
+
+    [Fact]
+    public void ProjectKey_Roundtrip()
+    {
+        var original = new ProjectKey( "MyAssembly", 12345UL, true );
+        var result = Roundtrip( original );
+
+        Assert.Equal( original.AssemblyName, result.AssemblyName );
+        Assert.Equal( original.PreprocessorSymbolHashCode, result.PreprocessorSymbolHashCode );
+    }
+
+    [Fact]
+    public void RpcEventEnvelope_PolymorphicData_Roundtrip()
+    {
+        // RpcEventEnvelope.Data is the abstract RpcEventData, so the concrete type name (and the nested
+        // ImmutableArray<string>) are written on the wire and resolved through the allow-list on read.
+        var original = new RpcEventEnvelope(
+            "TestApi",
+            new CompilationResultChangedEventData(
+                new ProjectKey( "Test", 123UL, true ),
+                false,
+                ImmutableArray.Create( "file1.cs", "file2.cs" ) ) );
+
+        var result = Roundtrip( original );
+
+        var data = Assert.IsType<CompilationResultChangedEventData>( result.Data );
+        Assert.True( data.SyntaxTreePaths.SequenceEqual( new[] { "file1.cs", "file2.cs" } ) );
+    }
+
+    [Fact]
+    public void OnContractType_AllowedThroughObjectPath()
+    {
+        // An allow-listed type must still round-trip through the typeless ('object'-typed) path.
+        object original = new ProjectKey( "MyAssembly", 12345UL, true );
+
+        var json = JsonConvert.SerializeObject( original, typeof(object), _settings );
+        var result = JsonConvert.DeserializeObject<object>( json, _settings );
+
+        Assert.Equal( "MyAssembly", Assert.IsType<ProjectKey>( result ).AssemblyName );
+    }
+
+    [Fact]
+    public void OffContractType_RejectedOnDeserialize()
+    {
+        // Models an attacker-chosen gadget: a type NOT on the allow-list, serialized through the object path so its
+        // $type is written. Serialization is unguarded (the attacker crafts arbitrary bytes); the guard is on the
+        // deserialization side, which is the untrusted boundary.
+        var json = JsonConvert.SerializeObject( new OffContractGadget(), typeof(object), _settings );
+
+        AssertRejectedByAllowList( () => JsonConvert.DeserializeObject<object>( json, _settings ) );
+    }
+
+    [Fact]
+    public void OffContractEventData_RejectedInEnvelope()
+    {
+        // An RpcEventData subclass that is not on the allow-list must be rejected when it rides the abstract Data slot.
+        var json = JsonConvert.SerializeObject( new RpcEventEnvelope( "TestApi", new OffContractEventData() ), _settings );
+
+        AssertRejectedByAllowList( () => JsonConvert.DeserializeObject<RpcEventEnvelope>( json, _settings ) );
+    }
+
+    private static void AssertRejectedByAllowList( Func<object?> deserialize )
+    {
+        var exception = Record.Exception( () => deserialize() );
+
+        Assert.NotNull( exception );
+
+        // Newtonsoft wraps binder exceptions in JsonSerializationException; the #1651 marker survives in ToString().
+        Assert.Contains( "#1651", exception!.ToString() );
+    }
+}
+
+/// <summary>An <see cref="RpcEventData"/> subclass deliberately NOT on the allow-list (models an attacker-controlled event).</summary>
+internal sealed class OffContractEventData : RpcEventData
+{
+    public override string Category => nameof(OffContractEventData);
+}
+
+/// <summary>A type deliberately NOT on the allow-list, standing in for an attacker-chosen gadget.</summary>
+internal sealed class OffContractGadget
+{
+    public string Payload { get; set; } = "pwned";
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/JsonRpcSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/JsonRpcSerializationTests.cs
@@ -92,6 +92,25 @@ public sealed class JsonRpcSerializationTests
         AssertRejectedByAllowList( () => JsonConvert.DeserializeObject<RpcEventEnvelope>( json, _settings ) );
     }
 
+    [Fact]
+    public void AddContractType_InvalidatesRejectionCache()
+    {
+        // Regression for the allow-list cache (#1651): a type rejected — and cached as denied — before it is registered
+        // through the late-registration seam must be accepted once AddContractType is called.
+        var binder = new JsonSerializationBinder();
+        binder.BindToName( typeof(OffContractGadget), out var assemblyName, out var typeName );
+        assemblyName = JsonSerializationBinderHelper.RemoveAssemblyDetailsFromAssemblyName( assemblyName! );
+        typeName = JsonSerializationBinderHelper.RemoveAssemblyDetailsFromTypeName( typeName! );
+
+        // Initially off-contract: rejected, and the rejection is cached.
+        Assert.Throws<InvalidOperationException>( () => binder.BindToType( assemblyName, typeName ) );
+
+        // Register the type after the rejection has been cached; the cached decision must be invalidated.
+        binder.AddContractType( typeof(OffContractGadget) );
+
+        Assert.Same( typeof(OffContractGadget), binder.BindToType( assemblyName, typeName ) );
+    }
+
     private static void AssertRejectedByAllowList( Func<object?> deserialize )
     {
         var exception = Record.Exception( () => deserialize() );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/SerializationBinderTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/SerializationBinderTests.cs
@@ -20,6 +20,29 @@ public sealed class SerializationBinderTests
     [InlineData( typeof(ProjectKey) )]
     [InlineData( typeof(ImmutableArray<string>) )]
     [InlineData( typeof(ImmutableArray<ProjectKey>) )]
+
+    // Every contract DTO type must be on the #1651 allow-list. These are registered by full-name string in
+    // JsonSerializationBinderProvider (not via typeof, to avoid the multi-version eager-load crash of #31075), so this
+    // theory guards against a typo in those strings: a mismatch makes BindToType reject the type and fails the test.
+    [InlineData( typeof(Metalama.Framework.DesignTime.AspectExplorer.AspectDatabaseAspectInstance) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.AspectExplorer.AspectDatabaseAspectTransformation) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.VisualStudio.AspectExplorer.AspectClassesChangedEventData) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.VisualStudio.AspectExplorer.AspectInstancesChangedEventData) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.CodeLens.CodeLensSummary) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsTable) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsHeader) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsEntry) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.CodeLens.CodeLensDetailsField) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.Diagnostics.DiagnosticData) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.VisualStudio.CompileTimeCodeEditingStatus.CompileTimeEditingStatusChangedEventData) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.VisualStudio.CompileTimeCodeEditingStatus.CompileTimeErrorsChangedEventData) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.VisualStudio.ServiceProvider.RpcServiceInfo) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.VisualStudio.ServiceProvider.ServicesAddedEventData) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.VisualStudio.SourceGenerating.GeneratedSourceChangedEventData) )]
+    [InlineData( typeof(Metalama.Framework.DesignTime.Preview.SerializablePreviewTransformationResult) )]
+    [InlineData( typeof(Metalama.Framework.Engine.DesignTime.SerializableSyntaxTree) )]
+    [InlineData( typeof(Metalama.Framework.Engine.DesignTime.SerializableAnnotation) )]
+    [InlineData( typeof(Metalama.Framework.Code.SerializableDeclarationId) )]
     public void Binder( Type type )
     {
         this._binder.BindToName( type, out var assemblyName, out var typeName );


### PR DESCRIPTION
## Summary
Backports two security advisories from `develop/2026.1` to 2025.1.

- **#1650 / GHSA-m6wq-39m7-9xpp** — Relocate the temp directory off world-writable `/tmp` on Unix. Metalama loads and executes assemblies from its temp directory; on Unix `Path.GetTempPath()` (`/tmp`) is world-writable, letting another local user plant a DLL. The temp directory now lives under the per-user application-data directory on Unix (Windows unchanged, `%TEMP%` is already per-user). Adds `IRuntimeInformation` so both branches are unit-testable; the cache clean-up sweeps the legacy `/tmp/Metalama`; `ResourceExtractor` mirrors the relocation independently.
- **#1651 / GHSA-h26j-4vp7-x9w2** — Enforce a per-type allow-list on the design-time RPC deserialization. 2025.1 predates the MessagePack migration and is in the JSON era (Newtonsoft `TypeNameHandling.All`), so this hardens `JsonSerializationBinder.BindToType` into a closed allow-list (`JsonSerializationAllowList`): only registered contract/collection types plus scalar primitives may be deserialized, with recursive generic-argument and array-element validation. Adds an extension seam (`AddContractType` / `AddRpcContractTypes`) so design-time extensions (including Premium) register the types they put on the wire.

## Notes
- The companion PR in `metalama/Metalama.Premium` registers the code-fix RPC wire types against the new allow-list.
- One pre-existing, environment-specific test (`ConfigurationManagerTests.OutsideModification`, a file-watcher timeout) fails in the Docker container regardless of this change and is unrelated to it; all other affected tests pass locally (Backstage 1175, Framework 1361).

Backports #1650 and #1651.