### PR TITLE
Fix duplicate design-time validators, and clean up the cross-version manifest path (#1710)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Contracts/Pipeline/ITransitiveCompilationResult2.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Contracts/Pipeline/ITransitiveCompilationResult2.cs
@@ -1,0 +1,31 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System.Runtime.InteropServices;
+
+namespace Metalama.Framework.DesignTime.Contracts.Pipeline;
+
+/// <summary>
+/// Extends <see cref="ITransitiveCompilationResult"/> with a content hash of
+/// <see cref="ITransitiveCompilationResult.Manifest"/>, so that a consumer can tell an unchanged manifest from a
+/// changed one without hashing the bytes itself.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A separate interface rather than a member on <see cref="ITransitiveCompilationResult"/>, because the producer is
+/// a different, possibly older, version of Metalama: one that predates this interface returns a result that does not
+/// implement it. A consumer must therefore type-test and fall back to hashing the bytes, which is what the added
+/// member saves rather than enables.
+/// </para>
+/// </remarks>
+[ComImport]
+[Guid( "D4A3DD08-8127-40EB-B571-293BE58C2EBF" )]
+public interface ITransitiveCompilationResult2 : ITransitiveCompilationResult
+{
+    /// <summary>
+    /// Gets a content hash of <see cref="ITransitiveCompilationResult.Manifest"/>, or zero when there is no manifest.
+    /// Producers must hash the same bytes they expose, so that equal hashes mean equal manifests.
+    /// </summary>
+    long ManifestHash { get; }
+}

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -608,13 +608,11 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                     }
                     else
                     {
-                        // The referenced project must be compilable by the *current* Metalama version, because the
-                        // consuming project binds the manifest against its own compile-time closure, which contains
-                        // this reference. Obtaining the configuration is what gates that, so a failure here aborts
-                        // rather than surfacing later as a binding error attributed to the consumer.
-                        //
-                        // Note that we deliberately do not deserialize the manifest here. See the comment on the
-                        // DesignTimeProjectReference constructed below.
+                        // Require the referenced project to have a valid configuration for the current Metalama
+                        // version before accepting its manifest. The consuming project resolves the manifest's
+                        // run-time type names through its own compile-time closure, which contains this reference,
+                        // so a reference the current version cannot configure would fail later as a binding error
+                        // reported against the consumer. Failing here reports it against the reference instead.
 
                         var pipelineResult = await this._pipelineFactory.GetOrCreatePipelineAsync( reference, cancellationToken );
 
@@ -638,12 +636,8 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                                 $"Cannot get configuration: {configuration.DebugReason}" );
                         }
 
-                        // Carry only the serialized manifest. The consumer deserializes it into its own compile-time
-                        // copy (issue #1710), so there is nothing for a live manifest to do here: a live manifest is
-                        // read exclusively by DesignTimeProjectVersion.ReferencedExtensions and
-                        // TryGetReusableTransitiveAspectsManifest, both of which need the producer's concrete
-                        // DesignTimeAspectPipelineResult, and a cross-version producer cannot supply one — its
-                        // result is an object of the *other* version's Metalama.Framework.Engine.
+                        // A cross-version reference carries the serialized manifest alone: the producer's live
+                        // result is an object of the other version's Metalama.Framework.Engine and cannot cross.
                         compilationReferences.Add(
                             new DesignTimeProjectReference(
                                 reference.ProjectKey,

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -608,8 +608,13 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                     }
                     else
                     {
-                        // To deserialize the manifest, we need a service provider with the CompileTimeProject of the referenced project, compiled
-                        // for the current Metalama version.
+                        // The referenced project must be compilable by the *current* Metalama version, because the
+                        // consuming project binds the manifest against its own compile-time closure, which contains
+                        // this reference. Obtaining the configuration is what gates that, so a failure here aborts
+                        // rather than surfacing later as a binding error attributed to the consumer.
+                        //
+                        // Note that we deliberately do not deserialize the manifest here. See the comment on the
+                        // DesignTimeProjectReference constructed below.
 
                         var pipelineResult = await this._pipelineFactory.GetOrCreatePipelineAsync( reference, cancellationToken );
 
@@ -633,18 +638,16 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                                 $"Cannot get configuration: {configuration.DebugReason}" );
                         }
 
-                        var manifest = TransitiveAspectsManifest.Deserialize(
-                            new MemoryStream( result.Manifest! ),
-                            configuration.Value.ServiceProvider,
-                            reference.Compilation.AssemblyName );
-
-                        // Also carry the raw serialized manifest (produced by the referenced project) so the consumer
-                        // can deserialize inherited aspects and options into its own compile-time copy (issue #1710).
+                        // Carry only the serialized manifest. The consumer deserializes it into its own compile-time
+                        // copy (issue #1710), so there is nothing for a live manifest to do here: a live manifest is
+                        // read exclusively by DesignTimeProjectVersion.ReferencedExtensions and
+                        // TryGetReusableTransitiveAspectsManifest, both of which need the producer's concrete
+                        // DesignTimeAspectPipelineResult, and a cross-version producer cannot supply one — its
+                        // result is an object of the *other* version's Metalama.Framework.Engine.
                         compilationReferences.Add(
                             new DesignTimeProjectReference(
                                 reference.ProjectKey,
-                                manifest,
-                                SerializedTransitiveAspectManifest.Create( result.Manifest!.ToImmutableArray() ) ) );
+                                serializedTransitiveAspectManifest: SerializedTransitiveAspectManifest.Create( result.Manifest!.ToImmutableArray() ) ) );
 
                         if ( result.IsPipelinePaused )
                         {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -554,29 +554,28 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                             $"The pipeline for the reference '{reference.ProjectKey}' failed: {referenceResult.DebugReason}" );
                     }
 
-                    // Serialize the referenced project's transitive manifest. The serialized form is
-                    // compilation-neutral by definition: compile-time types are always written as their run-time
-                    // names. We must use the *referenced* project's service provider because only its closure can
-                    // name (resolve) that project's own compile-time copy of a shared, possibly multi-targeted
-                    // assembly; the consuming project's provider would fail to serialize types bound to a copy that
-                    // is not in its closure. The consumer then deserializes these bytes with its own service
-                    // provider, which binds the run-time names to the consumer's own compile-time copy (issue #1710).
-                    // The successful result always carries the reference pipeline's configuration (even when the
-                    // pipeline is paused), so the serialized manifest is always available alongside the live one.
-                    var serializedManifest = referenceResult.Value.Result.SerializedTransitiveAspectManifest;
-
-                    // When the reference exports nothing to inherit, its serialized manifest is `default`. We then
-                    // carry neither the live nor the serialized manifest, keeping the both-or-neither invariant of
-                    // DesignTimeProjectReference and letting the consumer skip deserialization entirely. Dropping the
-                    // live manifest is safe here: an empty manifest also has an empty Extensions collection, so
-                    // DesignTimeProjectVersion.ReferencedExtensions loses nothing.
+                    // Carry the reference's manifest only when it exports something to inherit, which is what makes
+                    // this the common fast path: a Metalama project exporting no inheritable aspect, option,
+                    // annotation or validator carries neither the live nor the serialized form, so nothing is
+                    // serialized here and nothing is deserialized or merged on the consumer's side. Dropping the live
+                    // manifest along with it is safe, because a project with nothing to inherit also has an empty
+                    // Extensions collection, so DesignTimeProjectVersion.ReferencedExtensions loses nothing.
+                    //
+                    // The serialized form is compilation-neutral by definition: compile-time types are always written
+                    // as their run-time names. It is produced by the *referenced* project's service provider because
+                    // only its closure can name (resolve) that project's own compile-time copy of a shared, possibly
+                    // multi-targeted assembly; the consuming project's provider would fail to serialize types bound
+                    // to a copy that is not in its closure. The consumer then deserializes those bytes with its own
+                    // provider, which binds the run-time names to its own compile-time copy (issue #1710). A
+                    // successful result always carries the reference pipeline's configuration, even when the pipeline
+                    // is paused, so the serialized manifest is always available alongside the live one.
                     compilationReferences.Add(
-                        serializedManifest.IsDefaultOrEmpty
-                            ? new DesignTimeProjectReference( referenceResult.Value.ProjectVersion.ProjectKey )
-                            : new DesignTimeProjectReference(
+                        referenceResult.Value.Result.HasTransitiveAspectManifestContent
+                            ? new DesignTimeProjectReference(
                                 referenceResult.Value.ProjectVersion.ProjectKey,
                                 referenceResult.Value.Result,
-                                serializedManifest ) );
+                                referenceResult.Value.Result.SerializedTransitiveAspectManifestWithoutValidators )
+                            : new DesignTimeProjectReference( referenceResult.Value.ProjectVersion.ProjectKey ) );
 
                     if ( referenceResult.Value.Status == DesignTimeAspectPipelineStatus.Paused )
                     {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -640,7 +640,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                         compilationReferences.Add(
                             new DesignTimeProjectReference(
                                 reference.ProjectKey,
-                                serializedTransitiveAspectManifest: SerializedTransitiveAspectManifest.Create( result.Manifest!.ToImmutableArray() ) ) );
+                                serializedTransitiveAspectManifest: GetCrossVersionManifest( result ) ) );
 
                         if ( result.IsPipelinePaused )
                         {
@@ -660,6 +660,29 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
         }
 
         return new DesignTimeProjectVersion( compilationVersion, compilationReferences, pipelineStatus );
