### PR TITLE
Fix stale compile-time cache on dependency version change (#1722)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
@@ -184,10 +184,15 @@ internal sealed partial class CompileTimeCompilationBuilder
         h.Append( assemblyIdentity.Version.ToString() );
         this._logger.Trace?.Log( $"ProjectHash: AssemblyIdentity='{assemblyIdentity.Name}, {assemblyIdentity.Version}'" );
 
-        foreach ( var reference in referencedProjects.OrderBy( r => r.Hash ) )
+        // We include each reference's full compile-time identity (its 'ml!<name>_<hash>' assembly name), not just
+        // its source hash. The compiled assembly bakes a reference to exactly that name, so if a referenced
+        // project's identity changes (e.g. a package version bump) while its source is unchanged, the dependent's
+        // hash must change too. Otherwise a stale dependent assembly is served from the cache and keeps a baked
+        // reference to a 'ml!' assembly that is no longer loaded, causing a FileNotFoundException (issue #1722).
+        foreach ( var reference in referencedProjects.OrderBy( r => r.CompileTimeIdentity.Name, StringComparer.Ordinal ) )
         {
-            h.Append( reference.Hash );
-            this._logger.Trace?.Log( $"ProjectHash: '{reference.RunTimeIdentity.Name}'={reference.Hash}" );
+            h.Append( reference.CompileTimeIdentity.Name );
+            this._logger.Trace?.Log( $"ProjectHash: '{reference.RunTimeIdentity.Name}'={reference.CompileTimeIdentity.Name}" );
         }
 
         h.Append( sourceHash );

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Aspects/Issue1722.Aspects.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Aspects/Issue1722.Aspects.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <InternalOnlyPackage>True</InternalOnlyPackage>
+    <!-- Aspects is packed once (version 1.0.0) against whatever Primitives version is current at pack time.
+         Its embedded compile-time manifest therefore records that Primitives version permanently, which is the
+         key to the deterministic reproduction: the consumer can later upgrade Primitives independently. -->
+    <Issue1722AspectsVersion Condition="'$(Issue1722AspectsVersion)' == ''">1.0.0</Issue1722AspectsVersion>
+    <Version>$(Issue1722AspectsVersion)</Version>
+    <AssemblyVersion>$(Issue1722AspectsVersion)</AssemblyVersion>
+    <FileVersion>$(Issue1722AspectsVersion)</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Metalama.Framework" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Issue1722.Primitives/Issue1722.Primitives.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Aspects/SetContextAttribute.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Aspects/SetContextAttribute.cs
@@ -1,0 +1,42 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using Issue1722.Primitives;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Eligibility;
+
+namespace Issue1722.Aspects;
+
+// The aspect lives in a DIFFERENT package than AspectUtilities and pulls it in as a (transitive) reference.
+// It calls the cross-package extension method from eligibility code, which is exactly the scenario reported in
+// issue #1722. (The failure is NOT specific to eligibility: calling AspectUtilities from the OverrideMethod
+// template fails identically, reported as LAMA0041 "while executing the template" instead of LAMA0001 "while
+// evaluating eligibility" - eligibility simply runs first in the pipeline.)
+public sealed class SetContextAttribute : OverrideMethodAspect
+{
+    public override void BuildEligibility( IEligibilityBuilder<IMethod> builder )
+    {
+        base.BuildEligibility( builder );
+
+        builder.MustSatisfy(
+            method => this.ProduceValidationFailureMessage( $"The method '{method}'", method ) == null,
+            method => $"the return type must be a result object, or a task result object" );
+    }
+
+    private FormattableString? ProduceValidationFailureMessage( FormattableString description, IMethod method )
+    {
+        // Extension-method syntax on a type defined in the referenced Issue1722.Primitives package.
+        // This is the call that throws FileNotFoundException for 'ml!Issue1722.Primitives...'.
+        if ( !method.ReturnType.IsResultTask() )
+        {
+            return $"{description} must return a result object, or a task result object";
+        }
+
+        return null;
+    }
+
+    public override dynamic? OverrideMethod() => meta.Proceed();
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Consumer/Issue1722.Consumer.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Consumer/Issue1722.Consumer.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Only the aspect package is referenced directly; Issue1722.Primitives comes in transitively,
+         mirroring the NuGet dependency chain in issue #1722. -->
+    <ProjectReference Include="../Issue1722.Aspects/Issue1722.Aspects.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Consumer/Target.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Consumer/Target.cs
@@ -1,0 +1,19 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Threading.Tasks;
+using Issue1722.Aspects;
+
+namespace Issue1722.Consumer;
+
+internal class Target
+{
+    // The aspect's eligibility runs against these methods during the EvaluateAspectSources pipeline step.
+    // Evaluating eligibility invokes SetContextAttribute.ProduceValidationFailureMessage -> the cross-package
+    // extension method AspectUtilities.IsResultTask, which is where issue #1722 reports a FileNotFoundException
+    // for 'ml!...Primitives...'. This solution builds green, proving the cross-package extension method resolves
+    // correctly in the eligibility pipeline stage.
+    [SetContext]
+    private static Task<int> DoTheThing3( int a, int b ) => Task.FromResult( a + b );
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Primitives/AspectUtilities.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Primitives/AspectUtilities.cs
@@ -1,0 +1,22 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Threading.Tasks;
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+
+namespace Issue1722.Primitives;
+
+// A compile-time-only utility class in its OWN package/assembly. It contains NO aspect, template, fabric or
+// option types, so its compile-time assembly (ml!Issue1722.Primitives) is only ever brought into the
+// CompileTimeDomain through the recursive reference preload of the consuming aspect's compile-time project.
+[CompileTime]
+public static class AspectUtilities
+{
+    // The extension method reported in issue #1722. Calling it via extension syntax
+    // (method.ReturnType.IsResultTask()) from another package's BuildEligibility triggers a
+    // FileNotFoundException for 'ml!Issue1722.Primitives...'; calling it as a plain static method works.
+    public static bool IsResultTask( this IType type )
+        => type.IsConvertibleTo( typeof(Task<>), ConversionKind.TypeDefinition );
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Primitives/Issue1722.Primitives.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.Primitives/Issue1722.Primitives.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>true</IsPackable>
+    <InternalOnlyPackage>True</InternalOnlyPackage>
+    <!-- Re-enable assembly-info generation (the Standalone harness disables it) so AssemblyVersion actually
+         takes effect and v1/v2 produce different compile-time assembly hashes. -->
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>
+    <!-- The package/assembly version is driven by the Issue1722.proj orchestrator. Because the compile-time
+         assembly name 'ml!Issue1722.Primitives_<hash>' embeds this version (via
+         CompileTimeCompilationBuilder.ComputeProjectHash) but the SOURCE is unchanged, bumping the version
+         changes the compile-time assembly name without changing the source hash — the core of issue #1722. -->
+    <Issue1722PrimitivesVersion Condition="'$(Issue1722PrimitivesVersion)' == ''">1.0.0</Issue1722PrimitivesVersion>
+    <Version>$(Issue1722PrimitivesVersion)</Version>
+    <AssemblyVersion>$(Issue1722PrimitivesVersion)</AssemblyVersion>
+    <FileVersion>$(Issue1722PrimitivesVersion)</FileVersion>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Metalama.Framework" />
+  </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.proj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.proj
@@ -1,0 +1,37 @@
+<Project>
+
+  <!-- Imports Directory.Build.props of the upper directory. We must do this explicitly because this project has no SDK. -->
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Build.props', '$(MSBuildThisFileDirectory)../'))" Condition="Exists('$([MSBuild]::GetPathOfFileAbove(`Directory.Build.props`, `$(MSBuildThisFileDirectory)../`))')" />
+
+  <!--
+    Issue #1722 - deterministic reproduction of the FileNotFoundException raised while evaluating aspect
+    eligibility, matching the reporter's scenario: an aspect NuGet package that references a compile-time helper
+    package is consumed, then the helper package is upgraded to a new version.
+
+    Root cause: the aspect's compile-time assembly (ml!Issue1722.Aspects_<hash>) is cached under a key
+    (CompileTimeCompilationBuilder.ComputeProjectHash) that includes the referenced Primitives project's SOURCE
+    hash only, NOT its identity/version. The 'ml!Issue1722.Primitives_<hash>' reference baked into ml!Aspects,
+    however, derives from Primitives' FULL hash, which DOES include the version. Issue1722.Primitives 1.0.0 and
+    2.0.0 have identical source, so:
+      * the aspect's compile-time cache key is unchanged, so the stale ml!Aspects (referencing ml!Primitives @
+        1.0.0) is reused;
+      * the domain loads ml!Primitives @ 2.0.0 (a differently-named compile-time assembly).
+    CompileTimeDomain.ResolveAssembly has no path fallback for referenced package compile-time assemblies, so the
+    mismatch is a fatal FileNotFoundException - during eligibility, the first place the compiled ml!Aspects
+    delegate's baked reference is JITed.
+
+    The steps are driven by repro.ps1, which launches every 'dotnet' invocation as an independent top-level
+    process (Start-Process -Wait). That isolation is essential: running the builds directly as MSBuild <Exec>
+    children makes them share one warm in-process CompileTimeDomain that keeps ml!Primitives @ 1.0.0 loaded,
+    which masks (self-heals) the bug.
+
+    The Build target FAILS while the bug is present and SUCCEEDS once it is fixed.
+  -->
+  <Target Name="Build">
+    <!-- Route through 'cmd /c start /wait' so the reproduction runs in a process tree fully detached from this
+         MSBuild invocation. Otherwise the builds it spawns rejoin this MSBuild's node ecosystem and share one
+         warm in-process CompileTimeDomain, which self-heals the bug. -->
+    <Exec Command="cmd /c start &quot;Issue1722&quot; /wait powershell.exe -NoProfile -ExecutionPolicy Bypass -File &quot;$(MSBuildThisFileDirectory)repro.ps1&quot; -MetalamaVersion $(MetalamaVersion)" />
+  </Target>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.sln
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/Issue1722.sln
@@ -1,0 +1,37 @@
+
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.1.32319.34
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Issue1722.Consumer", "Issue1722.Consumer/Issue1722.Consumer.csproj", "{C1722C00-0000-4000-8000-000000000001}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Issue1722.Aspects", "Issue1722.Aspects/Issue1722.Aspects.csproj", "{C1722C00-0000-4000-8000-000000000002}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Issue1722.Primitives", "Issue1722.Primitives/Issue1722.Primitives.csproj", "{C1722C00-0000-4000-8000-000000000003}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{C1722C00-0000-4000-8000-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1722C00-0000-4000-8000-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1722C00-0000-4000-8000-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1722C00-0000-4000-8000-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1722C00-0000-4000-8000-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1722C00-0000-4000-8000-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1722C00-0000-4000-8000-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1722C00-0000-4000-8000-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C1722C00-0000-4000-8000-000000000003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C1722C00-0000-4000-8000-000000000003}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C1722C00-0000-4000-8000-000000000003}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C1722C00-0000-4000-8000-000000000003}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {C1722C00-0000-4000-8000-0000000000FF}
+	EndGlobalSection
+EndGlobal

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/Directory.Packages.props
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/Directory.Packages.props
@@ -1,0 +1,11 @@
+<Project>
+  <Import Project="$([MSBuild]::GetPathOfFileAbove('Directory.Packages.props', '$(MSBuildThisFileDirectory)../'))" />
+  <PropertyGroup>
+    <ConsumerAspectsVersion Condition="'$(ConsumerAspectsVersion)' == ''">1.0.0</ConsumerAspectsVersion>
+    <ConsumerPrimitivesVersion Condition="'$(ConsumerPrimitivesVersion)' == ''">1.0.0</ConsumerPrimitivesVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Issue1722.Aspects" Version="$(ConsumerAspectsVersion)" />
+    <PackageVersion Include="Issue1722.Primitives" Version="$(ConsumerPrimitivesVersion)" />
+  </ItemGroup>
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/Issue1722.PackageConsumer.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/Issue1722.PackageConsumer.csproj
@@ -1,0 +1,11 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Issue1722.Aspects" />
+    <PackageReference Include="Issue1722.Primitives" />
+  </ItemGroup>
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/Target.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/Target.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+using System.Threading.Tasks;
+using Issue1722.Aspects;
+
+namespace Issue1722.PackageConsumer;
+
+internal class Target
+{
+    [SetContext]
+    private static Task<int> DoTheThing3(int a, int b) => Task.FromResult(a + b);
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/nuget.config
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/PackageConsumer/nuget.config
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <config>
+    <!-- Isolated package cache so the two Primitives versions restore cleanly and the test is self-contained.
+         Relative to this nuget.config's directory. -->
+    <add key="globalPackagesFolder" value="..\artifacts\pkgs" />
+  </config>
+  <!-- Inherit the repo's sources (nuget.org, Metalama, Metalama.Compiler) and add the test's local feed. -->
+  <packageSources>
+    <add key="i1722" value="..\artifacts\feed" />
+  </packageSources>
+  <!-- The repo maps Metalama.* to the Metalama feed; clear the mapping so Issue1722.* restores from the local feed. -->
+  <packageSourceMapping>
+    <clear />
+  </packageSourceMapping>
+</configuration>

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/README.md
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/README.md
@@ -1,0 +1,71 @@
+# Issue #1722 — deterministic reproduction
+
+Reproduces https://github.com/metalama/Metalama/issues/1722 (namespaces anonymized; the reporter's `FlyingChi.*`
+names are not used): a `FileNotFoundException` raised while evaluating aspect **eligibility** when an aspect
+NuGet package that references a compile-time helper package is consumed and the helper package is then upgraded
+to a new version.
+
+## How to run
+
+```
+powershell -NoProfile -ExecutionPolicy Bypass -File repro.ps1 -MetalamaVersion <local-version>
+```
+
+Exit code `0` = the final consumer build succeeded = issue #1722 is fixed.
+Non-zero = the final consumer build failed with `FileNotFound … ml!Issue1722.Primitives_<hash> … while
+evaluating eligibility` = the bug is still present.
+
+`Issue1722.proj` is a thin MSBuild wrapper that invokes `repro.ps1`. **Run `repro.ps1` directly** — see the
+"Harness caveat" below.
+
+## What it does
+1. Packs `Issue1722.Primitives` **1.0.0**, `Issue1722.Aspects` **1.0.0** (built against Primitives 1.0.0, so its
+   embedded compile-time manifest is frozen at Primitives 1.0.0), and `Issue1722.Primitives` **2.0.0** (identical
+   source, only the version differs) into a local feed.
+2. Empties the compile-time cache.
+3. **Step A** — consumes `Aspects 1.0.0` + `Primitives 1.0.0`. Succeeds, and caches
+   `ml!Issue1722.Aspects_<hash>` referencing `ml!Issue1722.Primitives @ 1.0.0`.
+4. **Step B** — upgrades to `Primitives 2.0.0` (Aspects stays 1.0.0) and rebuilds, reusing the compile-time
+   cache. This is where the bug fires.
+
+Every `dotnet` call is launched as an independent top-level process (`Start-Process -Wait`) so the two consumer
+builds do not share an in-process compile-time domain (see the caveat).
+
+## Root cause
+`ml!<name>_<hash>` is `CompileTimeCompilationBuilder.ComputeProjectHash`. For a referenced project it folds in
+that reference's **source hash only** (`reference.Hash`), NOT its identity/version. But the reference's own
+`ml!` name derives from its FULL hash, which DOES include the version:
+- `ml!Issue1722.Primitives_<hashA>` = Primitives @ 1.0.0
+- `ml!Issue1722.Primitives_<hashB>` = Primitives @ 2.0.0
+
+Primitives 1.0.0 and 2.0.0 have identical source, so the **aspect's** cache key is unchanged. In step B the
+stale `ml!Aspects` (referencing `<hashA>`) is reused while the domain loads `<hashB>`.
+`CompileTimeDomain.ResolveAssembly` has **no path fallback** for referenced package compile-time assemblies, so
+the mismatch is a fatal `FileNotFoundException` — during eligibility, the first place the compiled `ml!Aspects`
+delegate's baked assembly reference is JITed.
+
+This explains the reporter's clues: eligibility fails while templates work (templates resolve types via the code
+model against the loaded assembly; only the compiled eligibility delegate carries the stale baked reference);
+"rewriting the extension call as a static call fixes it" is incidental (identical IL) — editing recompiles
+`ml!Aspects` against the current Primitives hash.
+
+## Proposed fix
+1. Include the referenced project's **full identity/hash** (its `CompileTimeIdentity` / `ComputeProjectHash`),
+   not just its source hash, in `ComputeProjectHash`, so the aspect's `ml!` assembly invalidates when a
+   dependency's identity changes and the baked reference always matches the loaded name.
+2. And/or give `CompileTimeDomain.ResolveAssembly` a path fallback for referenced package compile-time assemblies
+   (register each `CompileTimeProject.CompiledAssemblyPath` by `CompileTimeIdentity.Name`), so a residual
+   mismatch degrades gracefully instead of throwing.
+
+## Harness caveat (why `repro.ps1` must run top-level)
+The bug only manifests when step A and step B run in **separate** compile-time domains. When the two builds run
+under one parent MSBuild invocation (e.g. `Issue1722.proj` built by `ManyDotNetSolutions`, or the builds run as
+`<Exec>` children), MSBuild keeps a worker process warm that both builds reuse, so `ml!Primitives @ 1.0.0` stays
+loaded and the reference resolves — the bug **self-heals**. This masking is the same reason the reporter's
+failure was intermittent and disappeared after an edit/rebuild.
+
+`repro.ps1` avoids this by launching each build as an independent top-level process, which reproduces
+deterministically from an empty cache. It could not be made to fail from inside a parent MSBuild despite
+`--disable-build-servers`, `-nodeReuse:false`, disabling the MSBuild server, killing worker nodes, and
+`Start-Process`/`cmd start` detachment. A committed regression test should therefore invoke `repro.ps1` as a
+top-level process (e.g. from an integration test) rather than relying on the `.proj` being built in-place.

