### PR TITLE
Merge security backport (#1650, #1651) into 2026.0

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/JsonRpcSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Remoting/JsonRpcSerializationTests.cs
@@ -118,7 +118,7 @@ public sealed class JsonRpcSerializationTests
         Assert.NotNull( exception );
 
         // Newtonsoft wraps binder exceptions in JsonSerializationException; the #1651 marker survives in ToString().
-        Assert.Contains( "#1651", exception!.ToString() );
+        Assert.Contains( "#1651", exception!.ToString(), StringComparison.Ordinal );
     }
 }
 


### PR DESCRIPTION
## Summary
- Merge the security backport branch (`topic/2025.1/security-backport-1650-1651`) into 2026.0.
- Enforce a per-type allow-list on RPC JSON deserialization (#1651), with a design-time extension seam to register allow-list contract types, allow-list cache invalidation on contract-type registration, and registration of allow-list types by name to avoid a multi-version crash.
- Relocate the temp directory off the world-writable `/tmp` on Unix (#1650).
- Fix DevHub assembly loading causing `MissingMethodException` in VS 2026 (#1461).

## Merge Notes
- All conflicts were confined to `Metalama.Backstage`. `IRuntimeInformation`, `RuntimeInformationProvider` and `TestRuntimeInformation` were resolved to the union (adding the `ProcessKind` member). `TestsBase.cs` was reconciled to the existing 2026.0 DI pattern — the backport's 2025.1-era standalone `RuntimeInformation` field was redundant and would have produced a duplicate `IRuntimeInformation` registration.
- Framework RPC files merged without conflict.

## Validation
- `Metalama.Backstage` builds clean; tests pass (1218/1219 net8.0, 1219/1220 net472). The single failure is `ConfigurationManagerTests.OutsideModification`, a `FileSystemWatcher` test that does not fire in Docker Windows containers — unrelated to this merge.
- Framework-side validation requires a full `Build.ps1 build` (cross-solution dependency) and is left to CI.

## Issues Fixed
- #1650 - Relocate temp directory off world-writable /tmp on Unix
- #1651 - Enforce per-type allow-list on RPC JSON deserialization
- #1461 - DevHub assembly loading causing MissingMethodException in VS 2026

— Claude for @gfraiteur