+    }
+
+    /// <summary>
+    /// Wraps the manifest received from a cross-version reference, taking the content hash from the producer when it
+    /// reports one.
+    /// </summary>
+    /// <remarks>
+    /// The hash is what <c>TransitiveManifestDeserializationCache</c> keys on downstream, so supplying it here is
+    /// what lets an unchanged reference skip being deserialized again. A producer older than
+    /// <see cref="ITransitiveCompilationResult2"/> reports none, and the bytes are hashed on first use as before.
+    /// That is the only case in which the ordering rule, a referencing project never being older than the project it
+    /// references, puts the older Metalama on the producing side.
+    /// </remarks>
+    private static SerializedTransitiveAspectManifest? GetCrossVersionManifest( ITransitiveCompilationResult result )
+    {
+        if ( result.Manifest is not { Length: > 0 } bytes )
+        {
+            return null;
+        }
+
+        return SerializedTransitiveAspectManifest.Create(
+            bytes.ToImmutableArray(),
+            result is ITransitiveCompilationResult2 { ManifestHash: var hash } ? hash : null );
     }
 
     public ValueTask<FallibleResultWithDiagnostics<DesignTimeAspectPipelineResultAndState>> ExecuteAsync(

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -749,16 +749,18 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Compressed, unlike <see cref="SerializedTransitiveAspectManifest"/>, and not because these bytes are stored
-    /// anywhere: they are consumed in this same process and discarded, exactly like the same-version ones. The
-    /// reason is compatibility. These bytes are read by the <em>other</em> version's deserializer, and the
-    /// uncompressed format is recognized by peeking a marker byte that was only introduced in 2026.1 (issue #1710).
-    /// A peer older than that has no such peek: it would treat the marker as the first byte of a DEFLATE stream and
-    /// fail. The compressed format is the one every peer understands, so it is what we emit outwards.
+    /// Compressed, unlike <see cref="SerializedTransitiveAspectManifest"/>, following the rule that the compressed
+    /// form is the <em>interchange</em> format, read by a Metalama build that may not be this one, while the
+    /// uncompressed form is the <em>private</em> format, read by this same build in this same process and then
+    /// discarded. The other user of the interchange format is <c>TransitiveAspectsManifest.ToResource</c>, embedded
+    /// in the PE binary and read later by whichever version compiles against that assembly.
     /// </para>
     /// <para>
-    /// This is therefore the one place that compresses without storing. Everything stored compresses too
-    /// (<c>TransitiveAspectsManifest.ToResource</c>, embedded in the PE binary), but the converse does not hold.
+    /// Concretely, these bytes are read by the other version's deserializer, and the uncompressed form is recognized
+    /// by peeking a marker byte introduced in 2026.1 (issue #1710). A peer older than that has no such peek: it
+    /// would treat the marker as the first byte of a DEFLATE stream and fail. Once pre-2026.1 interop is dropped
+    /// this can stop compressing, tracked by issue #1737. The path is cold (mixed-version solutions only, once per
+    /// cross-version reference per pipeline run), so there is nothing to gain by removing it sooner.
     /// </para>
     /// </remarks>
     internal byte[] SerializeTransitiveAspectManifestForOtherVersion()

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -687,19 +687,21 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// </item>
     /// <item>
     /// <c>true</c> for a consumer built against a different version of Metalama. Such a reference carries no live
-    /// result — the producer's result is an object of the other version's <c>Metalama.Framework.Engine</c> and
-    /// cannot cross — so <c>ReferencedExtensions</c> contributes nothing for it and the manifest is the only
-    /// channel available. See <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>.
+    /// result (the producer's result is an object of the other version's <c>Metalama.Framework.Engine</c> and cannot
+    /// cross), so <c>ReferencedExtensions</c> contributes nothing for it and the manifest is the only channel
+    /// available. See <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>.
     /// </item>
     /// </list>
     /// </summary>
     private TransitiveAspectsManifest CreateTransitiveManifest( bool includeValidators )
         =>
 
-            // ContainsInitializableTypes is set to the safe default `true` here for the same reason as in
-            // ITransitiveAspectsManifest.ContainsInitializableTypes above: DesignTimeAspectPipelineResult does
-            // not track the flag, and `true` only causes consumers to run the walker unnecessarily, while
-            // `false` would risk missing required WithInitialize wrapping.
+            // ContainsInitializableTypes is set to the safe default `true`: DesignTimeAspectPipelineResult does not
+            // track the flag (the tracking would be useless at design time, where LinkerAnalysisStep force-runs the
+            // OnInitialized walker because the partial compilation may exclude trees declaring implementers).
+            // LinkerAnalysisStep consumes the flag to skip that walker, so `true` only makes a consumer run it
+            // unnecessarily, a performance pessimization at worst. `false` would be unsafe: a consumer reading it at
+            // compile time could miss required WithInitialize wrapping.
             TransitiveAspectsManifest.Create(
                 this._inheritableAspects.SelectMany( g => g ).ToImmutableArray(),
                 this.Extensions.ToTransitiveValidatorInstances( includeValidators ),
@@ -746,8 +748,18 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// other side is what converts the manifest into the consuming version's object model.
     /// </summary>
     /// <remarks>
-    /// Compressed, unlike <see cref="SerializedTransitiveAspectManifest"/>: the consumer may be an older version
-    /// that only understands the legacy compressed format.
+    /// <para>
+    /// Compressed, unlike <see cref="SerializedTransitiveAspectManifest"/>, and not because these bytes are stored
+    /// anywhere: they are consumed in this same process and discarded, exactly like the same-version ones. The
+    /// reason is compatibility. These bytes are read by the <em>other</em> version's deserializer, and the
+    /// uncompressed format is recognized by peeking a marker byte that was only introduced in 2026.1 (issue #1710).
+    /// A peer older than that has no such peek: it would treat the marker as the first byte of a DEFLATE stream and
+    /// fail. The compressed format is the one every peer understands, so it is what we emit outwards.
+    /// </para>
+    /// <para>
+    /// This is therefore the one place that compresses without storing. Everything stored compresses too
+    /// (<c>TransitiveAspectsManifest.ToResource</c>, embedded in the PE binary), but the converse does not hold.
+    /// </para>
     /// </remarks>
     internal byte[] SerializeTransitiveAspectManifestForOtherVersion()
         => this.CreateTransitiveManifest( includeValidators: true )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -729,9 +729,9 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// do match, the consumer skips it and reuses <see cref="LiveTransitiveAspectManifest"/> instead.
     /// </para>
     /// <para>
-    /// Having no version to cross is separately what lets it stay uncompressed: the only reader is this build, which
-    /// understands the uncompressed marker. That is the sole reason the cross-version form still compresses, so the
-    /// two are not inconsistent. See the remarks there, and issue #1737.
+    /// Uncompressed, as is <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>: nothing that reads either
+    /// of them predates the uncompressed marker. Only <c>TransitiveAspectsManifest.ToResource</c> still compresses,
+    /// and for a reason that does not apply here, namely keeping the PE binary small.
     /// </para>
     /// <para>
     /// Returns <c>default</c> when there is nothing to inherit (see
@@ -769,21 +769,21 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Compressed, unlike <see cref="SerializedTransitiveAspectManifest"/>, following the rule that the compressed
-    /// form is the <em>interchange</em> format, read by a Metalama build that may not be this one, while the
-    /// uncompressed form is the <em>private</em> format, read by this same build in this same process and then
-    /// discarded. The other user of the interchange format is <c>TransitiveAspectsManifest.ToResource</c>, embedded
-    /// in the PE binary and read later by whichever version compiles against that assembly.
+    /// Uncompressed, like <see cref="SerializedTransitiveAspectManifest"/>, even though the reader is a different
+    /// build than the one that wrote these bytes. The uncompressed form is recognized by peeking a marker byte
+    /// introduced in 2026.1 (issue #1710), so a reader older than that would fail on it, but no such reader can
+    /// receive these bytes: a project only consumes this manifest if it has a project reference to this one, and a
+    /// referencing project's Metalama version is never older than the referenced project's. Every possible reader is
+    /// therefore at least this version.
     /// </para>
     /// <para>
-    /// Concretely, these bytes are read by the other version's deserializer, and the uncompressed form is recognized
-    /// by peeking a marker byte introduced in 2026.1 (issue #1710). A peer older than that has no such peek: it
-    /// would treat the marker as the first byte of a DEFLATE stream and fail. Once pre-2026.1 interop is dropped
-    /// this can stop compressing, tracked by issue #1737. The path is cold (mixed-version solutions only, once per
-    /// cross-version reference per pipeline run), so there is nothing to gain by removing it sooner.
+    /// That bound applies to what we <em>write</em>, not to what we read. The converse case is ordinary: this
+    /// project may reference an older one, whose manifest arrives in the legacy compressed form. That is why
+    /// <c>TransitiveAspectsManifest.Deserialize</c> keeps accepting both formats even though nothing writes the
+    /// compressed one any more except <c>ToResource</c>, which compresses to keep the PE binary small.
     /// </para>
     /// </remarks>
     internal byte[] SerializeTransitiveAspectManifestForOtherVersion()
         => this.CreateTransitiveManifest( includeValidators: true )
-            .ToBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: true );
+            .ToBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -675,7 +675,7 @@ public sealed partial class DesignTimeAspectPipelineResult
 
     /// <summary>
     /// Creates the transitive manifest. <paramref name="includeValidators"/> selects whether the design-time
-    /// validators travel in the manifest, and must match whether the consumer has the other channel that carries
+    /// validators are included in the manifest, and must match whether the consumer has the other channel that carries
     /// them, <see cref="DesignTimeProjectVersion.ReferencedExtensions"/>:
     /// <list type="bullet">
     /// <item>
@@ -710,16 +710,36 @@ public sealed partial class DesignTimeAspectPipelineResult
                 containsInitializableTypes: true );
 
     /// <summary>
-    /// Gets the transitive manifest serialized for a consumer built against the <em>same</em> version of Metalama.
-    /// It exists because the consumer must bind the manifest to its own compile-time copy of each type, which a
-    /// round-trip through the serialized form is what achieves (issue #1710); it is not a version bridge. Serialized
-    /// uncompressed, unlike <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>: producer and consumer
-    /// are the same version, so no legacy format has to be honoured and compression would be pure overhead on bytes
-    /// that are produced, consumed and discarded immediately. Returns <c>default</c> when there is nothing to inherit
-    /// (see <see cref="HasTransitiveAspectManifestContent"/>), so a referencing project neither serializes here nor
+    /// Gets the transitive manifest serialized for the design-time pipeline of a referencing project running the
+    /// same version of Metalama in this same process.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A manifest is serialized in exactly three places, and they differ only in which boundary the bytes have to
+    /// cross. <see cref="SerializeTransitiveAspectManifestForOtherVersion"/> crosses a Metalama version.
+    /// <c>TransitiveAspectsManifest.ToResource</c> crosses a process and an arbitrary amount of time, being embedded
+    /// in the PE binary and read by whichever version later compiles against that assembly. This one crosses
+    /// neither: it is produced and consumed by this build, in this process, and then discarded.
+    /// </para>
+    /// <para>
+    /// It exists because a boundary remains even so. The consuming project has to bind the manifest to <em>its own</em>
+    /// compile-time copy of each type, and the round-trip through run-time type names is what rebinds them (issue
+    /// #1710). Two projects of the same Metalama version can hold different compile-time copies, typically when a
+    /// shared assembly is multi-targeted, so what this crosses is a compile-time copy, not a version. When the copies
+    /// do match, the consumer skips it and reuses <see cref="LiveTransitiveAspectManifest"/> instead.
+    /// </para>
+    /// <para>
+    /// Having no version to cross is separately what lets it stay uncompressed: the only reader is this build, which
+    /// understands the uncompressed marker. That is the sole reason the cross-version form still compresses, so the
+    /// two are not inconsistent. See the remarks there, and issue #1737.
+    /// </para>
+    /// <para>
+    /// Returns <c>default</c> when there is nothing to inherit (see
+    /// <see cref="HasTransitiveAspectManifestContent"/>), so a referencing project neither serializes here nor
     /// deserializes and merges an empty manifest on the other side. That is the common case for a Metalama project
     /// exporting no inheritable aspects, options, annotations, or validators.
-    /// </summary>
+    /// </para>
+    /// </remarks>
     [Memo]
     internal SerializedTransitiveAspectManifest SerializedTransitiveAspectManifest
         => this.HasTransitiveAspectManifestContent

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -775,9 +775,10 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// </para>
     /// </remarks>
     [Memo]
-    internal ImmutableArray<byte> SerializedTransitiveAspectManifestWithValidators
-        => this.CreateTransitiveManifest( includeValidators: true )
-            .ToImmutableBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false );
+    internal SerializedTransitiveAspectManifest SerializedTransitiveAspectManifestWithValidators
+        => SerializedTransitiveAspectManifest.Create(
+            this.CreateTransitiveManifest( includeValidators: true )
+                .ToImmutableBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false ) );
 
     /// <summary>
     /// Gets the live, in-memory manifest. A same-version consumer whose compile-time

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -698,16 +698,17 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
     /// them, <see cref="DesignTimeProjectVersion.ReferencedExtensions"/>:
     /// <list type="bullet">
     /// <item>
-    /// <c>false</c> for the in-process, same-version consumer. Its reference carries this very result as its live
+    /// <c>false</c> for a consumer built against the same version of Metalama. Its reference carries this very result as its live
     /// <c>TransitiveAspectsManifest</c>, so <c>ReferencedExtensions</c> reads the validators out of the design-time
     /// extension collection, which deduplicates diamond-shaped reference graphs. Putting them in the manifest as
     /// well would deliver each validator twice (once per channel), and more than twice across a diamond, because
     /// the manifest channel is walked once per direct reference and is not deduplicated.
     /// </item>
     /// <item>
-    /// <c>true</c> for the cross-version (RPC) consumer. Its reference carries a deserialized
-    /// <see cref="TransitiveAspectsManifest"/> rather than a <see cref="DesignTimeAspectPipelineResult"/>, so
-    /// <c>ReferencedExtensions</c> skips it and the manifest is the only channel available.
+    /// <c>true</c> for a consumer built against a different version of Metalama. Such a reference carries no live
+    /// result — the producer's result is an object of the other version's <c>Metalama.Framework.Engine</c> and
+    /// cannot cross — so <c>ReferencedExtensions</c> contributes nothing for it and the manifest is the only
+    /// channel available. See <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>.
     /// </item>
     /// </list>
     /// </summary>
