### PR TITLE
Recover design-time RPC accept loop from mid-connect client disconnect (#1724)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ServerEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ServerEndpoint.cs
@@ -6,6 +6,7 @@ using Metalama.Backstage.Diagnostics;
 using StreamJsonRpc;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
+using System.IO;
 using System.IO.Pipes;
 
 namespace Metalama.Framework.DesignTime.Rpc;
@@ -158,18 +159,58 @@ public abstract class ServerEndpoint : BaseEndpoint
 
     private async Task AcceptNewClientAsync( string pipeName, ImmutableArray<RpcService> services, CancellationToken cancellationToken )
     {
-        var pipe = new NamedPipeServerStream(
-            pipeName,
-            PipeDirection.InOut,
-            NamedPipeServerStream.MaxAllowedServerInstances,
-            PipeTransmissionMode.Byte,
-            PipeOptions.Asynchronous );
+        NamedPipeServerStream pipe;
 
-        await this.OnServerPipeCreatedAsync( cancellationToken ).WarnIfLongAsync( this.Logger, nameof(this.OnServerPipeCreatedAsync), cancellationToken );
+        // Accept loop with recovery. A newly-created NamedPipeServerStream is connectable the moment it
+        // exists — before we reach WaitForConnectionAsync. If a client connects into that window and then
+        // disconnects before we accept it (e.g. a ClientEndpoint that is disposed mid-connect), that pipe
+        // instance is broken and WaitForConnectionAsync throws IOException ("The pipe is being closed").
+        // We must discard the broken instance and create a fresh one, otherwise the exception would tear
+        // down this accept task and the endpoint would silently stop accepting ANY further client on this
+        // pipe for the rest of the session (leaving design-time features permanently unresponsive).
+        while ( true )
+        {
+            // Bail out promptly if the endpoint is being disposed, rather than creating a fresh pipe instance
+            // and running OnServerPipeCreatedAsync only to unwind at the next await.
+            cancellationToken.ThrowIfCancellationRequested();
 
-        this.Logger.Trace?.Log( $"Endpoint '{pipeName}': wait for a client (currently has {this.ClientCount})." );
+            pipe = new NamedPipeServerStream(
+                pipeName,
+                PipeDirection.InOut,
+                NamedPipeServerStream.MaxAllowedServerInstances,
+                PipeTransmissionMode.Byte,
+                PipeOptions.Asynchronous );
 
-        await pipe.WaitForConnectionAsync( cancellationToken );
+            await this.OnServerPipeCreatedAsync( cancellationToken ).WarnIfLongAsync( this.Logger, nameof(this.OnServerPipeCreatedAsync), cancellationToken );
+
+            this.Logger.Trace?.Log( $"Endpoint '{pipeName}': wait for a client (currently has {this.ClientCount})." );
+
+            if ( this.TestSyncProvider != null )
+            {
+                // Sync point placed AFTER the server pipe is created (so a client can already connect to it)
+                // but BEFORE WaitForConnectionAsync. Tests use this to force the interleaving where a client
+                // connects and disconnects while the server is still parked here.
+                await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.BeforeWaitForConnection:{pipeName}", cancellationToken );
+            }
+
+            try
+            {
+                await pipe.WaitForConnectionAsync( cancellationToken );
+
+                break;
+            }
+            catch ( IOException e )
+            {
+                // A client connected to this instance and disconnected before we accepted it. The instance is
+                // now unusable; dispose it and loop to create a fresh one and keep accepting. Cancellation
+                // (endpoint disposal) surfaces as OperationCanceledException, not IOException, and is handled
+                // by the ThrowIfCancellationRequested at the top of the loop.
+                this.Logger.Trace?.Log(
+                    $"Endpoint '{pipeName}': a client disconnected before it could be accepted ('{e.Message}'); discarding the pipe instance and retrying." );
+
+                pipe.Dispose();
+            }
+        }
 
         if ( this.TestSyncProvider != null )
         {
@@ -178,45 +219,82 @@ public abstract class ServerEndpoint : BaseEndpoint
 
         this.Logger.Trace?.Log( $"Endpoint '{pipeName}': got a client (now has {this.ClientCount + 1})." );
 
-        var rpc = CreateRpc( pipe );
+        JsonRpc? rpc = null;
+        var ownershipTransferred = false;
 
-        this.Logger.Trace?.Log( $"Endpoint '{pipeName}': adding services {string.Join( ", ", services.Select( s => s.GetType().Name ) )}." );
-
-        foreach ( var i in services )
+        try
         {
-            i.ConfigureRpc( rpc );
+            rpc = CreateRpc( pipe );
+
+            this.Logger.Trace?.Log( $"Endpoint '{pipeName}': adding services {string.Join( ", ", services.Select( s => s.GetType().Name ) )}." );
+
+            foreach ( var i in services )
+            {
+                i.ConfigureRpc( rpc );
+            }
+
+            rpc.Disconnected += this.OnRpcDisconnected;
+
+            // From this point the pipe and rpc are owned by _pipes: Dispose() and OnRpcDisconnected release them.
+            this._pipes.TryAdd( rpc, pipe );
+            ownershipTransferred = true;
+
+            if ( this.TestSyncProvider != null )
+            {
+                await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.AfterConfiguresRpc:{pipeName}", cancellationToken );
+            }
+
+            this.Logger.Trace?.Log( $"Endpoint '{pipeName}': start listening." );
+            rpc.StartListening();
+
+            if ( this.TestSyncProvider != null )
+            {
+                await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.AfterStartsListening:{pipeName}", cancellationToken );
+            }
+
+            // Promote the rpc into each service's callback bookkeeping AFTER StartListening so that any
+            // concurrent broadcast (RaiseEventAsync) cannot pick up a rpc that would throw
+            // "This operation is not allowed before listening for messages has started."
+            foreach ( var i in services )
+            {
+                i.OnRpcStarted( rpc );
+            }
+
+            this.Logger.Trace?.Log( $"The server endpoint '{pipeName}' is ready." );
+
+            // Listen to another client.
+            this.ExecuteBackgroundTask( ct => this.AcceptNewClientAsync( pipeName, services, ct ), nameof(this.AcceptNewClientAsync), false );
+
+            this.OnConnected( services );
         }
-
-        rpc.Disconnected += this.OnRpcDisconnected;
-        this._pipes.TryAdd( rpc, pipe );
-
-        if ( this.TestSyncProvider != null )
+        catch
         {
-            await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.AfterConfiguresRpc:{pipeName}", cancellationToken );
+            // If ownership was never transferred to _pipes (e.g. CreateRpc/ConfigureRpc threw, or the accepted
+            // client disconnected before we finished setting it up), nothing else will dispose the pipe or rpc,
+            // so release them here to avoid leaking the OS pipe handle. Once in _pipes, Dispose() handles them.
+            if ( !ownershipTransferred )
+            {
+                try
+                {
+                    rpc?.Dispose();
+                }
+                catch ( Exception disposeException )
+                {
+                    this.Logger.Warning?.Log( $"Disposing rpc after a failed accept threw: {disposeException}" );
+                }
+
+                try
+                {
+                    pipe.Dispose();
+                }
+                catch ( Exception disposeException )
+                {
+                    this.Logger.Warning?.Log( $"Disposing pipe after a failed accept threw: {disposeException}" );
+                }
+            }
+
+            throw;
         }
-
-        this.Logger.Trace?.Log( $"Endpoint '{pipeName}': start listening." );
-        rpc.StartListening();
-
-        if ( this.TestSyncProvider != null )
-        {
-            await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.AfterStartsListening:{pipeName}", cancellationToken );
-        }
-
-        // Promote the rpc into each service's callback bookkeeping AFTER StartListening so that any
-        // concurrent broadcast (RaiseEventAsync) cannot pick up a rpc that would throw
-        // "This operation is not allowed before listening for messages has started."
-        foreach ( var i in services )
-        {
-            i.OnRpcStarted( rpc );
-        }
-
-        this.Logger.Trace?.Log( $"The server endpoint '{pipeName}' is ready." );
-
-        // Listen to another client.
-        this.ExecuteBackgroundTask( ct => this.AcceptNewClientAsync( pipeName, services, ct ), nameof(this.AcceptNewClientAsync), false );
-
-        this.OnConnected( services );
     }
 
     private void OnRpcDisconnected( object? sender, JsonRpcDisconnectedEventArgs e )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ServerEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ServerEndpoint.cs
@@ -159,72 +159,72 @@ public abstract class ServerEndpoint : BaseEndpoint
 
     private async Task AcceptNewClientAsync( string pipeName, ImmutableArray<RpcService> services, CancellationToken cancellationToken )
     {
-        NamedPipeServerStream pipe;
-
-        // Accept loop with recovery. A newly-created NamedPipeServerStream is connectable the moment it
-        // exists — before we reach WaitForConnectionAsync. If a client connects into that window and then
-        // disconnects before we accept it (e.g. a ClientEndpoint that is disposed mid-connect), that pipe
-        // instance is broken and WaitForConnectionAsync throws IOException ("The pipe is being closed").
-        // We must discard the broken instance and create a fresh one, otherwise the exception would tear
-        // down this accept task and the endpoint would silently stop accepting ANY further client on this
-        // pipe for the rest of the session (leaving design-time features permanently unresponsive).
-        while ( true )
-        {
-            // Bail out promptly if the endpoint is being disposed, rather than creating a fresh pipe instance
-            // and running OnServerPipeCreatedAsync only to unwind at the next await.
-            cancellationToken.ThrowIfCancellationRequested();
-
-            pipe = new NamedPipeServerStream(
-                pipeName,
-                PipeDirection.InOut,
-                NamedPipeServerStream.MaxAllowedServerInstances,
-                PipeTransmissionMode.Byte,
-                PipeOptions.Asynchronous );
-
-            await this.OnServerPipeCreatedAsync( cancellationToken ).WarnIfLongAsync( this.Logger, nameof(this.OnServerPipeCreatedAsync), cancellationToken );
-
-            this.Logger.Trace?.Log( $"Endpoint '{pipeName}': wait for a client (currently has {this.ClientCount})." );
-
-            if ( this.TestSyncProvider != null )
-            {
-                // Sync point placed AFTER the server pipe is created (so a client can already connect to it)
-                // but BEFORE WaitForConnectionAsync. Tests use this to force the interleaving where a client
-                // connects and disconnects while the server is still parked here.
-                await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.BeforeWaitForConnection:{pipeName}", cancellationToken );
-            }
-
-            try
-            {
-                await pipe.WaitForConnectionAsync( cancellationToken );
-
-                break;
-            }
-            catch ( IOException e )
-            {
-                // A client connected to this instance and disconnected before we accepted it. The instance is
-                // now unusable; dispose it and loop to create a fresh one and keep accepting. Cancellation
-                // (endpoint disposal) surfaces as OperationCanceledException, not IOException, and is handled
-                // by the ThrowIfCancellationRequested at the top of the loop.
-                this.Logger.Trace?.Log(
-                    $"Endpoint '{pipeName}': a client disconnected before it could be accepted ('{e.Message}'); discarding the pipe instance and retrying." );
-
-                pipe.Dispose();
-            }
-        }
-
-        if ( this.TestSyncProvider != null )
-        {
-            await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.AfterGetsClient:{pipeName}", cancellationToken );
-        }
-
-        this.Logger.Trace?.Log( $"Endpoint '{pipeName}': got a client (now has {this.ClientCount + 1})." );
-
+        NamedPipeServerStream? pipe = null;
         JsonRpc? rpc = null;
-        var ownershipTransferred = false;
+        var pipeOwnershipTransferred = false;
 
         try
         {
-            rpc = CreateRpc( pipe );
+            // Accept loop with recovery. A newly-created NamedPipeServerStream is connectable the moment it
+            // exists — before we reach WaitForConnectionAsync. If a client connects into that window and then
+            // disconnects before we accept it (e.g. a ClientEndpoint that is disposed mid-connect), that pipe
+            // instance is broken and WaitForConnectionAsync throws IOException ("The pipe is being closed").
+            // We must discard the broken instance and create a fresh one, otherwise the exception would tear
+            // down this accept task and the endpoint would silently stop accepting ANY further client on this
+            // pipe for the rest of the session (leaving design-time features permanently unresponsive).
+            while ( true )
+            {
+                // Bail out promptly if the endpoint is being disposed, rather than creating a fresh pipe instance
+                // and running OnServerPipeCreatedAsync only to unwind at the next await.
+                cancellationToken.ThrowIfCancellationRequested();
+
+                pipe = new NamedPipeServerStream(
+                    pipeName,
+                    PipeDirection.InOut,
+                    NamedPipeServerStream.MaxAllowedServerInstances,
+                    PipeTransmissionMode.Byte,
+                    PipeOptions.Asynchronous );
+
+                await this.OnServerPipeCreatedAsync( cancellationToken )
+                    .WarnIfLongAsync( this.Logger, nameof(this.OnServerPipeCreatedAsync), cancellationToken );
+
+                this.Logger.Trace?.Log( $"Endpoint '{pipeName}': wait for a client (currently has {this.ClientCount})." );
+
+                if ( this.TestSyncProvider != null )
+                {
+                    // Sync point placed AFTER the server pipe is created (so a client can already connect to it)
+                    // but BEFORE WaitForConnectionAsync. Tests use this to force the interleaving where a client
+                    // connects and disconnects while the server is still parked here.
+                    await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.BeforeWaitForConnection:{pipeName}", cancellationToken );
+                }
+
+                try
+                {
+                    await pipe.WaitForConnectionAsync( cancellationToken );
+
+                    break;
+                }
+                catch ( IOException e )
+                {
+                    // A client connected to this instance and disconnected before we accepted it. The instance is
+                    // now unusable; dispose it and loop to create a fresh one and keep accepting. Cancellation
+                    // (endpoint disposal) surfaces as OperationCanceledException, not IOException, and is handled
+                    // by the ThrowIfCancellationRequested at the top of the loop.
+                    this.Logger.Trace?.Log(
+                        $"Endpoint '{pipeName}': a client disconnected before it could be accepted ('{e.Message}'); discarding the pipe instance and retrying." );
+
+                    pipe.Dispose();
+                }
+            }
+
+            if ( this.TestSyncProvider != null )
+            {
+                await this.TestSyncProvider.SyncPointAsync( $"ServerEndpoint.AfterGetsClient:{pipeName}", cancellationToken );
+            }
+
+            this.Logger.Trace?.Log( $"Endpoint '{pipeName}': got a client (now has {this.ClientCount + 1})." );
+
+            rpc = this.CreateRpc( pipe );
 
             this.Logger.Trace?.Log( $"Endpoint '{pipeName}': adding services {string.Join( ", ", services.Select( s => s.GetType().Name ) )}." );
 
@@ -237,7 +237,7 @@ public abstract class ServerEndpoint : BaseEndpoint
 
             // From this point the pipe and rpc are owned by _pipes: Dispose() and OnRpcDisconnected release them.
             this._pipes.TryAdd( rpc, pipe );
-            ownershipTransferred = true;
+            pipeOwnershipTransferred = true;
 
             if ( this.TestSyncProvider != null )
             {
@@ -272,7 +272,7 @@ public abstract class ServerEndpoint : BaseEndpoint
             // If ownership was never transferred to _pipes (e.g. CreateRpc/ConfigureRpc threw, or the accepted
             // client disconnected before we finished setting it up), nothing else will dispose the pipe or rpc,
             // so release them here to avoid leaking the OS pipe handle. Once in _pipes, Dispose() handles them.
-            if ( !ownershipTransferred )
+            if ( !pipeOwnershipTransferred )
             {
                 try
                 {
@@ -285,7 +285,7 @@ public abstract class ServerEndpoint : BaseEndpoint
 
                 try
                 {
-                    pipe.Dispose();
+                    pipe?.Dispose();
                 }
                 catch ( Exception disposeException )
                 {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/CLAUDE.md
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/CLAUDE.md
@@ -87,7 +87,9 @@ public async Task TestWithSyncPoint()
 ```
 
 Available sync points:
+- `ServerEndpoint.BeforeWaitForConnection:{pipeName}` - After the server pipe instance is created (so a client can already connect to it) but before `WaitForConnectionAsync`. Use this to force the interleaving where a client connects and disconnects before the server accepts it. Used by the #1724 recovery regression test.
 - `ServerEndpoint.AfterGetsClient:{pipeName}` - After server accepts client but before configuring RPC
+- `ServerEndpoint.AfterStartsListening:{pipeName}` - After the server's RPC starts listening (its read loop is active, so it can observe EOF/disconnect)
 - `ClientEndpoint.AfterStartsListening:{pipeName}` - After the client starts listening but before publishing the connection (client not yet visible to `GetClient()`)
 - `ClientEndpoint.BeforeSignalingAwaiters:{pipeName}` - After client updates collections but before signaling awaiters
 - `ClientEndpoint.BeforeRegisterAwaiter:{pipeName}` - **Synchronous** sync point inside `_addClientLock` in `GetOrWaitForClientAsync`, after `GetClient()` returned null and before the awaiter is registered. Use `SyncProvider` as usual; it blocks the calling thread (the lock is held), so the code under test must be on a background task. Used by the #1640 lost-wakeup regression test.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceRaiseEventTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceRaiseEventTests.cs
@@ -6,6 +6,7 @@
 
 using Metalama.Framework.DesignTime.Rpc;
 using Metalama.Framework.Engine.Utilities.Threading;
+using Metalama.Testing.UnitTesting;
 using System;
 using System.Collections.Generic;
 using System.Reflection;
@@ -617,14 +618,22 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
     /// happens only after <c>rpc.StartListening</c>. Disposing while <c>ConnectCoreAsync</c> was
     /// still in flight was a silent no-op: the OS pipe stayed open, the server's <c>JsonRpc</c>
     /// never raised <c>Disconnected</c>, and any code waiting for <c>OnRpcDisconnected</c> hung
-    /// forever. This test pauses client2 at <c>ClientEndpoint.AfterGetsServer</c> (pipe accepted,
-    /// rpc not yet created), disposes the endpoint, and asserts that the server observes the
-    /// disconnect.
+    /// forever. This test pauses the client at <c>ClientEndpoint.AfterGetsServer</c> (pipe connected,
+    /// rpc not yet created), waits for the server to accept it and start listening, then disposes the
+    /// client and asserts that the server observes the disconnect.
     /// </summary>
+    /// <remarks>
+    /// The wait for <c>ServerEndpoint.AfterStartsListening</c> is essential: the server can only observe
+    /// EOF (and raise <c>Disconnected</c>) once its own <c>JsonRpc</c> is listening. Disposing the client
+    /// before that point exercises a different interleaving — the client connects and disconnects before
+    /// the server accepts it — which is covered by
+    /// <see cref="ServerRecoversWhenClientDisconnectsBeforeBeingAccepted"/>. Not synchronizing on the
+    /// server here is what made this test intermittently hang (issue #1724).
+    /// </remarks>
     [Fact]
     public async Task ClientEndpointDispose_MidConnect_ClosesPendingPipe_ServerSeesDisconnect()
     {
-        using var testContext = this.CreateRpcTestContext();
+        using var testContext = this.CreateRpcTestContext( new TestContextOptions { Timeout = TimeSpan.FromSeconds( 30 ) } );
 
         var pipeName = $"{nameof(RpcServiceRaiseEventTests)}_{Guid.NewGuid()}";
 
@@ -633,25 +642,36 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
         var clientDisconnectedTcs = new TaskCompletionSource<bool>();
         serverEndpoint.ClientDisconnected += () => clientDisconnectedTcs.TrySetResult( true );
 
-        serverEndpoint.Start();
-
         // Pause the client right after the OS pipe handshake but before rpc is constructed: only
         // the NamedPipeClientStream exists and it has not yet been added to _connectionByStream.
-        var syncPointName = $"ClientEndpoint.AfterGetsServer:{pipeName}";
-        testContext.SyncProvider.EnableSyncPoint( syncPointName );
+        var clientSyncPointName = $"ClientEndpoint.AfterGetsServer:{pipeName}";
+        testContext.SyncProvider.EnableSyncPoint( clientSyncPointName );
+
+        // Pause the server right after it has accepted the client and started listening, so that disposing
+        // the client below deterministically hits the "server is already listening" interleaving that #1624
+        // is about.
+        var serverListeningSyncPointName = $"ServerEndpoint.AfterStartsListening:{pipeName}";
+        testContext.SyncProvider.EnableSyncPoint( serverListeningSyncPointName );
+
+        serverEndpoint.Start();
 
         var clientEndpoint = new EventTestClientEndpoint( testContext.ServiceProvider, pipeName );
 
         // Fire-and-forget connect: the test disposes before the connect can finish.
         var connectTask = clientEndpoint.ConnectAsync( testContext.CancellationToken );
 
-        await testContext.SyncProvider.WaitForSyncPointReachedAsync( syncPointName, testContext.CancellationToken );
+        // Wait for the client to complete the OS handshake (its pipe is now connected and open)...
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( clientSyncPointName, testContext.CancellationToken );
+
+        // ...and for the server to accept that still-connected client and start listening on it.
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( serverListeningSyncPointName, testContext.CancellationToken );
 
         // Dispose mid-connect. With the fix, the pending pipe is closed and the server's JsonRpc
         // detects EOF and raises Disconnected (which fires ClientDisconnected).
         clientEndpoint.Dispose();
 
-        testContext.SyncProvider.ReleaseSyncPoint( syncPointName );
+        testContext.SyncProvider.ReleaseSyncPoint( clientSyncPointName );
+        testContext.SyncProvider.ReleaseSyncPoint( serverListeningSyncPointName );
 
         try
         {
@@ -665,6 +685,85 @@ public sealed partial class RpcServiceRaiseEventTests : RpcUnitTestClass
 
         // The real assertion: without the fix, this hangs until the test cancellation token cancels.
         await clientDisconnectedTcs.Task.WithCancellation( testContext.CancellationToken );
+    }
+
+    /// <summary>
+    /// Regression test for issue #1724. A <see cref="System.IO.Pipes.NamedPipeServerStream"/> is connectable
+    /// the moment it is created, before the server reaches <c>WaitForConnectionAsync</c>. If a client connects
+    /// into that window and disconnects before being accepted (e.g. a <c>ClientEndpoint</c> disposed
+    /// mid-connect), <c>WaitForConnectionAsync</c> throws <see cref="System.IO.IOException"/> on the now-broken
+    /// pipe instance.
+    /// Before the fix this exception tore down the accept loop and the endpoint stopped accepting any
+    /// further client on that pipe for the rest of the session. This test forces that interleaving via the
+    /// <c>ServerEndpoint.BeforeWaitForConnection</c> sync point and asserts that the server recovers: it
+    /// discards the broken instance, loops back to <c>BeforeWaitForConnection</c>, and goes on to accept a
+    /// subsequent well-behaved client.
+    /// </summary>
+    [Fact]
+    public async Task ServerRecoversWhenClientDisconnectsBeforeBeingAccepted()
+    {
+        // A short timeout keeps the test fast: without the fix the accept loop dies and the waits below fail
+        // via cancellation in a few seconds instead of the 240s default.
+        using var testContext = this.CreateRpcTestContext( new TestContextOptions { Timeout = TimeSpan.FromSeconds( 30 ) } );
+
+        var pipeName = $"{nameof(RpcServiceRaiseEventTests)}_{Guid.NewGuid()}";
+
+        using var serverEndpoint = new EventTestServerEndpoint( testContext.ServiceProvider, pipeName );
+
+        var clientConnectedTcs = new TaskCompletionSource<bool>();
+        serverEndpoint.ClientConnected += () => clientConnectedTcs.TrySetResult( true );
+
+        // Park the server AFTER it creates the pipe but BEFORE it calls WaitForConnectionAsync.
+        var serverSyncPointName = $"ServerEndpoint.BeforeWaitForConnection:{pipeName}";
+        testContext.SyncProvider.EnableSyncPoint( serverSyncPointName );
+
+        // Park clients right after the OS pipe handshake but before rpc is constructed.
+        var clientSyncPointName = $"ClientEndpoint.AfterGetsServer:{pipeName}";
+        testContext.SyncProvider.EnableSyncPoint( clientSyncPointName );
+
+        serverEndpoint.Start();
+
+        // First accept iteration: parked before WaitForConnectionAsync. The pipe now exists, so a client can
+        // connect to it even though the server has not accepted yet.
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( serverSyncPointName, testContext.CancellationToken );
+
+        // Phantom client: connect the OS pipe, then dispose mid-connect so it disconnects before the server
+        // accepts it.
+        var phantom = new EventTestClientEndpoint( testContext.ServiceProvider, pipeName );
+        var phantomConnect = phantom.ConnectAsync( testContext.CancellationToken );
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( clientSyncPointName, testContext.CancellationToken );
+        phantom.Dispose();
+        testContext.SyncProvider.ReleaseSyncPoint( clientSyncPointName );
+
+        try
+        {
+            await phantomConnect.WithCancellation( testContext.CancellationToken );
+        }
+        catch
+        {
+            // Expected: the phantom's connect faults because it was disposed mid-connect.
+        }
+
+        // Release the first accept iteration: WaitForConnectionAsync throws IOException on the phantom-broken
+        // instance. The fix must catch it, discard the instance, and loop back to BeforeWaitForConnection.
+        testContext.SyncProvider.ReleaseSyncPoint( serverSyncPointName );
+
+        // Proof of recovery: the accept loop reached BeforeWaitForConnection a SECOND time. Without the fix
+        // the loop dies at the throw above and this wait times out.
+        await testContext.SyncProvider.WaitForSyncPointReachedAsync( serverSyncPointName, testContext.CancellationToken );
+        testContext.SyncProvider.ReleaseSyncPoint( serverSyncPointName );
+
+        // End-to-end: a fresh, well-behaved client now connects and the server accepts it. Its own
+        // AfterGetsServer sync point parks it after the OS handshake, but the server accepts as soon as that
+        // handshake completes, so ClientConnected fires without the client having to be released first.
+        using var client2 = new EventTestClientEndpoint( testContext.ServiceProvider, pipeName );
+        var client2Connect = client2.ConnectAsync( testContext.CancellationToken );
+
+        await clientConnectedTcs.Task.WithCancellation( testContext.CancellationToken );
+
+        // Let client2 finish connecting cleanly.
+        testContext.SyncProvider.ReleaseSyncPoint( clientSyncPointName );
+        await client2Connect.WithCancellation( testContext.CancellationToken );
     }
 
     /// <summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcUnitTestClass.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcUnitTestClass.cs
@@ -22,6 +22,8 @@ public abstract class RpcUnitTestClass : UnitTestClass
     /// <summary>
     /// Creates an RPC test context with synchronization provider pre-configured.
     /// </summary>
+    /// <param name="contextOptions">Optional non-default <see cref="TestContextOptions"/> (e.g. a shorter
+    /// <see cref="TestContextOptions.Timeout"/>). When <c>null</c>, the default options are used.</param>
     /// <param name="callerFile">Automatically populated by the compiler.</param>
     /// <param name="callerMemberName">Automatically populated by the compiler.</param>
     /// <returns>An <see cref="RpcTestContext"/> that must be disposed after the test.</returns>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcUnitTestClass.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcUnitTestClass.cs
@@ -26,14 +26,17 @@ public abstract class RpcUnitTestClass : UnitTestClass
     /// <param name="callerMemberName">Automatically populated by the compiler.</param>
     /// <returns>An <see cref="RpcTestContext"/> that must be disposed after the test.</returns>
     [MustDisposeResource]
-    private protected RpcTestContext CreateRpcTestContext( [CallerFilePath] string? callerFile = null, [CallerMemberName] string? callerMemberName = null )
+    private protected RpcTestContext CreateRpcTestContext(
+        TestContextOptions? contextOptions = null,
+        [CallerFilePath] string? callerFile = null,
+        [CallerMemberName] string? callerMemberName = null )
     {
         var syncProvider = new TestSynchronizationProvider( this.TestOutput );
 
         var additionalServices = new AdditionalServiceCollection();
         additionalServices.AddUntypedGlobalService( typeof(ITestSynchronizationProvider), syncProvider );
 
-        var testContext = this.CreateTestContext( additionalServices, callerFile, callerMemberName );
+        var testContext = this.CreateTestContext( contextOptions, additionalServices, callerFile, callerMemberName );
 
         return new RpcTestContext( testContext, syncProvider );
     }


### PR DESCRIPTION
Fixes #1724.

## Problem

A `NamedPipeServerStream` is connectable the moment it is created — before the server reaches `WaitForConnectionAsync`. If a client connects into that window and disconnects before being accepted (e.g. a `ClientEndpoint` disposed mid-connect), `WaitForConnectionAsync` throws `IOException` ("The pipe is being closed") on the now-broken pipe instance.

`ServerEndpoint.AcceptNewClientAsync` had no handling for this: the exception killed the accept background task, and because the loop only reschedules itself *after* a successful accept, the endpoint stopped accepting **any** further client on that pipe for the rest of the session — a permanently dead design-time endpoint (diagnostics, CodeLens, source generators, notifications on that pipe go silent until VS restart). I confirmed the "permanent death" empirically: after the phantom, a fresh second client could not connect either.

The original symptom was an intermittent 4-minute test hang (`RpcServiceRaiseEventTests.ClientEndpointDispose_MidConnect_ClosesPendingPipe_ServerSeesDisconnect`) — the test was waiting on a disconnect that never came after the loop died.

## Fix

`AcceptNewClientAsync` now:
- Retries on the phantom `IOException`: it discards the broken pipe instance and creates a fresh one, so the endpoint keeps accepting. Cancellation (endpoint disposal) surfaces as `OperationCanceledException`, handled by a `ThrowIfCancellationRequested` at the top of the loop.
- Wraps the whole method (loop included) in a cleanup `try`, so the accepted pipe and its `JsonRpc` are disposed if setup fails before ownership is transferred to `_pipes`, or if the loop is cancelled — closing a pre-existing potential leak of the OS pipe handle.

## Tests

All deterministic via test synchronization points (no delays):
- **`ServerRecoversWhenClientDisconnectsBeforeBeingAccepted`** (new #1724 regression) — forces the phantom interleaving via a new `ServerEndpoint.BeforeWaitForConnection` sync point and proves the accept loop reaches it a second time and then accepts a subsequent client. Fails at 30s without the fix.
- **`ClientEndpointDispose_MidConnect_ClosesPendingPipe_ServerSeesDisconnect`** (the originally-flaky #1624 test) — made deterministic by waiting for `ServerEndpoint.AfterStartsListening` before disposing the client, so it reliably exercises the "server already listening" interleaving it was meant to test.
- Added optional `TestContextOptions` on `CreateRpcTestContext` (short timeouts); documented the new sync points.

**Verification:** all 86 `DesignTime.Rpc` tests pass (1 pre-existing skip); the recovery test fails without the fix.

— Claude for @gfraiteur