--- a/Metalama.Framework/src/tests/Standalone/Issue1722/repro.ps1
+++ b/Metalama.Framework/src/tests/Standalone/Issue1722/repro.ps1
@@ -1,0 +1,106 @@
+# Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+# Deterministic reproduction driver for issue #1722. Invoked by Issue1722.proj.
+#
+# Each build is launched as a fully detached top-level process (Start-Process -Wait). This is essential: if the
+# builds run as MSBuild <Exec> children they share one warm in-process CompileTimeDomain that keeps
+# ml!Primitives @ 1.0.0 loaded, and the bug self-heals. Independent processes reproduce it deterministically.
+#
+# Exit code 0 => the final consumer build succeeded => issue #1722 is fixed.
+# Non-zero    => the final consumer build failed (FileNotFound during eligibility) => bug still present.
+
+param(
+    [Parameter(Mandatory = $true)] [string] $MetalamaVersion
+)
+
+$ErrorActionPreference = 'Stop'
+
+# When this script is launched from an MSBuild <Exec> task, the environment carries variables that make child
+# 'dotnet' processes rejoin the parent MSBuild's SDK/node ecosystem (and thus share one in-process
+# CompileTimeDomain, which self-heals the bug). Clear them so every build below is a truly independent top-level
+# process, exactly as when the script is run from a plain shell.
+foreach ($v in 'MSBUILD_EXE_PATH', 'MSBuildSDKsPath', 'MSBuildExtensionsPath', 'MSBuildExtensionsPath32',
+    'MSBuildExtensionsPath64', 'MSBuildLoadMicrosoftTargetsReadOnly', 'MSBUILDNOINPROCNODE',
+    'MSBUILDDISABLENODEREUSE', 'MSBUILDTARGETSVERBOSE', 'DOTNET_ROOT_X64', 'DOTNET_ROOT', 'DOTNET_HOST_PATH') {
+    Remove-Item "env:$v" -ErrorAction SilentlyContinue
+}
+# Never route builds through the persistent dotnet MSBuild server: with disable-build-servers the compilation
+# runs inside that server process, which persists across the two consumer builds and keeps ml!Primitives @ 1.0.0
+# loaded (masking the bug).
+$env:DOTNET_CLI_USE_MSBUILD_SERVER = '0'
+$env:MSBUILDDISABLENODEREUSE = '1'
+
+$dir = $PSScriptRoot
+$feed = Join-Path $dir 'artifacts\feed'
+$pkgs = Join-Path $dir 'artifacts\pkgs'
+$cacheRoot = Join-Path ([System.IO.Path]::GetTempPath()) 'Metalama\CompileTime'
+$common = @('--disable-build-servers', '-nodeReuse:false', '-clp:ErrorsOnly', '-nologo', "-p:MetalamaVersion=$MetalamaVersion")
+
+function Invoke-Dotnet([string[]] $arguments) {
+    # Launch dotnet as an independent top-level process so it does not share in-process state with this script
+    # or with previous builds.
+    $p = Start-Process -FilePath 'dotnet' -ArgumentList $arguments -Wait -NoNewWindow -PassThru
+    return $p.ExitCode
+}
+
+function Remove-Dir([string] $path) {
+    if (Test-Path $path) { Remove-Item -Recurse -Force $path -ErrorAction SilentlyContinue }
+}
+
+function Stop-BuildWorkers {
+    # Kill the Roslyn compiler server and any persistent MSBuild worker nodes (dotnet '/nodemode:' processes),
+    # which host the warm in-process CompileTimeDomain. This does NOT touch the orchestrator: worker nodes are
+    # identified by their command line, not by killing every dotnet. Essential when running under MSBuild, where
+    # such workers survive 'dotnet build-server shutdown' and would otherwise keep ml!Primitives @ 1.0.0 loaded.
+    Get-Process VBCSCompiler -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+    Get-CimInstance Win32_Process -Filter "Name = 'dotnet.exe'" -ErrorAction SilentlyContinue |
+        Where-Object { $_.CommandLine -match '/nodemode:' -or $_.CommandLine -match 'VBCSCompiler' } |
+        ForEach-Object { Stop-Process -Id $_.ProcessId -Force -ErrorAction SilentlyContinue }
+    Start-Sleep -Milliseconds 500
+}
+
+Write-Host 'Issue1722: resetting local feed, package cache and compile-time cache.'
+Invoke-Dotnet @('build-server', 'shutdown') | Out-Null
+Remove-Dir $feed
+Remove-Dir $pkgs
+foreach ($p in 'Issue1722.Primitives', 'Issue1722.Aspects', 'Issue1722.PackageConsumer') { Remove-Dir (Join-Path $cacheRoot $p) }
+
+# NuGet package versions are immutable in the global cache, so a stale Issue1722.* package from an earlier run
+# (built against a different Metalama version) would be reused and mask the result. Remove them from the global
+# packages folder so the consumer always restores the freshly-packed packages.
+$globalPackages = ((& dotnet nuget locals global-packages --list) -replace '^[^:]*:\s*', '').Trim()
+if ($globalPackages -and (Test-Path $globalPackages)) {
+    Get-ChildItem $globalPackages -Filter 'issue1722.*' -Directory -ErrorAction SilentlyContinue |
+        Remove-Item -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+New-Item -ItemType Directory -Force -Path $feed | Out-Null
+
+$primitives = Join-Path $dir 'Issue1722.Primitives\Issue1722.Primitives.csproj'
+$aspects    = Join-Path $dir 'Issue1722.Aspects\Issue1722.Aspects.csproj'
+$consumer   = Join-Path $dir 'PackageConsumer\Issue1722.PackageConsumer.csproj'
+
+Write-Host 'Issue1722: packing Primitives 1.0.0/2.0.0 and Aspects 1.0.0.'
+if ((Invoke-Dotnet (@('pack', $primitives) + $common + @('-p:Issue1722PrimitivesVersion=1.0.0', '-o', $feed))) -ne 0) { throw 'pack Primitives 1.0.0 failed' }
+if ((Invoke-Dotnet (@('pack', $aspects) + $common + @('-p:Issue1722PrimitivesVersion=1.0.0', '-p:Issue1722AspectsVersion=1.0.0', '-o', $feed))) -ne 0) { throw 'pack Aspects 1.0.0 failed' }
+if ((Invoke-Dotnet (@('pack', $primitives) + $common + @('-p:Issue1722PrimitivesVersion=2.0.0', '-o', $feed))) -ne 0) { throw 'pack Primitives 2.0.0 failed' }
+
+# The pack builds populated the compile-time cache; empty it so the consumer builds it fresh.
+foreach ($p in 'Issue1722.Primitives', 'Issue1722.Aspects', 'Issue1722.PackageConsumer') { Remove-Dir (Join-Path $cacheRoot $p) }
+
+Write-Host 'Issue1722: step A - consume Aspects 1.0.0 + Primitives 1.0.0 (must succeed).'
+if ((Invoke-Dotnet (@('build', $consumer) + $common + @('-p:ConsumerAspectsVersion=1.0.0', '-p:ConsumerPrimitivesVersion=1.0.0'))) -ne 0) {
+    throw 'Issue1722: step A failed unexpectedly (consuming matching versions should succeed).'
+}
+
+Invoke-Dotnet @('build-server', 'shutdown') | Out-Null
+Stop-BuildWorkers
+
+Write-Host 'Issue1722: step B - upgrade Primitives to 2.0.0 and rebuild (reproduces the bug when present).'
+$exit = Invoke-Dotnet (@('build', $consumer) + $common + @('-p:ConsumerAspectsVersion=1.0.0', '-p:ConsumerPrimitivesVersion=2.0.0'))
+if ($exit -ne 0) {
+    Write-Host 'Issue1722: step B FAILED - issue #1722 reproduced (compile-time assembly mismatch during eligibility).'
+    exit $exit
+}
+
+Write-Host 'Issue1722: step B succeeded - issue #1722 is fixed.'
+exit 0


### PR DESCRIPTION
Closes #1722

## Summary

- A project's compile-time assembly (`ml!<name>_<hash>`) bakes a reference, *by hashed name*, to the compile-time assembly of each referenced project. `CompileTimeCompilationBuilder.ComputeProjectHash` only folded in each reference's **source** hash, not its identity. So when a referenced project's identity changed (most commonly a package **version bump**) while its source was unchanged, a stale dependent assembly was served from the cache and kept a baked reference to an `ml!` assembly that was no longer loaded, throwing `FileNotFoundException`. It surfaced during aspect **eligibility** because that is the first place the compiled aspect's baked reference is JITed (it fails identically from a template, reported as `LAMA0041`).
- **Fix:** `ComputeProjectHash` now folds each reference's full compile-time identity (`CompileTimeIdentity.Name`, i.e. the exact `ml!<name>_<hash>` that gets baked in) into the dependent's hash, so a dependent invalidates whenever a dependency's identity changes.
- Adds a deterministic end-to-end regression test under `Metalama.Framework/src/tests/Standalone/Issue1722` (`repro.ps1`) that reproduces the package-upgrade scenario (consume Aspects 1.0.0 + Primitives 1.0.0, then upgrade Primitives to 2.0.0). It fails on the unfixed engine and passes on the fixed one. The builds must run as independent top-level processes: a shared warm compile-time domain masks the bug, which is the same reason the original report was intermittent.

## Issues Fixed

- #1722 - FileNotFound while invoking extension method defined in other package