@@ -726,9 +727,12 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
                 containsInitializableTypes: true );
 
     /// <summary>
-    /// Gets the transitive manifest serialized for in-process consumption by the current-version design-time
-    /// pipeline. It is serialized uncompressed: the bytes are produced and consumed in the same process and
-    /// discarded, so compression would be pure overhead. Returns <c>default</c> when there is nothing to inherit
+    /// Gets the transitive manifest serialized for a consumer built against the <em>same</em> version of Metalama.
+    /// It exists because the consumer must bind the manifest to its own compile-time copy of each type, which a
+    /// round-trip through the serialized form is what achieves (issue #1710); it is not a version bridge. Serialized
+    /// uncompressed, unlike <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>: producer and consumer
+    /// are the same version, so no legacy format has to be honoured and compression would be pure overhead on bytes
+    /// that are produced, consumed and discarded immediately. Returns <c>default</c> when there is nothing to inherit
     /// (see <see cref="HasTransitiveAspectManifestContent"/>), so a referencing project neither serializes here nor
     /// deserializes and merges an empty manifest on the other side. That is the common case for a Metalama project
     /// exporting no inheritable aspects, options, annotations, or validators.
@@ -743,19 +747,28 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
 
     /// <summary>
     /// Gets the live, in-memory manifest. It is content-identical to what
-    /// <see cref="SerializedTransitiveAspectManifest"/> encodes, since both are built from the same
-    /// <see cref="CreateTransitiveManifest"/> call. A consumer whose compile-time copies match this producer's can
-    /// consume this object directly and skip the serialize/deserialize round-trip (issue #1710 fast path); see
-    /// <c>TransitivePipelineContributorSource</c>. Memoized so repeated consumer runs share one instance.
+    /// <see cref="SerializedTransitiveAspectManifest"/> encodes, since both come from
+    /// <see cref="CreateTransitiveManifest"/> with the same argument. A same-version consumer whose compile-time
+    /// copies match this producer's can consume this object directly and skip the serialize/deserialize round-trip
+    /// (issue #1710 fast path); see <c>TransitivePipelineContributorSource</c>. Memoized so repeated consumer runs
+    /// share one instance.
     /// </summary>
     [Memo]
     internal TransitiveAspectsManifest LiveTransitiveAspectManifest => this.CreateTransitiveManifest( includeValidators: false );
 
     /// <summary>
-    /// Serializes the transitive manifest for shipping over RPC to a potentially different (possibly older)
-    /// Metalama version, which may only understand the legacy compressed format, so this one is compressed.
+    /// Serializes the transitive manifest for a consumer built against a <em>different</em> version of Metalama:
+    /// two projects of the same solution, one referencing the other, each referencing its own Metalama version.
+    /// Both versions are loaded in the same process and reach each other through the version-neutral
+    /// <c>Metalama.Framework.DesignTime.Contracts</c> assembly, but their <c>Metalama.Framework.Engine</c> types have
+    /// distinct identities, so no manifest object can be passed across. Serializing here and deserializing on the
+    /// other side is what converts the manifest into the consuming version's object model.
     /// </summary>
-    internal byte[] SerializeTransitiveAspectManifestForRpc()
+    /// <remarks>
+    /// Compressed, unlike <see cref="SerializedTransitiveAspectManifest"/>: the consumer may be an older version
+    /// that only understands the legacy compressed format.
+    /// </remarks>
+    internal byte[] SerializeTransitiveAspectManifestForOtherVersion()
         => this.CreateTransitiveManifest( includeValidators: true )
             .ToBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: true );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -692,7 +692,26 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
            || !this.Annotations.IsEmpty
            || !this.Extensions.IsEmpty;
 
-    private TransitiveAspectsManifest CreateTransitiveManifest()
+    /// <summary>
+    /// Creates the transitive manifest. <paramref name="includeValidators"/> selects whether the design-time
+    /// validators travel in the manifest, and must match whether the consumer has the other channel that carries
+    /// them, <see cref="DesignTimeProjectVersion.ReferencedExtensions"/>:
+    /// <list type="bullet">
+    /// <item>
+    /// <c>false</c> for the in-process, same-version consumer. Its reference carries this very result as its live
+    /// <c>TransitiveAspectsManifest</c>, so <c>ReferencedExtensions</c> reads the validators out of the design-time
+    /// extension collection, which deduplicates diamond-shaped reference graphs. Putting them in the manifest as
+    /// well would deliver each validator twice (once per channel), and more than twice across a diamond, because
+    /// the manifest channel is walked once per direct reference and is not deduplicated.
+    /// </item>
+    /// <item>
+    /// <c>true</c> for the cross-version (RPC) consumer. Its reference carries a deserialized
+    /// <see cref="TransitiveAspectsManifest"/> rather than a <see cref="DesignTimeAspectPipelineResult"/>, so
+    /// <c>ReferencedExtensions</c> skips it and the manifest is the only channel available.
+    /// </item>
+    /// </list>
+    /// </summary>
+    private TransitiveAspectsManifest CreateTransitiveManifest( bool includeValidators )
         =>
 
             // ContainsInitializableTypes is set to the safe default `true` here for the same reason as in
@@ -701,7 +720,7 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
             // `false` would risk missing required WithInitialize wrapping.
             TransitiveAspectsManifest.Create(
                 this._inheritableAspects.SelectMany( g => g ).ToImmutableArray(),
-                this.Extensions.ToTransitiveValidatorInstances( true ),
+                this.Extensions.ToTransitiveValidatorInstances( includeValidators ),
                 this.InheritableOptions,
                 this.Annotations,
                 containsInitializableTypes: true );
@@ -718,7 +737,8 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
     internal SerializedTransitiveAspectManifest SerializedTransitiveAspectManifest
         => this.HasTransitiveAspectManifestContent
             ? SerializedTransitiveAspectManifest.Create(
-                this.CreateTransitiveManifest().ToImmutableBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false ) )
+                this.CreateTransitiveManifest( includeValidators: false )
+                    .ToImmutableBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false ) )
             : default;
 
     /// <summary>
@@ -729,12 +749,13 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
     /// <c>TransitivePipelineContributorSource</c>. Memoized so repeated consumer runs share one instance.
     /// </summary>
     [Memo]
-    internal TransitiveAspectsManifest LiveTransitiveAspectManifest => this.CreateTransitiveManifest();
+    internal TransitiveAspectsManifest LiveTransitiveAspectManifest => this.CreateTransitiveManifest( includeValidators: false );
 
     /// <summary>
     /// Serializes the transitive manifest for shipping over RPC to a potentially different (possibly older)
     /// Metalama version, which may only understand the legacy compressed format, so this one is compressed.
     /// </summary>
     internal byte[] SerializeTransitiveAspectManifestForRpc()
-        => this.CreateTransitiveManifest().ToBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: true );
+        => this.CreateTransitiveManifest( includeValidators: true )
+            .ToBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: true );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -28,7 +28,7 @@ namespace Metalama.Framework.DesignTime.Pipeline;
 /// <summary>
 /// Caches the pipeline results for each syntax tree.
 /// </summary>
-public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsManifest
+public sealed partial class DesignTimeAspectPipelineResult
 {
     private static readonly ImmutableDictionary<string, SyntaxTreePipelineResult> _emptySyntaxTreeResults =
         ImmutableDictionary.Create<string, SyntaxTreePipelineResult>( StringComparer.Ordinal );
@@ -653,25 +653,6 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
     public IEnumerable<string> InheritableAspectTypes => this._inheritableAspects.Keys;
 
     public IEnumerable<InheritableAspectInstance> GetInheritableAspects( string aspectType ) => this._inheritableAspects[aspectType];
-
-    /// <summary>
-    /// At design time, cross-project reference validators are not added to the main pipeline. Instead, the validator
-    /// provider recursively includes the providers of referenced projects. However, cross-project references are
-    /// still used for PE references.
-    /// </summary>
-    ImmutableArray<ITransitiveAspectsManifestExtension> ITransitiveAspectsManifest.Extensions => this.Extensions.ToTransitiveValidatorInstances( false );
-
-    /// <summary>
-    /// Gets a value indicating whether the compilation contains <c>IInitializable</c> implementers.
-    /// <see cref="DesignTimeAspectPipelineResult"/> does not track this (the tracking would be useless at design
-    /// time, where <c>LinkerAnalysisStep</c> force-runs the <c>OnInitialized</c> walker because the partial
-    /// compilation may exclude trees declaring implementers). We therefore report the safe default <c>true</c>: the
-    /// flag is consumed by <c>LinkerAnalysisStep</c> to skip the walker, and returning <c>true</c> just forces the
-    /// walker to run, which is a performance pessimization at worst, never a correctness bug. Returning
-    /// <c>false</c> would be unsafe: if any consumer reads this at compile time, it could miss required
-    /// <c>WithInitialize</c> wrapping.
-    /// </summary>
-    bool ITransitiveAspectsManifest.ContainsInitializableTypes => true;
 
     /// <summary>
     /// Gets a value indicating whether this project exports something a referencing project could inherit: an

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -658,7 +658,7 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// Gets a value indicating whether this project exports something a referencing project could inherit: an
     /// inheritable aspect, an inheritable option, an exported annotation, or a transitive validator (carried by
     /// <see cref="Extensions"/>). When it is <c>false</c> there is nothing to serialize and nothing for a consumer
-    /// to merge, so the manifest is not produced at all. See <see cref="SerializedTransitiveAspectManifest"/> and
+    /// to merge, so the manifest is not produced at all. See <see cref="SerializedTransitiveAspectManifestWithoutValidators"/> and
     /// the reference-construction site in <c>DesignTimeAspectPipeline</c>.
     /// </summary>
     /// <remarks>
@@ -689,7 +689,7 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// <c>true</c> for a consumer built against a different version of Metalama. Such a reference carries no live
     /// result (the producer's result is an object of the other version's <c>Metalama.Framework.Engine</c> and cannot
     /// cross), so <c>ReferencedExtensions</c> contributes nothing for it and the manifest is the only channel
-    /// available. See <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>.
+    /// available. See <see cref="SerializedTransitiveAspectManifestWithValidators"/>.
     /// </item>
     /// </list>
     /// </summary>
@@ -716,7 +716,7 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// <remarks>
     /// <para>
     /// A manifest is serialized in exactly three places, and they differ only in which boundary the bytes have to
-    /// cross. <see cref="SerializeTransitiveAspectManifestForOtherVersion"/> crosses a Metalama version.
+    /// cross. <see cref="SerializedTransitiveAspectManifestWithValidators"/> crosses a Metalama version.
     /// <c>TransitiveAspectsManifest.ToResource</c> crosses a process and an arbitrary amount of time, being embedded
     /// in the PE binary and read by whichever version later compiles against that assembly. This one crosses
     /// neither: it is produced and consumed by this build, in this process, and then discarded.
@@ -729,38 +729,24 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// do match, the consumer skips it and reuses <see cref="LiveTransitiveAspectManifest"/> instead.
     /// </para>
     /// <para>
-    /// Uncompressed, as is <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>: nothing that reads either
+    /// Uncompressed, as is <see cref="SerializedTransitiveAspectManifestWithValidators"/>: nothing that reads either
     /// of them predates the uncompressed marker. Only <c>TransitiveAspectsManifest.ToResource</c> still compresses,
     /// and for a reason that does not apply here, namely keeping the PE binary small.
     /// </para>
     /// <para>
-    /// Returns <c>default</c> when there is nothing to inherit (see
-    /// <see cref="HasTransitiveAspectManifestContent"/>), so a referencing project neither serializes here nor
-    /// deserializes and merges an empty manifest on the other side. That is the common case for a Metalama project
-    /// exporting no inheritable aspects, options, annotations, or validators.
+    /// Serializes unconditionally. Whether it is worth serializing at all is the caller's question, answered by
+    /// <see cref="HasTransitiveAspectManifestContent"/>: a project exporting nothing to inherit, which is the common
+    /// case, carries no manifest on its reference, so nothing is deserialized or merged on the other side either.
     /// </para>
     /// </remarks>
     [Memo]
-    internal SerializedTransitiveAspectManifest SerializedTransitiveAspectManifest
-        => this.HasTransitiveAspectManifestContent
-            ? SerializedTransitiveAspectManifest.Create(
-                this.CreateTransitiveManifest( includeValidators: false )
-                    .ToImmutableBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false ) )
-            : default;
+    internal SerializedTransitiveAspectManifest SerializedTransitiveAspectManifestWithoutValidators
+        => SerializedTransitiveAspectManifest.Create(
+            this.LiveTransitiveAspectManifest
+                .ToImmutableBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false ) );
 
     /// <summary>
-    /// Gets the live, in-memory manifest. It is content-identical to what
-    /// <see cref="SerializedTransitiveAspectManifest"/> encodes, since both come from
-    /// <see cref="CreateTransitiveManifest"/> with the same argument. A same-version consumer whose compile-time
-    /// copies match this producer's can consume this object directly and skip the serialize/deserialize round-trip
-    /// (issue #1710 fast path); see <c>TransitivePipelineContributorSource</c>. Memoized so repeated consumer runs
-    /// share one instance.
-    /// </summary>
-    [Memo]
-    internal TransitiveAspectsManifest LiveTransitiveAspectManifest => this.CreateTransitiveManifest( includeValidators: false );
-
-    /// <summary>
-    /// Serializes the transitive manifest for a consumer built against a <em>different</em> version of Metalama:
+    /// Gets the transitive manifest serialized for a consumer built against a <em>different</em> version of Metalama:
     /// two projects of the same solution, one referencing the other, each referencing its own Metalama version.
     /// Both versions are loaded in the same process and reach each other through the version-neutral
     /// <c>Metalama.Framework.DesignTime.Contracts</c> assembly, but their <c>Metalama.Framework.Engine</c> types have
@@ -769,7 +755,7 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Uncompressed, like <see cref="SerializedTransitiveAspectManifest"/>, even though the reader is a different
+    /// Uncompressed, like <see cref="SerializedTransitiveAspectManifestWithoutValidators"/>, even though the reader is a different
     /// build than the one that wrote these bytes. The uncompressed form is recognized by peeking a marker byte
     /// introduced in 2026.1 (issue #1710), so a reader older than that would fail on it, but no such reader can
     /// receive these bytes: a project only consumes this manifest if it has a project reference to this one, and a
@@ -782,8 +768,22 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// <c>TransitiveAspectsManifest.Deserialize</c> keeps accepting both formats even though nothing writes the
     /// compressed one any more except <c>ToResource</c>, which compresses to keep the PE binary small.
     /// </para>
+    /// <para>
+    /// Serializes unconditionally, as <see cref="SerializedTransitiveAspectManifestWithoutValidators"/> does, and for the same
+    /// reason: whether there is anything worth sending is <see cref="HasTransitiveAspectManifestContent"/>, which
+    /// belongs to the caller.
+    /// </para>
     /// </remarks>
-    internal byte[] SerializeTransitiveAspectManifestForOtherVersion()
+    [Memo]
+    internal ImmutableArray<byte> SerializedTransitiveAspectManifestWithValidators
         => this.CreateTransitiveManifest( includeValidators: true )
-            .ToBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false );
+            .ToImmutableBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: false );
+
+    /// <summary>
+    /// Gets the live, in-memory manifest. A same-version consumer whose compile-time
+    /// copies match this producer's can consume this object directly and skip the serialize/deserialize round-trip
+    /// (issue #1710 fast path); see <c>TransitivePipelineContributorSource</c>. 
+    /// </summary>
+    [Memo]
+    internal TransitiveAspectsManifest LiveTransitiveAspectManifest => this.CreateTransitiveManifest( includeValidators: false );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
@@ -13,18 +13,31 @@ namespace Metalama.Framework.DesignTime.Pipeline;
 /// </summary>
 internal readonly struct DesignTimeProjectReference
 {
-    // The two manifest representations below are always both set or both null: a reference carries them when it is
-    // a Metalama project that exports something to inherit (an inheritable aspect, option, annotation, or validator),
-    // and carries neither when it is not a Metalama project or is one that exports nothing (see gate in
-    // DesignTimeAspectPipelineResult.HasTransitiveAspectManifestContent). They are not interchangeable: they serve
-    // different consumers and neither can be derived from the other at the point where it is needed.
+    // A reference carries a serialized manifest when it is a Metalama project that exports something to inherit (an
+    // inheritable aspect, option, annotation, or validator), and carries none when it is not a Metalama project or is
+    // one that exports nothing (see gate in DesignTimeAspectPipelineResult.HasTransitiveAspectManifestContent).
+    //
+    // The live result below is carried in addition, but only for a same-version reference. The two are not
+    // interchangeable: they serve different consumers and neither can be derived from the other at the point where
+    // it is needed.
 
     /// <summary>
-    /// Gets the referenced project's live manifest. Used only by <see cref="DesignTimeProjectVersion.ReferencedExtensions"/>,
-    /// which needs the concrete <c>DesignTimeAspectPipelineResult</c> to read its design-time extension collections
-    /// (a shape the serialized manifest does not carry).
+    /// Gets the referenced project's live pipeline result, or <c>null</c> when the reference is to a project built
+    /// against a different version of Metalama. Used only by
+    /// <see cref="DesignTimeProjectVersion.ReferencedExtensions"/> and
+    /// <see cref="DesignTimeProjectVersion.TryGetReusableTransitiveAspectsManifest"/>, both of which need the
+    /// concrete <see cref="DesignTimeAspectPipelineResult"/> — the first to read its design-time extension
+    /// collections (a shape the serialized manifest does not carry), the second to reuse the producer's live objects
+    /// and its configuration.
     /// </summary>
-    public ITransitiveAspectsManifest? TransitiveAspectsManifest { get; }
+    /// <remarks>
+    /// This is deliberately typed as the concrete result rather than <c>ITransitiveAspectsManifest</c>. A
+    /// cross-version producer cannot supply one at all: its pipeline result is an object of the *other* version's
+    /// <c>Metalama.Framework.Engine</c>, so the only thing that can cross is the serialized manifest. Typing it
+    /// concretely states that, instead of accepting any manifest here and having both readers narrow to this type
+    /// and silently ignore anything else.
+    /// </remarks>
+    public DesignTimeAspectPipelineResult? TransitiveAspectsManifest { get; }
 
     /// <summary>
     /// Gets the transitive aspect manifest in its serialized (compilation-neutral) form: compile-time types are
@@ -40,12 +53,13 @@ internal readonly struct DesignTimeProjectReference
 
     public DesignTimeProjectReference(
         ProjectKey projectKey,
-        ITransitiveAspectsManifest? transitiveAspectsManifest = null,
+        DesignTimeAspectPipelineResult? transitiveAspectsManifest = null,
         SerializedTransitiveAspectManifest serializedTransitiveAspectManifest = default )
     {
-        // Both manifest representations are either both present or both absent: a reference either has a
-        // transitive aspect manifest (in both its live and its serialized form) or is not a Metalama project.
-        Invariant.Assert( transitiveAspectsManifest != null == !serializedTransitiveAspectManifest.IsDefaultOrEmpty );
+        // A live result is only ever carried alongside a serialized manifest, never on its own: it comes from a
+        // same-version reference that exports something to inherit, and such a reference always serializes too. The
+        // converse does not hold, because a cross-version reference carries the serialized manifest alone.
+        Invariant.Assert( transitiveAspectsManifest == null || !serializedTransitiveAspectManifest.IsDefaultOrEmpty );
 
         this.TransitiveAspectsManifest = transitiveAspectsManifest;
         this.SerializedTransitiveAspectManifest = serializedTransitiveAspectManifest;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
@@ -9,7 +9,9 @@ using Metalama.Framework.Engine.Aspects;
 namespace Metalama.Framework.DesignTime.Pipeline;
 
 /// <summary>
-/// Associates a <see cref="ProjectKey"/> and a <see cref="TransitiveAspectsManifest"/>.
+/// A referenced project, as seen by the referencing project's design-time pipeline: a <see cref="ProjectKey"/>, the
+/// serialized transitive manifest when the reference exports anything to inherit, and, for a reference built against
+/// the same version of Metalama, that project's live pipeline result as well.
 /// </summary>
 internal readonly struct DesignTimeProjectReference
 {
@@ -26,7 +28,7 @@ internal readonly struct DesignTimeProjectReference
     /// against a different version of Metalama. Used only by
     /// <see cref="DesignTimeProjectVersion.ReferencedExtensions"/> and
     /// <see cref="DesignTimeProjectVersion.TryGetReusableTransitiveAspectsManifest"/>, both of which need the
-    /// concrete <see cref="DesignTimeAspectPipelineResult"/> — the first to read its design-time extension
+    /// concrete <see cref="DesignTimeAspectPipelineResult"/>: the first to read its design-time extension
     /// collections (a shape the serialized manifest does not carry), the second to reuse the producer's live objects
     /// and its configuration.
     /// </summary>

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
@@ -49,19 +49,19 @@ internal readonly struct DesignTimeProjectReference
     /// only that project's closure can name (resolve) its own compile-time copy of a shared assembly; the
     /// consuming project's provider could not serialize types bound to a copy that is not in its closure.
     /// </summary>
-    public SerializedTransitiveAspectManifest SerializedTransitiveAspectManifest { get; }
+    public SerializedTransitiveAspectManifest? SerializedTransitiveAspectManifest { get; }
 
     public ProjectKey ProjectKey { get; }
 
     public DesignTimeProjectReference(
         ProjectKey projectKey,
         DesignTimeAspectPipelineResult? transitiveAspectsManifest = null,
-        SerializedTransitiveAspectManifest serializedTransitiveAspectManifest = default )
+        SerializedTransitiveAspectManifest? serializedTransitiveAspectManifest = null )
     {
         // A live result is only ever carried alongside a serialized manifest, never on its own: it comes from a
         // same-version reference that exports something to inherit, and such a reference always serializes too. The
         // converse does not hold, because a cross-version reference carries the serialized manifest alone.
-        Invariant.Assert( transitiveAspectsManifest == null || !serializedTransitiveAspectManifest.IsDefaultOrEmpty );
+        Invariant.Assert( transitiveAspectsManifest == null || serializedTransitiveAspectManifest != null );
 
         this.TransitiveAspectsManifest = transitiveAspectsManifest;
         this.SerializedTransitiveAspectManifest = serializedTransitiveAspectManifest;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
@@ -22,10 +22,24 @@ internal sealed class DesignTimeProjectVersion : ITransitiveAspectManifestProvid
     public IProjectVersion ProjectVersion { get; }
 
     /// <summary>
-    /// Gets the design-time extension collections of the referenced projects. Cross-version references contribute
-    /// nothing here, because they carry no live result; their contribution travels in the serialized manifest
-    /// instead, which the engine deserializes into this project's own compile-time copy.
+    /// Gets the design-time extension collections of the referenced projects. This is one of the two channels by
+    /// which a reference's design-time validators reach this project, and it serves same-version references only.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A reference built against a different version of Metalama contributes nothing here, because it carries no
+    /// live result to read the collection from. It is not lost: it travels instead through the serialized manifest,
+    /// which <c>TransitivePipelineContributorSource</c> deserializes into this project's own compile-time copy. That
+    /// is why <c>DesignTimeAspectPipelineResult.CreateTransitiveManifest</c> puts validators in the manifest for a
+    /// cross-version consumer and keeps them out for a same-version one: whichever channel is unavailable, exactly
+    /// one carries them.
+    /// </para>
+    /// <para>
+    /// The split is not merely an optimization. This channel deduplicates diamond-shaped reference graphs, whereas
+    /// the manifest channel is walked once per direct reference and does not, so routing a same-version reference
+    /// through both delivers its validators more than once.
+    /// </para>
+    /// </remarks>
     public IEnumerable<DesignTimeAspectPipelineResultExtensionCollection> ReferencedExtensions
         => this._references.Values.Select( r => r.TransitiveAspectsManifest?.Extensions ).WhereNotNull();
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
@@ -53,14 +53,14 @@ internal sealed class DesignTimeProjectVersion : ITransitiveAspectManifestProvid
         this._references = references.ToImmutableDictionary( x => x.ProjectKey, x => x );
     }
 
-    public SerializedTransitiveAspectManifest GetSerializedTransitiveAspectsManifest( Compilation compilation )
+    public SerializedTransitiveAspectManifest? GetSerializedTransitiveAspectsManifest( Compilation compilation )
     {
         if ( this._references.TryGetValue( compilation.GetProjectKey(), out var reference ) )
         {
             return reference.SerializedTransitiveAspectManifest;
         }
 
-        return default;
+        return null;
     }
 
     public bool TryGetReusableTransitiveAspectsManifest(

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
@@ -21,8 +21,13 @@ internal sealed class DesignTimeProjectVersion : ITransitiveAspectManifestProvid
 
     public IProjectVersion ProjectVersion { get; }
 
+    /// <summary>
+    /// Gets the design-time extension collections of the referenced projects. Cross-version references contribute
+    /// nothing here, because they carry no live result; their contribution travels in the serialized manifest
+    /// instead, which the engine deserializes into this project's own compile-time copy.
+    /// </summary>
     public IEnumerable<DesignTimeAspectPipelineResultExtensionCollection> ReferencedExtensions
-        => this._references.Values.Select( r => (r.TransitiveAspectsManifest as DesignTimeAspectPipelineResult)?.Extensions ).WhereNotNull();
+        => this._references.Values.Select( r => r.TransitiveAspectsManifest?.Extensions ).WhereNotNull();
 
     public DesignTimeProjectVersion(
         IProjectVersion projectVersion,
@@ -49,11 +54,11 @@ internal sealed class DesignTimeProjectVersion : ITransitiveAspectManifestProvid
         [NotNullWhen( true )] out ITransitiveAspectsManifest? manifest,
         [NotNullWhen( true )] out AspectPipelineConfiguration? producerConfiguration )
     {
-        // Only a same-version project reference carries a live DesignTimeAspectPipelineResult (a cross-version
-        // reference carries a deserialized manifest, which cannot be reused). We also need the producer's
-        // configuration to compare compile-time copies, so require it to be present.
+        // Only a same-version project reference carries a live result; a cross-version reference carries the
+        // serialized manifest alone, and there is nothing to reuse. We also need the producer's configuration to
+        // compare compile-time copies, so require it to be present.
         if ( this._references.TryGetValue( compilation.GetProjectKey(), out var reference )
-             && reference.TransitiveAspectsManifest is DesignTimeAspectPipelineResult { HasTransitiveAspectManifestContent: true, Configuration: { } configuration } result )
+             && reference.TransitiveAspectsManifest is { HasTransitiveAspectManifestContent: true, Configuration: { } configuration } result )
         {
             producerConfiguration = configuration;
             manifest = result.LiveTransitiveAspectManifest;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationResult.cs
@@ -3,11 +3,12 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.DesignTime.Contracts.Pipeline;
+using Metalama.Framework.Engine.Aspects;
 using Microsoft.CodeAnalysis;
 
 namespace Metalama.Framework.DesignTime.VersionNeutral;
 
-internal sealed class TransitiveCompilationResult : ITransitiveCompilationResult
+internal sealed class TransitiveCompilationResult : ITransitiveCompilationResult2
 {
     public bool IsSuccessful { get; }
 
@@ -15,18 +16,30 @@ internal sealed class TransitiveCompilationResult : ITransitiveCompilationResult
 
     public byte[]? Manifest { get; }
 
+    /// <summary>
+    /// Gets the hash of <see cref="Manifest"/>. Taken from the producing project's
+    /// <see cref="SerializedTransitiveAspectManifest"/>, so it hashes exactly the bytes exposed here.
+    /// </summary>
+    public long ManifestHash { get; }
+
     public Diagnostic[] Diagnostics { get; }
 
-    private TransitiveCompilationResult( bool isSuccessful, bool isPipelinePaused, byte[]? manifest, Diagnostic[] diagnostics )
+    private TransitiveCompilationResult(
+        bool isSuccessful,
+        bool isPipelinePaused,
+        byte[]? manifest,
+        long manifestHash,
+        Diagnostic[] diagnostics )
     {
         this.IsSuccessful = isSuccessful;
         this.IsPipelinePaused = isPipelinePaused;
         this.Manifest = manifest;
+        this.ManifestHash = manifestHash;
         this.Diagnostics = diagnostics;
     }
 
-    public static TransitiveCompilationResult Success( bool isPipelinePaused, byte[] manifest )
-        => new( true, isPipelinePaused, manifest, Array.Empty<Diagnostic>() );
+    public static TransitiveCompilationResult Success( bool isPipelinePaused, SerializedTransitiveAspectManifest manifest )
+        => new( true, isPipelinePaused, manifest.Bytes.ToArray(), manifest.Hash, Array.Empty<Diagnostic>() );
 
-    public static TransitiveCompilationResult Failed( Diagnostic[] diagnostics ) => new( false, false, null, diagnostics );
+    public static TransitiveCompilationResult Failed( Diagnostic[] diagnostics ) => new( false, false, null, 0, diagnostics );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
@@ -46,7 +46,7 @@ internal sealed class TransitiveCompilationService : ITransitiveCompilationServi
         {
             result[0] = TransitiveCompilationResult.Success(
                 pipelineResult.Value.Status == DesignTimeAspectPipelineStatus.Paused,
-                pipelineResult.Value.Result.SerializeTransitiveAspectManifestForRpc() );
+                pipelineResult.Value.Result.SerializeTransitiveAspectManifestForOtherVersion() );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
@@ -46,7 +46,7 @@ internal sealed class TransitiveCompilationService : ITransitiveCompilationServi
         {
             result[0] = TransitiveCompilationResult.Success(
                 pipelineResult.Value.Status == DesignTimeAspectPipelineStatus.Paused,
-                pipelineResult.Value.Result.SerializeTransitiveAspectManifestForOtherVersion() );
+                pipelineResult.Value.Result.SerializedTransitiveAspectManifestWithValidators.ToArray() );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
@@ -46,7 +46,7 @@ internal sealed class TransitiveCompilationService : ITransitiveCompilationServi
         {
             result[0] = TransitiveCompilationResult.Success(
                 pipelineResult.Value.Status == DesignTimeAspectPipelineStatus.Paused,
-                pipelineResult.Value.Result.SerializedTransitiveAspectManifestWithValidators.ToArray() );
+                pipelineResult.Value.Result.SerializedTransitiveAspectManifestWithValidators );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/ITransitiveAspectManifestProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/ITransitiveAspectManifestProvider.cs
@@ -33,10 +33,10 @@ namespace Metalama.Framework.Engine.Aspects
         /// shared assembly. The consumer deserializes it with its own service provider, which binds the run-time
         /// names to the consumer's own compile-time copy of each type, so inherited aspects and options are bound
         /// to the consuming project's copy of a shared (e.g. multi-targeted) compile-time assembly rather than the
-        /// producer's copy (issue #1710). Returns a default (or empty) array if the reference has no transitive
-        /// aspect manifest (e.g. it is not a Metalama project). The returned value carries a hash of the bytes, so a
-        /// consumer can tell an unchanged manifest from a merely re-produced one.
+        /// producer's copy (issue #1710). Returns <c>null</c> if the reference has no transitive aspect manifest,
+        /// for instance because it is not a Metalama project or exports nothing to inherit. The returned value
+        /// carries a hash of the bytes, so a consumer can tell an unchanged manifest from a merely re-produced one.
         /// </summary>
-        SerializedTransitiveAspectManifest GetSerializedTransitiveAspectsManifest( Compilation compilationReferenceCompilation );
+        SerializedTransitiveAspectManifest? GetSerializedTransitiveAspectsManifest( Compilation compilationReferenceCompilation );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/SerializedTransitiveAspectManifest.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/SerializedTransitiveAspectManifest.cs
@@ -92,8 +92,9 @@ public sealed class SerializedTransitiveAspectManifest : IEquatable<SerializedTr
 
     public override int GetHashCode() => this.Hash.GetHashCode();
 
+    // ReSharper disable once ArrangeRedundantParentheses
     public static bool operator ==( SerializedTransitiveAspectManifest? left, SerializedTransitiveAspectManifest? right )
-        => left?.Equals( right ) ?? right is null;
+        => left?.Equals( right ) ?? (right is null);
 
     public static bool operator !=( SerializedTransitiveAspectManifest? left, SerializedTransitiveAspectManifest? right )
         => !(left == right);

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/SerializedTransitiveAspectManifest.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/SerializedTransitiveAspectManifest.cs
@@ -29,56 +29,72 @@ namespace Metalama.Framework.Engine.Aspects;
 /// </para>
 /// </remarks>
 [PublicAPI]
-public readonly struct SerializedTransitiveAspectManifest : IEquatable<SerializedTransitiveAspectManifest>
+public sealed class SerializedTransitiveAspectManifest : IEquatable<SerializedTransitiveAspectManifest>
 {
+    private long? _hash;
+
     /// <summary>
-    /// Gets the serialized manifest. Default or empty when the project exports nothing to inherit.
+    /// Gets the serialized manifest.
     /// </summary>
     public ImmutableArray<byte> Bytes { get; }
 
-    /// <summary>
-    /// Gets an <see cref="T:System.IO.Hashing.XxHash64"/> of <see cref="Bytes"/>, or zero when there are no bytes.
-    /// </summary>
-    public long Hash { get; }
-
-    private SerializedTransitiveAspectManifest( ImmutableArray<byte> bytes, long hash )
+    private SerializedTransitiveAspectManifest( ImmutableArray<byte> bytes, long? hash )
     {
+        Invariant.AssertNot( bytes.IsDefault );
+        
         this.Bytes = bytes;
-        this.Hash = hash;
+        this._hash = hash;
+    }
+    
+    /// <summary>
+    /// Gets an <see cref="T:System.IO.Hashing.XxHash64"/> of <see cref="Bytes"/>, computed on first access unless
+    /// the producer supplied it.
+    /// </summary>
+    public long Hash => this._hash ??= this.ComputeHash();
+
+    private long ComputeHash()
+    {
+        var hash = new XxHash64();
+        hash.Append( this.Bytes );
+
+        return (long) hash.GetCurrentHashAsUInt64();
     }
 
     /// <summary>
-    /// Creates a <see cref="SerializedTransitiveAspectManifest"/> from its bytes, computing the hash. Returns the
-    /// default value when there are no bytes, so that "nothing to inherit" has a single representation.
+    /// Creates a <see cref="SerializedTransitiveAspectManifest"/> from its bytes, hashing them on first access.
     /// </summary>
+    /// <remarks>
+    /// Wrapping is all this does: a project with nothing to inherit is represented by a <c>null</c> manifest, never
+    /// by one holding no bytes, so callers decide absence before they get here.
+    /// </remarks>
     public static SerializedTransitiveAspectManifest Create( ImmutableArray<byte> bytes )
-    {
-        if ( bytes.IsDefaultOrEmpty )
-        {
-            return default;
-        }
+        => new( bytes, null );
 
-        var hash = new XxHash64();
-        hash.Append( bytes );
-
-        return new SerializedTransitiveAspectManifest( bytes, (long) hash.GetCurrentHashAsUInt64() );
-    }
-
-    public bool IsDefaultOrEmpty => this.Bytes.IsDefaultOrEmpty;
+    /// <summary>
+    /// Creates a <see cref="SerializedTransitiveAspectManifest"/> from its bytes and a hash already computed over
+    /// exactly those bytes, skipping the hashing.
+    /// </summary>
+    /// <remarks>
+    /// For a manifest received from a project built against a different version of Metalama, whose producer hashed
+    /// the bytes it sent and reports the result through <c>ITransitiveCompilationResult2.ManifestHash</c>. The hash
+    /// is taken on trust: it is treated as an identity here (see the remarks on this type), so passing a hash of
+    /// anything other than <paramref name="bytes"/> would make two different manifests compare equal.
+    /// </remarks>
+    public static SerializedTransitiveAspectManifest Create( ImmutableArray<byte> bytes, long? hash ) => new( bytes, hash );
 
     /// <summary>
     /// Determines whether two manifests have the same content, by comparing their hashes alone. See the remarks on
     /// <see cref="SerializedTransitiveAspectManifest"/> for why a hash equality is taken as an identity here.
     /// </summary>
-    public bool Equals( SerializedTransitiveAspectManifest other ) => this.Hash == other.Hash;
+    public bool Equals( SerializedTransitiveAspectManifest? other ) => other != null && this.Hash == other.Hash;
 
     public override bool Equals( object? obj ) => obj is SerializedTransitiveAspectManifest other && this.Equals( other );
 
     public override int GetHashCode() => this.Hash.GetHashCode();
 
-    public static bool operator ==( SerializedTransitiveAspectManifest left, SerializedTransitiveAspectManifest right )
-        => left.Equals( right );
+    public static bool operator ==( SerializedTransitiveAspectManifest? left, SerializedTransitiveAspectManifest? right )
+        => left?.Equals( right ) ?? right is null;
 
-    public static bool operator !=( SerializedTransitiveAspectManifest left, SerializedTransitiveAspectManifest right )
-        => !left.Equals( right );
+    public static bool operator !=( SerializedTransitiveAspectManifest? left, SerializedTransitiveAspectManifest? right )
+        => !(left == right);
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveManifestDeserializationCache.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveManifestDeserializationCache.cs
@@ -84,11 +84,11 @@ internal sealed class TransitiveManifestDeserializationCache : IProjectService
     /// </remarks>
     public ITransitiveAspectsManifest GetOrAdd(
         AssemblyIdentity producer,
-        in SerializedTransitiveAspectManifest serialized,
+        SerializedTransitiveAspectManifest? serialized,
         CompileTimeProject? consumerProject,
         Func<ITransitiveAspectsManifest> deserialize )
     {
-        if ( consumerProject == null || serialized.IsDefaultOrEmpty )
+        if ( consumerProject == null || serialized == null )
         {
             return deserialize();
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitivePipelineContributorSource.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitivePipelineContributorSource.cs
@@ -132,7 +132,7 @@ internal sealed partial class TransitivePipelineContributorSource : IExternalHie
                         var serializedManifest =
                             inheritableAspectProvider.GetSerializedTransitiveAspectsManifest( compilationReference.Compilation );
 
-                        if ( !serializedManifest.IsDefaultOrEmpty )
+                        if ( serializedManifest != null )
                         {
                             ITransitiveAspectsManifest DeserializeProjectManifest()
                                 => TransitiveAspectsManifest.Deserialize(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestDeserializationCacheTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestDeserializationCacheTests.cs
@@ -129,13 +129,13 @@ public sealed class TransitiveManifestDeserializationCacheTests : UnitTestClass
     }
 
     [Fact]
-    public void EmptyManifest_IsNeverCached()
+    public void AbsentManifest_IsNeverCached()
     {
         var cache = new TransitiveManifestDeserializationCache();
         var deserializer = new CountingDeserializer();
 
-        cache.GetOrAdd( _producerA, default, CompileTimeProject.Empty, deserializer.Deserialize );
-        cache.GetOrAdd( _producerA, default, CompileTimeProject.Empty, deserializer.Deserialize );
+        cache.GetOrAdd( _producerA, null, CompileTimeProject.Empty, deserializer.Deserialize );
+        cache.GetOrAdd( _producerA, null, CompileTimeProject.Empty, deserializer.Deserialize );
 
         Assert.Equal( 2, deserializer.CallCount );
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
@@ -156,9 +156,10 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         var result = Execute( testContext, factory, _producerCode );
         var serviceProvider = result.Configuration!.ServiceProvider;
 
-        // The in-process format is uncompressed (marked); the RPC/PE format is a bare DEFLATE stream (no marker).
+        // The same-version format is uncompressed (marked); the cross-version format, which an older consumer may
+        // require, is a bare DEFLATE stream (no marker).
         var uncompressed = result.SerializedTransitiveAspectManifest;
-        var compressed = result.SerializeTransitiveAspectManifestForRpc();
+        var compressed = result.SerializeTransitiveAspectManifestForOtherVersion();
 
         Assert.Equal( SerializationProtocol.UncompressedStreamMarker, uncompressed.Bytes[0] );
         Assert.NotEqual( SerializationProtocol.UncompressedStreamMarker, compressed[0] );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
@@ -72,7 +72,7 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         Assert.True( result.HasTransitiveAspectManifestContent );
 
         var serialized = result.SerializedTransitiveAspectManifestWithoutValidators;
-        Assert.False( serialized.IsDefaultOrEmpty );
+        Assert.NotEmpty( serialized.Bytes );
 
         // The in-process (design-time) manifest is serialized uncompressed, so it begins with the marker byte.
         Assert.Equal( SerializationProtocol.UncompressedStreamMarker, serialized.Bytes[0] );
@@ -111,14 +111,6 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
 
         Assert.Equal( serialized.Hash, recreated.Hash );
         Assert.Equal( serialized, recreated );
-    }
-
-    [Fact]
-    public void SerializedManifest_OfEmptyBytes_IsDefault()
-    {
-        Assert.True( SerializedTransitiveAspectManifest.Create( default ).IsDefaultOrEmpty );
-        Assert.True( SerializedTransitiveAspectManifest.Create( ImmutableArray<byte>.Empty ).IsDefaultOrEmpty );
-        Assert.Equal( 0, SerializedTransitiveAspectManifest.Create( default ).Hash );
     }
 
     /// <summary>
@@ -164,7 +156,7 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         var compressed = result.LiveTransitiveAspectManifest.ToBytes( serviceProvider, compress: true );
 
         Assert.Equal( SerializationProtocol.UncompressedStreamMarker, uncompressed.Bytes[0] );
-        Assert.Equal( SerializationProtocol.UncompressedStreamMarker, crossVersion[0] );
+        Assert.Equal( SerializationProtocol.UncompressedStreamMarker, crossVersion.Bytes[0] );
         Assert.NotEqual( SerializationProtocol.UncompressedStreamMarker, compressed[0] );
 
         // Both formats are auto-detected on read (peek of the first byte) and must decode to the same content.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CompileTime.Serialization;
 using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
 using Metalama.Testing.UnitTesting;
+using System;
 using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
@@ -29,15 +30,15 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
     /// has transitive content a referencing project could inherit.
     /// </summary>
     private const string _producerCode = """
-                                          using Metalama.Framework.Aspects;
-                                          using Metalama.Framework.Code;
+                                         using Metalama.Framework.Aspects;
+                                         using Metalama.Framework.Code;
 
-                                          [Inheritable]
-                                          public class MyInheritableAspect : TypeAspect { }
+                                         [Inheritable]
+                                         public class MyInheritableAspect : TypeAspect { }
 
-                                          [MyInheritableAspect]
-                                          public class Base { }
-                                          """;
+                                         [MyInheritableAspect]
+                                         public class Base { }
+                                         """;
 
     /// <summary>
     /// A non-inheritable aspect: it does real design-time work but exports nothing to inherit (no inheritable
@@ -135,8 +136,7 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         Assert.NotEqual( a, c );
         Assert.True( a != c );
 
-        Assert.Equal( default, default( SerializedTransitiveAspectManifest ) );
-        Assert.NotEqual( a, default );
+        Assert.NotNull( a );
     }
 
     [Fact]
@@ -164,8 +164,8 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         var fromCompressed = TransitiveAspectsManifest.Deserialize( new MemoryStream( compressed ), serviceProvider, "Producer" );
 
         Assert.Equal(
-            fromUncompressed.InheritableAspectTypes.OrderBy( x => x, System.StringComparer.Ordinal ),
-            fromCompressed.InheritableAspectTypes.OrderBy( x => x, System.StringComparer.Ordinal ) );
+            fromUncompressed.InheritableAspectTypes.OrderBy( x => x, StringComparer.Ordinal ),
+            fromCompressed.InheritableAspectTypes.OrderBy( x => x, StringComparer.Ordinal ) );
 
         Assert.Contains( "MyInheritableAspect", fromUncompressed.InheritableAspectTypes );
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
@@ -16,9 +16,9 @@ using Xunit.Abstractions;
 namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
 
 /// <summary>
-/// Covers the transitive-manifest serialization used by the design-time cross-project inheritance path:
-/// the "gate" that skips serializing a manifest with nothing to inherit (issue #1710 performance follow-up),
-/// and the round-trip through both the uncompressed (in-process) and the compressed (RPC/PE) formats.
+/// Covers the transitive-manifest serialization used by the design-time cross-project inheritance path: the
+/// condition on which a caller skips carrying a manifest with nothing to inherit (issue #1710 performance
+/// follow-up), and the round-trip through both the uncompressed and the legacy compressed formats.
 /// </summary>
 public sealed class TransitiveManifestSerializationTests : UnitTestClass
 {
@@ -71,7 +71,7 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
 
         Assert.True( result.HasTransitiveAspectManifestContent );
 
-        var serialized = result.SerializedTransitiveAspectManifest;
+        var serialized = result.SerializedTransitiveAspectManifestWithoutValidators;
         Assert.False( serialized.IsDefaultOrEmpty );
 
         // The in-process (design-time) manifest is serialized uncompressed, so it begins with the marker byte.
@@ -79,17 +79,17 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
     }
 
     [Fact]
-    public void ProjectWithoutInheritableContent_SkipsSerialization()
+    public void ProjectWithoutInheritableContent_ReportsNothingToInherit()
     {
         using var testContext = this.CreateTestContext();
         using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
 
         var result = Execute( testContext, factory, _emptyProducerCode );
 
-        // Gate: nothing to inherit, so the manifest is not serialized at all. The reference-construction site then
-        // carries neither the live nor the serialized manifest, and the consumer skips deserialization entirely.
+        // The gate itself lives on the caller: DesignTimeAspectPipeline builds a DesignTimeProjectReference carrying
+        // neither the live nor the serialized manifest when this is false, so the consumer skips deserialization
+        // entirely. The property below would serialize on demand; nobody asks it to.
         Assert.False( result.HasTransitiveAspectManifestContent );
-        Assert.True( result.SerializedTransitiveAspectManifest.IsDefaultOrEmpty );
     }
 
     /// <summary>
@@ -102,7 +102,7 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         using var testContext = this.CreateTestContext();
         using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
 
-        var serialized = Execute( testContext, factory, _producerCode ).SerializedTransitiveAspectManifest;
+        var serialized = Execute( testContext, factory, _producerCode ).SerializedTransitiveAspectManifestWithoutValidators;
 
         Assert.NotEqual( 0, serialized.Hash );
 
@@ -159,8 +159,8 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         // Both design-time manifests are uncompressed (marked). The compressed form is written only by ToResource
         // now, but a reader must still accept it: this project can reference an older one, whose manifest predates
         // the marker and arrives as a bare DEFLATE stream. That legacy shape is what `compressed` stands in for.
-        var uncompressed = result.SerializedTransitiveAspectManifest;
-        var crossVersion = result.SerializeTransitiveAspectManifestForOtherVersion();
+        var uncompressed = result.SerializedTransitiveAspectManifestWithoutValidators;
+        var crossVersion = result.SerializedTransitiveAspectManifestWithValidators;
         var compressed = result.LiveTransitiveAspectManifest.ToBytes( serviceProvider, compress: true );
 
         Assert.Equal( SerializationProtocol.UncompressedStreamMarker, uncompressed.Bytes[0] );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
@@ -156,12 +156,15 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         var result = Execute( testContext, factory, _producerCode );
         var serviceProvider = result.Configuration!.ServiceProvider;
 
-        // The same-version format is uncompressed (marked); the cross-version format, which an older consumer may
-        // require, is a bare DEFLATE stream (no marker).
+        // Both design-time manifests are uncompressed (marked). The compressed form is written only by ToResource
+        // now, but a reader must still accept it: this project can reference an older one, whose manifest predates
+        // the marker and arrives as a bare DEFLATE stream. That legacy shape is what `compressed` stands in for.
         var uncompressed = result.SerializedTransitiveAspectManifest;
-        var compressed = result.SerializeTransitiveAspectManifestForOtherVersion();
+        var crossVersion = result.SerializeTransitiveAspectManifestForOtherVersion();
+        var compressed = result.LiveTransitiveAspectManifest.ToBytes( serviceProvider, compress: true );
 
         Assert.Equal( SerializationProtocol.UncompressedStreamMarker, uncompressed.Bytes[0] );
+        Assert.Equal( SerializationProtocol.UncompressedStreamMarker, crossVersion[0] );
         Assert.NotEqual( SerializationProtocol.UncompressedStreamMarker, compressed[0] );
 
         // Both formats are auto-detected on read (peek of the first byte) and must decode to the same content.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -62,11 +62,16 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
                                  """;
 
     /// <summary>
-    /// Builds a pipeline result whose design-time extension collection holds <paramref name="extensions"/>, by
-    /// executing a trivial pipeline (which supplies a real <c>AspectPipelineConfiguration</c>, required by the
-    /// result's non-empty invariant) and then updating it with a fabricated execution result. Going through
-    /// <c>Update</c> exercises the real routing into <c>DesignTimeAspectPipelineResultExtensionCollection</c>.
+    /// Builds a pipeline result whose design-time extension collection holds the contributors returned by
+    /// <paramref name="createExtensions"/>, by executing a trivial pipeline (which supplies a real
+    /// <c>AspectPipelineConfiguration</c>, required by the result's non-empty invariant) and then updating it with a
+    /// fabricated execution result. Going through <c>Update</c> exercises the real routing into
+    /// <c>DesignTimeAspectPipelineResultExtensionCollection</c>.
     /// </summary>
+    /// <param name="createExtensions">
+    /// Builds the contributors, given a <see cref="SymbolDictionaryKey"/> for a type of the test compilation, which
+    /// only exists once the compilation does.
+    /// </param>
     private static DesignTimeAspectPipelineResult CreateResultWithExtensions(
         TestContext testContext,
         TestDesignTimeAspectPipelineFactory factory,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -20,6 +20,7 @@ using Metalama.Framework.Options;
 using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
 using Metalama.Testing.UnitTesting;
 using Microsoft.CodeAnalysis;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.IO;
@@ -49,7 +50,7 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
 /// <remarks>
 /// This regressed once already (issue #1710): the same-version reference path was rerouted from the live result,
 /// which filtered validators out, onto the manifest built for the cross-version consumer, which keeps them. Both
-/// channels then fired, and a downstream consumer reported every cross-project reference diagnostic twice — six
+/// channels then fired, and a downstream consumer reported every cross-project reference diagnostic twice, and six
 /// times across a diamond, where the undeduplicated manifest channel compounds.
 /// </remarks>
 public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
@@ -69,10 +70,16 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
     private static DesignTimeAspectPipelineResult CreateResultWithExtensions(
         TestContext testContext,
         TestDesignTimeAspectPipelineFactory factory,
-        params ITransitivePipelineContributor[] extensions )
+        Func<SymbolDictionaryKey, ITransitivePipelineContributor[]> createExtensions )
     {
         var compilation = testContext.CreateCSharpCompilation( _code );
         Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out var executed ) );
+
+        // A real key for the validated declaration. The fixture never looks a validator up by symbol, but the key
+        // indexes the validator dictionary that Update populates, so a default (identity-less) one would be a
+        // hazard the moment anything compared keys.
+        var validatedType = compilation.GetTypeByMetadataName( "C" ).AssertNotNull();
+        var extensions = createExtensions( SymbolDictionaryKey.CreatePersistentKey( validatedType ) );
 
         var partialCompilation = PartialCompilation.CreateComplete( compilation );
 
@@ -110,19 +117,28 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
         using var testContext = this.CreateTestContext();
         using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
 
-        var validator = new FakeContributor( isValidator: true );
-        var other = new FakeContributor( isValidator: false );
+        FakeContributor? validator = null;
+        FakeContributor? other = null;
 
-        var result = CreateResultWithExtensions( testContext, factory, validator, other );
+        var result = CreateResultWithExtensions(
+            testContext,
+            factory,
+            key =>
+            {
+                validator = new FakeContributor( key, isValidator: true );
+                other = new FakeContributor( key, isValidator: false );
+
+                return [validator, other];
+            } );
 
         // Channel 1 has the validator: this is the channel the consumer actually reads it from, so the validator
         // must not be lost, only kept out of the manifest.
-        Assert.Contains( validator, result.Extensions.Extensions );
+        Assert.Contains( validator.AssertNotNull(), result.Extensions.Extensions );
 
         var manifestExtensions = result.LiveTransitiveAspectManifest.Extensions;
 
-        Assert.DoesNotContain( validator.ManifestExtension, manifestExtensions );
-        Assert.Contains( other.ManifestExtension, manifestExtensions );
+        Assert.DoesNotContain( validator.AssertNotNull().ManifestExtension, manifestExtensions );
+        Assert.Contains( other.AssertNotNull().ManifestExtension, manifestExtensions );
     }
 
     /// <summary>
@@ -135,9 +151,7 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
         using var testContext = this.CreateTestContext();
         using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
 
-        var validator = new FakeContributor( isValidator: true );
-
-        var result = CreateResultWithExtensions( testContext, factory, validator );
+        var result = CreateResultWithExtensions( testContext, factory, key => [new FakeContributor( key, isValidator: true )] );
 
         // The gate is deliberately computed from the unfiltered collection: were it to go false here, the reference
         // would carry no live manifest either, and channel 1 would lose the validator along with the manifest.
@@ -162,8 +176,10 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
     /// </summary>
     private sealed class FakeContributor : ITransitivePipelineContributor, IDesignTimeValidatorExtension
     {
-        public FakeContributor( bool isValidator )
+        public FakeContributor( SymbolDictionaryKey validatedDeclaration, bool isValidator )
         {
+            this.ValidatedDeclaration = validatedDeclaration;
+
             this.ContributorKind = new ContributorKind<FakeContributor>( isValidator ? "FakeValidator" : "FakeExtension" )
             {
                 IsDesignTimeValidator = isValidator
@@ -186,7 +202,7 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
 
         public ReferenceIndexerRequirements? ReferenceIndexerRequirements => null;
 
-        public SymbolDictionaryKey ValidatedDeclaration => default;
+        public SymbolDictionaryKey ValidatedDeclaration { get; }
     }
 
     private sealed class FakeManifestExtension : ITransitiveAspectsManifestExtension

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -163,7 +163,7 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
         Assert.True( result.HasTransitiveAspectManifestContent );
 
         var serialized = result.SerializedTransitiveAspectManifestWithoutValidators;
-        Assert.False( serialized.IsDefaultOrEmpty );
+        Assert.NotEmpty( serialized.Bytes );
 
         var deserialized = TransitiveAspectsManifest.Deserialize(
             new MemoryStream( serialized.Bytes.ToArray() ),

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -162,7 +162,7 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
         // would carry no live manifest either, and channel 1 would lose the validator along with the manifest.
         Assert.True( result.HasTransitiveAspectManifestContent );
 
-        var serialized = result.SerializedTransitiveAspectManifest;
+        var serialized = result.SerializedTransitiveAspectManifestWithoutValidators;
         Assert.False( serialized.IsDefaultOrEmpty );
 
         var deserialized = TransitiveAspectsManifest.Deserialize(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -41,15 +41,16 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
 /// the manifest channel, which walks each direct reference's transitive manifest and is <em>not</em> deduplicated.
 /// </item>
 /// </list>
-/// A same-version, in-process consumer always has channel 1 (its reference carries the live result; see the
-/// both-or-neither invariant on <c>DesignTimeProjectReference</c>), so the in-process manifests must not carry
-/// validators. A cross-version (RPC) consumer has only channel 2, so its manifest must.
+/// A consumer built against the same version of Metalama always has channel 1, because its reference carries the
+/// producer's live result, so the same-version manifests must not carry validators. A consumer built against a
+/// different version of Metalama has only channel 2: the producer's result is an object of the other version's
+/// <c>Metalama.Framework.Engine</c> and cannot be handed across, so its manifest must carry them.
 /// </summary>
 /// <remarks>
-/// This regressed once already (issue #1710): the design-time reference path was rerouted from the live result,
-/// whose <c>ITransitiveAspectsManifest.Extensions</c> filters validators out, onto the manifest built for RPC,
-/// which keeps them. Both channels then fired, and a downstream consumer reported every cross-project reference
-/// diagnostic twice — six times across a diamond, where the undeduplicated manifest channel compounds.
+/// This regressed once already (issue #1710): the same-version reference path was rerouted from the live result,
+/// which filtered validators out, onto the manifest built for the cross-version consumer, which keeps them. Both
+/// channels then fired, and a downstream consumer reported every cross-project reference diagnostic twice — six
+/// times across a diamond, where the undeduplicated manifest channel compounds.
 /// </remarks>
 public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
 {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -1,0 +1,200 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.DesignTime.Pipeline;
+using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Collections;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Extensibility;
+using Metalama.Framework.Engine.HierarchicalOptions;
+using Metalama.Framework.Engine.Pipeline;
+using Metalama.Framework.Engine.ReferenceGraph;
+using Metalama.Framework.Engine.Transformations;
+using Metalama.Framework.Engine.Utilities.Roslyn;
+using Metalama.Framework.Options;
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
+
+/// <summary>
+/// Design-time validators reach a consuming project through two channels, and exactly one of them must carry
+/// them for any given consumer, or the consumer sees each validator more than once:
+/// <list type="number">
+/// <item>
+/// the design-time channel, <see cref="DesignTimeProjectVersion.ReferencedExtensions"/>, which reads the producer's
+/// live <c>DesignTimeAspectPipelineResult</c> and deduplicates diamond-shaped reference graphs; and
+/// </item>
+/// <item>
+/// the manifest channel, which walks each direct reference's transitive manifest and is <em>not</em> deduplicated.
+/// </item>
+/// </list>
+/// A same-version, in-process consumer always has channel 1 (its reference carries the live result; see the
+/// both-or-neither invariant on <c>DesignTimeProjectReference</c>), so the in-process manifests must not carry
+/// validators. A cross-version (RPC) consumer has only channel 2, so its manifest must.
+/// </summary>
+/// <remarks>
+/// This regressed once already (issue #1710): the design-time reference path was rerouted from the live result,
+/// whose <c>ITransitiveAspectsManifest.Extensions</c> filters validators out, onto the manifest built for RPC,
+/// which keeps them. Both channels then fired, and a downstream consumer reported every cross-project reference
+/// diagnostic twice — six times across a diamond, where the undeduplicated manifest channel compounds.
+/// </remarks>
+public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
+{
+    public TransitiveManifestValidatorChannelTests( ITestOutputHelper testOutput ) : base( testOutput ) { }
+
+    private const string _code = """
+                                 public class C { }
+                                 """;
+
+    /// <summary>
+    /// Builds a pipeline result whose design-time extension collection holds <paramref name="extensions"/>, by
+    /// executing a trivial pipeline (which supplies a real <c>AspectPipelineConfiguration</c>, required by the
+    /// result's non-empty invariant) and then updating it with a fabricated execution result. Going through
+    /// <c>Update</c> exercises the real routing into <c>DesignTimeAspectPipelineResultExtensionCollection</c>.
+    /// </summary>
+    private static DesignTimeAspectPipelineResult CreateResultWithExtensions(
+        TestContext testContext,
+        TestDesignTimeAspectPipelineFactory factory,
+        params ITransitivePipelineContributor[] extensions )
+    {
+        var compilation = testContext.CreateCSharpCompilation( _code );
+        Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out var executed ) );
+
+        var partialCompilation = PartialCompilation.CreateComplete( compilation );
+
+        var pipelineResults = new DesignTimePipelineExecutionResult(
+            partialCompilation.SyntaxTrees,
+            ImmutableArray<IntroducedSyntaxTree>.Empty,
+            ImmutableUserDiagnosticList.Empty,
+            ImmutableArray<InheritableAspectInstance>.Empty,
+            ImmutableArray<KeyValuePair<HierarchicalOptionsKey, IHierarchicalOptions>>.Empty,
+            extensions.ToImmutableArray(),
+            ImmutableArray<IAspectInstance>.Empty,
+            ImmutableArray<ITransformationBase>.Empty,
+            ImmutableDictionaryOfArray<IRef<IDeclaration>, AnnotationInstance>.Empty );
+
+        // No project references: this fixture is about what the producer puts in its own manifests.
+        var projectVersion = new DesignTimeProjectVersion(
+            new TestProjectVersion( compilation ),
+            ImmutableArray<DesignTimeProjectReference>.Empty,
+            DesignTimeAspectPipelineStatus.Default );
+
+        return executed.Result.Update(
+            partialCompilation,
+            projectVersion,
+            pipelineResults,
+            executed.Result.Configuration.AssertNotNull() );
+    }
+
+    /// <summary>
+    /// The fast path added by #1710. The live manifest is what a same-version consumer reuses directly, so it must
+    /// drop validators while keeping every other extension.
+    /// </summary>
+    [Fact]
+    public void LiveManifest_DropsValidators_ButKeepsOtherExtensions()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var validator = new FakeContributor( isValidator: true );
+        var other = new FakeContributor( isValidator: false );
+
+        var result = CreateResultWithExtensions( testContext, factory, validator, other );
+
+        // Channel 1 has the validator: this is the channel the consumer actually reads it from, so the validator
+        // must not be lost, only kept out of the manifest.
+        Assert.Contains( validator, result.Extensions.Extensions );
+
+        var manifestExtensions = result.LiveTransitiveAspectManifest.Extensions;
+
+        Assert.DoesNotContain( validator.ManifestExtension, manifestExtensions );
+        Assert.Contains( other.ManifestExtension, manifestExtensions );
+    }
+
+    /// <summary>
+    /// The slow in-process path, taken when the producer's and consumer's compile-time copies differ (e.g. a
+    /// multi-targeted assembly). The consumer still has channel 1, so this manifest must drop validators too.
+    /// </summary>
+    [Fact]
+    public void InProcessSerializedManifest_DropsValidators()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var validator = new FakeContributor( isValidator: true );
+
+        var result = CreateResultWithExtensions( testContext, factory, validator );
+
+        // The gate is deliberately computed from the unfiltered collection: were it to go false here, the reference
+        // would carry no live manifest either, and channel 1 would lose the validator along with the manifest.
+        Assert.True( result.HasTransitiveAspectManifestContent );
+
+        var serialized = result.SerializedTransitiveAspectManifest;
+        Assert.False( serialized.IsDefaultOrEmpty );
+
+        var deserialized = TransitiveAspectsManifest.Deserialize(
+            new MemoryStream( serialized.Bytes.ToArray() ),
+            result.Configuration.AssertNotNull().ServiceProvider,
+            "Producer" );
+
+        Assert.Empty( deserialized.Extensions );
+    }
+
+    /// <summary>
+    /// Stands in for a design-time validator, which in production comes from Metalama.Extensions.Validation and so
+    /// is not available here. One class covers both roles, with <c>isValidator</c> the only difference: routing
+    /// keys off <see cref="ContributorKind.IsDesignTimeValidator"/> (in conjunction with the interface, which both
+    /// roles implement), so varying just the flag isolates the behaviour under test.
+    /// </summary>
+    private sealed class FakeContributor : ITransitivePipelineContributor, IDesignTimeValidatorExtension
+    {
+        public FakeContributor( bool isValidator )
+        {
+            this.ContributorKind = new ContributorKind<FakeContributor>( isValidator ? "FakeValidator" : "FakeExtension" )
+            {
+                IsDesignTimeValidator = isValidator
+            };
+
+            this.ManifestExtension = new FakeManifestExtension( this.ContributorKind );
+        }
+
+        public FakeManifestExtension ManifestExtension { get; }
+
+        public ContributorKind ContributorKind { get; }
+
+        // Null puts the extension in the file-path-less bucket, which Update routes into the collection all the
+        // same; the fixture does not care which syntax tree it is attributed to.
+        public SyntaxTree? SyntaxTree => null;
+
+        public IDesignTimePipelineResultExtension? ToDesignTime() => this;
+
+        public ITransitiveAspectsManifestExtension ToTransitiveAspectManifestExtension() => this.ManifestExtension;
+
+        public ReferenceIndexerRequirements? ReferenceIndexerRequirements => null;
+
+        public SymbolDictionaryKey ValidatedDeclaration => default;
+    }
+
+    private sealed class FakeManifestExtension : ITransitiveAspectsManifestExtension
+    {
+        public FakeManifestExtension( ContributorKind contributorKind )
+        {
+            this.ContributorKind = contributorKind;
+        }
+
+        public ContributorKind ContributorKind { get; }
+    }
+}


### PR DESCRIPTION
Two related changes to the transitive-manifest path, both consequences of #1710: a bug fix with tests, then a cleanup of dead code and misleading names in the same area.

## Part 1 — the fix (`bbcc30d`)

`CreateTransitiveManifest` now takes an `includeValidators` flag, so design-time validators travel in the transitive manifest only for consumers that have no other channel to receive them.

| Manifest | Flag | Consumer |
|---|---|---|
| `SerializedTransitiveAspectManifest` | `false` | same version |
| `LiveTransitiveAspectManifest` (#1710 fast path) | `false` | same version |
| `SerializeTransitiveAspectManifestForOtherVersion` | `true` | different version |

Design-time validators reach a consuming project through two channels, and exactly one of them must carry them for any given consumer:

1. the **design-time channel**, `DesignTimeProjectVersion.ReferencedExtensions`, which reads the producer's live `DesignTimeAspectPipelineResult` and deduplicates diamond-shaped reference graphs; and
2. the **manifest channel**, which walks each direct reference's transitive manifest and is *not* deduplicated.

Before #1710 the same-version path read the live result, whose `ITransitiveAspectsManifest.Extensions` filtered validators out, so only channel 1 carried them. #1710 rerouted that path onto `CreateTransitiveManifest` — first via deserialization in `3b3807d74e`, then via the `LiveTransitiveAspectManifest` fast path in `19124afc98` — which is built for the cross-version consumer and keeps validators. Both channels then fired.

`HasTransitiveAspectManifestContent` deliberately stays computed from the unfiltered collection: were it to go `false` for a validators-only project, the reference would carry no live manifest either, and channel 1 would lose the validators along with it.

### Impact

Caught by the `Metalama.Extensions.Validation` cross-project design-time tests in Metalama.Premium, which reported every cross-project reference diagnostic twice — six times across a diamond, where the undeduplicated manifest channel compounds:

| Test | Expected | Was |
|---|---|---|
| `ValidatorTests.CrossProject` | 2 | 4 |
| `ValidatorTests.CrossProject_Diamond` | 2 | 12 |
| `ValidatorTests.CrossProject_ModificationInAttributeConstruction` | 1 | 2 |

## Part 2 — the cleanup (`1d28501`, `e586f9d`)

**What "cross-version" means:** two projects in the same solution, one referencing the other, each built against a **different version of Metalama**. Both versions are loaded in the **same process** and reach each other through the version-neutral `Metalama.Framework.DesignTime.Contracts` assembly. Their `Metalama.Framework.Engine` types have distinct identities, so no manifest object can be passed across — the manifest is serialized by the producing version and deserialized into the consuming version's object model. Same assembly-identity problem #1710 addressed; not a transport problem.

- **Removes a deserialization whose result has had no reader since #1710.** The cross-version branch of `GetDesignTimeProjectVersionAsync` deserialized the referenced project's manifest onto the `DesignTimeProjectReference`. Its two readers, `ReferencedExtensions` and `TryGetReusableTransitiveAspectsManifest`, both narrow to the concrete `DesignTimeAspectPipelineResult`, which a deserialized `TransitiveAspectsManifest` never is, so both silently ignored it. Its only remaining effect was satisfying the reference's both-or-neither invariant. It was load-bearing before #1710, when `DesignTimeProjectVersion.GetTransitiveAspectsManifest` returned it and `TransitivePipelineContributorSource` consumed it; #1710 routed the consumer through the serialized bytes and left this behind.
- **Types `TransitiveAspectsManifest` as the concrete result**, so "a cross-version reference has no live result" is stated by the type instead of by two readers narrowing and discarding whatever does not match. The invariant relaxes accordingly: a live result implies a serialized manifest, not the converse.
- **Renames `SerializeTransitiveAspectManifestForRpc` → `...ForOtherVersion`.** Nothing on that path is RPC. The genuine RPC — user process ↔ analysis process, `Metalama.Framework.DesignTime.Rpc`, consumed by Metalama.Vsx — is untouched.
- **Rewords the docs across the area**: the distinction is same-version vs different-version, not in-process vs out-of-process. Both are in-process.
- **`e586f9d` drops `DesignTimeAspectPipelineResult : ITransitiveAspectsManifest`**, unused once the property is typed concretely. Also deletes the "still used for PE references" comment, stale since #1710: a PE reference reads its manifest from the assembly metadata resource written by the compile-time pipeline and never touches a `DesignTimeAspectPipelineResult`. Kept as its own commit so it can be reverted alone if the interface is wanted for a reason not visible in the code.

## Behavioral change

The same-version transitive manifest no longer carries design-time validators, restoring pre-#1710 behavior. The cross-version manifest is unchanged.

## Testing

`Metalama.Framework.Tests.UnitTests` design-time suite: 437 passed, 5 skipped, 0 failed. Premium's `Metalama.Extensions.Validation.UnitTests` (13 tests, including the three above) pass against a locally built Metalama carrying this branch.

New `TransitiveManifestValidatorChannelTests` covers both same-version manifests, and was confirmed to fail without Part 1. The concrete `IDesignTimeValidatorExtension` implementations live in Metalama.Premium, so this repo cannot reproduce the failure end to end; the tests drive a fake contributor through the real `Update` → extension-collection routing. `LiveManifest_DropsValidators_ButKeepsOtherExtensions` also asserts the validator is still present on channel 1, so the fix cannot be trivially satisfied by dropping validators altogether.

### Gaps worth knowing

- **The cross-version path has no automated coverage** — nothing in the repo touches `ITransitiveCompilationService`, `GetTransitiveAspectManifestAsync`, or the entry-point consumer, which is why a vestigial deserialization sat there unnoticed. Exercising it needs two Metalama versions in one process, so Part 2's change to that branch is reviewed, not tested. Worth sanity-checking a two-version solution in VS before merging.
- **The `includeValidators: true` direction is untested.** Asserting on it requires a compile-time serializer for the fake extension. Behavior there is unchanged, but note the failure mode is silent: too few validators means diagnostics simply vanish, where too many were loudly duplicated.
- Part 2 leaves `GetOrCreatePipelineAsync`/`GetConfigurationAsync` in the cross-version branch. With the deserialization gone their only role is a gate — the referenced project must be compilable by the current version, and failing there beats a later consumer-side binding error. Documented rather than removed, since I could not verify they are inert without the coverage above.

## Issues Fixed

None — this is a regression from the (closed) #1710 work, referenced above for context.