### PR TITLE
Clean up the cross-version transitive manifest path (#1710)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -608,8 +608,13 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                     }
                     else
                     {
-                        // To deserialize the manifest, we need a service provider with the CompileTimeProject of the referenced project, compiled
-                        // for the current Metalama version.
+                        // The referenced project must be compilable by the *current* Metalama version, because the
+                        // consuming project binds the manifest against its own compile-time closure, which contains
+                        // this reference. Obtaining the configuration is what gates that, so a failure here aborts
+                        // rather than surfacing later as a binding error attributed to the consumer.
+                        //
+                        // Note that we deliberately do not deserialize the manifest here. See the comment on the
+                        // DesignTimeProjectReference constructed below.
 
                         var pipelineResult = await this._pipelineFactory.GetOrCreatePipelineAsync( reference, cancellationToken );
 
@@ -633,18 +638,16 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                                 $"Cannot get configuration: {configuration.DebugReason}" );
                         }
 
-                        var manifest = TransitiveAspectsManifest.Deserialize(
-                            new MemoryStream( result.Manifest! ),
-                            configuration.Value.ServiceProvider,
-                            reference.Compilation.AssemblyName );
-
-                        // Also carry the raw serialized manifest (produced by the referenced project) so the consumer
-                        // can deserialize inherited aspects and options into its own compile-time copy (issue #1710).
+                        // Carry only the serialized manifest. The consumer deserializes it into its own compile-time
+                        // copy (issue #1710), so there is nothing for a live manifest to do here: a live manifest is
+                        // read exclusively by DesignTimeProjectVersion.ReferencedExtensions and
+                        // TryGetReusableTransitiveAspectsManifest, both of which need the producer's concrete
+                        // DesignTimeAspectPipelineResult, and a cross-version producer cannot supply one — its
+                        // result is an object of the *other* version's Metalama.Framework.Engine.
                         compilationReferences.Add(
                             new DesignTimeProjectReference(
                                 reference.ProjectKey,
-                                manifest,
-                                SerializedTransitiveAspectManifest.Create( result.Manifest!.ToImmutableArray() ) ) );
+                                serializedTransitiveAspectManifest: SerializedTransitiveAspectManifest.Create( result.Manifest!.ToImmutableArray() ) ) );
 
                         if ( result.IsPipelinePaused )
                         {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -698,16 +698,17 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
     /// them, <see cref="DesignTimeProjectVersion.ReferencedExtensions"/>:
     /// <list type="bullet">
     /// <item>
-    /// <c>false</c> for the in-process, same-version consumer. Its reference carries this very result as its live
+    /// <c>false</c> for a consumer built against the same version of Metalama. Its reference carries this very result as its live
     /// <c>TransitiveAspectsManifest</c>, so <c>ReferencedExtensions</c> reads the validators out of the design-time
     /// extension collection, which deduplicates diamond-shaped reference graphs. Putting them in the manifest as
     /// well would deliver each validator twice (once per channel), and more than twice across a diamond, because
     /// the manifest channel is walked once per direct reference and is not deduplicated.
     /// </item>
     /// <item>
-    /// <c>true</c> for the cross-version (RPC) consumer. Its reference carries a deserialized
-    /// <see cref="TransitiveAspectsManifest"/> rather than a <see cref="DesignTimeAspectPipelineResult"/>, so
-    /// <c>ReferencedExtensions</c> skips it and the manifest is the only channel available.
+    /// <c>true</c> for a consumer built against a different version of Metalama. Such a reference carries no live
+    /// result — the producer's result is an object of the other version's <c>Metalama.Framework.Engine</c> and
+    /// cannot cross — so <c>ReferencedExtensions</c> contributes nothing for it and the manifest is the only
+    /// channel available. See <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>.
     /// </item>
     /// </list>
     /// </summary>
@@ -726,9 +727,12 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
                 containsInitializableTypes: true );
 
     /// <summary>
-    /// Gets the transitive manifest serialized for in-process consumption by the current-version design-time
-    /// pipeline. It is serialized uncompressed: the bytes are produced and consumed in the same process and
-    /// discarded, so compression would be pure overhead. Returns <c>default</c> when there is nothing to inherit
+    /// Gets the transitive manifest serialized for a consumer built against the <em>same</em> version of Metalama.
+    /// It exists because the consumer must bind the manifest to its own compile-time copy of each type, which a
+    /// round-trip through the serialized form is what achieves (issue #1710); it is not a version bridge. Serialized
+    /// uncompressed, unlike <see cref="SerializeTransitiveAspectManifestForOtherVersion"/>: producer and consumer
+    /// are the same version, so no legacy format has to be honoured and compression would be pure overhead on bytes
+    /// that are produced, consumed and discarded immediately. Returns <c>default</c> when there is nothing to inherit
     /// (see <see cref="HasTransitiveAspectManifestContent"/>), so a referencing project neither serializes here nor
     /// deserializes and merges an empty manifest on the other side. That is the common case for a Metalama project
     /// exporting no inheritable aspects, options, annotations, or validators.
@@ -743,19 +747,28 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
 
     /// <summary>
     /// Gets the live, in-memory manifest. It is content-identical to what
-    /// <see cref="SerializedTransitiveAspectManifest"/> encodes, since both are built from the same
-    /// <see cref="CreateTransitiveManifest"/> call. A consumer whose compile-time copies match this producer's can
-    /// consume this object directly and skip the serialize/deserialize round-trip (issue #1710 fast path); see
-    /// <c>TransitivePipelineContributorSource</c>. Memoized so repeated consumer runs share one instance.
+    /// <see cref="SerializedTransitiveAspectManifest"/> encodes, since both come from
+    /// <see cref="CreateTransitiveManifest"/> with the same argument. A same-version consumer whose compile-time
+    /// copies match this producer's can consume this object directly and skip the serialize/deserialize round-trip
+    /// (issue #1710 fast path); see <c>TransitivePipelineContributorSource</c>. Memoized so repeated consumer runs
+    /// share one instance.
     /// </summary>
     [Memo]
     internal TransitiveAspectsManifest LiveTransitiveAspectManifest => this.CreateTransitiveManifest( includeValidators: false );
 
     /// <summary>
-    /// Serializes the transitive manifest for shipping over RPC to a potentially different (possibly older)
-    /// Metalama version, which may only understand the legacy compressed format, so this one is compressed.
+    /// Serializes the transitive manifest for a consumer built against a <em>different</em> version of Metalama:
+    /// two projects of the same solution, one referencing the other, each referencing its own Metalama version.
+    /// Both versions are loaded in the same process and reach each other through the version-neutral
+    /// <c>Metalama.Framework.DesignTime.Contracts</c> assembly, but their <c>Metalama.Framework.Engine</c> types have
+    /// distinct identities, so no manifest object can be passed across. Serializing here and deserializing on the
+    /// other side is what converts the manifest into the consuming version's object model.
     /// </summary>
-    internal byte[] SerializeTransitiveAspectManifestForRpc()
+    /// <remarks>
+    /// Compressed, unlike <see cref="SerializedTransitiveAspectManifest"/>: the consumer may be an older version
+    /// that only understands the legacy compressed format.
+    /// </remarks>
+    internal byte[] SerializeTransitiveAspectManifestForOtherVersion()
         => this.CreateTransitiveManifest( includeValidators: true )
             .ToBytes( this.Configuration.AssertNotNull().ServiceProvider, compress: true );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -28,7 +28,7 @@ namespace Metalama.Framework.DesignTime.Pipeline;
 /// <summary>
 /// Caches the pipeline results for each syntax tree.
 /// </summary>
-public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsManifest
+public sealed partial class DesignTimeAspectPipelineResult
 {
     private static readonly ImmutableDictionary<string, SyntaxTreePipelineResult> _emptySyntaxTreeResults =
         ImmutableDictionary.Create<string, SyntaxTreePipelineResult>( StringComparer.Ordinal );
@@ -653,25 +653,6 @@ public sealed partial class DesignTimeAspectPipelineResult : ITransitiveAspectsM
     public IEnumerable<string> InheritableAspectTypes => this._inheritableAspects.Keys;
 
     public IEnumerable<InheritableAspectInstance> GetInheritableAspects( string aspectType ) => this._inheritableAspects[aspectType];
-
-    /// <summary>
-    /// At design time, cross-project reference validators are not added to the main pipeline. Instead, the validator
-    /// provider recursively includes the providers of referenced projects. However, cross-project references are
-    /// still used for PE references.
-    /// </summary>
-    ImmutableArray<ITransitiveAspectsManifestExtension> ITransitiveAspectsManifest.Extensions => this.Extensions.ToTransitiveValidatorInstances( false );
-
-    /// <summary>
-    /// Gets a value indicating whether the compilation contains <c>IInitializable</c> implementers.
-    /// <see cref="DesignTimeAspectPipelineResult"/> does not track this (the tracking would be useless at design
-    /// time, where <c>LinkerAnalysisStep</c> force-runs the <c>OnInitialized</c> walker because the partial
-    /// compilation may exclude trees declaring implementers). We therefore report the safe default <c>true</c>: the
-    /// flag is consumed by <c>LinkerAnalysisStep</c> to skip the walker, and returning <c>true</c> just forces the
-    /// walker to run, which is a performance pessimization at worst, never a correctness bug. Returning
-    /// <c>false</c> would be unsafe: if any consumer reads this at compile time, it could miss required
-    /// <c>WithInitialize</c> wrapping.
-    /// </summary>
-    bool ITransitiveAspectsManifest.ContainsInitializableTypes => true;
 
     /// <summary>
     /// Gets a value indicating whether this project exports something a referencing project could inherit: an

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectReference.cs
@@ -13,18 +13,31 @@ namespace Metalama.Framework.DesignTime.Pipeline;
 /// </summary>
 internal readonly struct DesignTimeProjectReference
 {
-    // The two manifest representations below are always both set or both null: a reference carries them when it is
-    // a Metalama project that exports something to inherit (an inheritable aspect, option, annotation, or validator),
-    // and carries neither when it is not a Metalama project or is one that exports nothing (see gate in
-    // DesignTimeAspectPipelineResult.HasTransitiveAspectManifestContent). They are not interchangeable: they serve
-    // different consumers and neither can be derived from the other at the point where it is needed.
+    // A reference carries a serialized manifest when it is a Metalama project that exports something to inherit (an
+    // inheritable aspect, option, annotation, or validator), and carries none when it is not a Metalama project or is
+    // one that exports nothing (see gate in DesignTimeAspectPipelineResult.HasTransitiveAspectManifestContent).
+    //
+    // The live result below is carried in addition, but only for a same-version reference. The two are not
+    // interchangeable: they serve different consumers and neither can be derived from the other at the point where
+    // it is needed.
 
     /// <summary>
-    /// Gets the referenced project's live manifest. Used only by <see cref="DesignTimeProjectVersion.ReferencedExtensions"/>,
-    /// which needs the concrete <c>DesignTimeAspectPipelineResult</c> to read its design-time extension collections
-    /// (a shape the serialized manifest does not carry).
+    /// Gets the referenced project's live pipeline result, or <c>null</c> when the reference is to a project built
+    /// against a different version of Metalama. Used only by
+    /// <see cref="DesignTimeProjectVersion.ReferencedExtensions"/> and
+    /// <see cref="DesignTimeProjectVersion.TryGetReusableTransitiveAspectsManifest"/>, both of which need the
+    /// concrete <see cref="DesignTimeAspectPipelineResult"/> — the first to read its design-time extension
+    /// collections (a shape the serialized manifest does not carry), the second to reuse the producer's live objects
+    /// and its configuration.
     /// </summary>
-    public ITransitiveAspectsManifest? TransitiveAspectsManifest { get; }
+    /// <remarks>
+    /// This is deliberately typed as the concrete result rather than <c>ITransitiveAspectsManifest</c>. A
+    /// cross-version producer cannot supply one at all: its pipeline result is an object of the *other* version's
+    /// <c>Metalama.Framework.Engine</c>, so the only thing that can cross is the serialized manifest. Typing it
+    /// concretely states that, instead of accepting any manifest here and having both readers narrow to this type
+    /// and silently ignore anything else.
+    /// </remarks>
+    public DesignTimeAspectPipelineResult? TransitiveAspectsManifest { get; }
 
     /// <summary>
     /// Gets the transitive aspect manifest in its serialized (compilation-neutral) form: compile-time types are
@@ -40,12 +53,13 @@ internal readonly struct DesignTimeProjectReference
 
     public DesignTimeProjectReference(
         ProjectKey projectKey,
-        ITransitiveAspectsManifest? transitiveAspectsManifest = null,
+        DesignTimeAspectPipelineResult? transitiveAspectsManifest = null,
         SerializedTransitiveAspectManifest serializedTransitiveAspectManifest = default )
     {
-        // Both manifest representations are either both present or both absent: a reference either has a
-        // transitive aspect manifest (in both its live and its serialized form) or is not a Metalama project.
-        Invariant.Assert( transitiveAspectsManifest != null == !serializedTransitiveAspectManifest.IsDefaultOrEmpty );
+        // A live result is only ever carried alongside a serialized manifest, never on its own: it comes from a
+        // same-version reference that exports something to inherit, and such a reference always serializes too. The
+        // converse does not hold, because a cross-version reference carries the serialized manifest alone.
+        Invariant.Assert( transitiveAspectsManifest == null || !serializedTransitiveAspectManifest.IsDefaultOrEmpty );
 
         this.TransitiveAspectsManifest = transitiveAspectsManifest;
         this.SerializedTransitiveAspectManifest = serializedTransitiveAspectManifest;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeProjectVersion.cs
@@ -21,8 +21,13 @@ internal sealed class DesignTimeProjectVersion : ITransitiveAspectManifestProvid
 
     public IProjectVersion ProjectVersion { get; }
 
+    /// <summary>
+    /// Gets the design-time extension collections of the referenced projects. Cross-version references contribute
+    /// nothing here, because they carry no live result; their contribution travels in the serialized manifest
+    /// instead, which the engine deserializes into this project's own compile-time copy.
+    /// </summary>
     public IEnumerable<DesignTimeAspectPipelineResultExtensionCollection> ReferencedExtensions
-        => this._references.Values.Select( r => (r.TransitiveAspectsManifest as DesignTimeAspectPipelineResult)?.Extensions ).WhereNotNull();
+        => this._references.Values.Select( r => r.TransitiveAspectsManifest?.Extensions ).WhereNotNull();
 
     public DesignTimeProjectVersion(
         IProjectVersion projectVersion,
@@ -49,11 +54,11 @@ internal sealed class DesignTimeProjectVersion : ITransitiveAspectManifestProvid
         [NotNullWhen( true )] out ITransitiveAspectsManifest? manifest,
         [NotNullWhen( true )] out AspectPipelineConfiguration? producerConfiguration )
     {
-        // Only a same-version project reference carries a live DesignTimeAspectPipelineResult (a cross-version
-        // reference carries a deserialized manifest, which cannot be reused). We also need the producer's
-        // configuration to compare compile-time copies, so require it to be present.
+        // Only a same-version project reference carries a live result; a cross-version reference carries the
+        // serialized manifest alone, and there is nothing to reuse. We also need the producer's configuration to
+        // compare compile-time copies, so require it to be present.
         if ( this._references.TryGetValue( compilation.GetProjectKey(), out var reference )
-             && reference.TransitiveAspectsManifest is DesignTimeAspectPipelineResult { HasTransitiveAspectManifestContent: true, Configuration: { } configuration } result )
+             && reference.TransitiveAspectsManifest is { HasTransitiveAspectManifestContent: true, Configuration: { } configuration } result )
         {
             producerConfiguration = configuration;
             manifest = result.LiveTransitiveAspectManifest;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VersionNeutral/TransitiveCompilationService.cs
@@ -46,7 +46,7 @@ internal sealed class TransitiveCompilationService : ITransitiveCompilationServi
         {
             result[0] = TransitiveCompilationResult.Success(
                 pipelineResult.Value.Status == DesignTimeAspectPipelineStatus.Paused,
-                pipelineResult.Value.Result.SerializeTransitiveAspectManifestForRpc() );
+                pipelineResult.Value.Result.SerializeTransitiveAspectManifestForOtherVersion() );
         }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestSerializationTests.cs
@@ -156,9 +156,10 @@ public sealed class TransitiveManifestSerializationTests : UnitTestClass
         var result = Execute( testContext, factory, _producerCode );
         var serviceProvider = result.Configuration!.ServiceProvider;
 
-        // The in-process format is uncompressed (marked); the RPC/PE format is a bare DEFLATE stream (no marker).
+        // The same-version format is uncompressed (marked); the cross-version format, which an older consumer may
+        // require, is a bare DEFLATE stream (no marker).
         var uncompressed = result.SerializedTransitiveAspectManifest;
-        var compressed = result.SerializeTransitiveAspectManifestForRpc();
+        var compressed = result.SerializeTransitiveAspectManifestForOtherVersion();
 
         Assert.Equal( SerializationProtocol.UncompressedStreamMarker, uncompressed.Bytes[0] );
         Assert.NotEqual( SerializationProtocol.UncompressedStreamMarker, compressed[0] );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -41,15 +41,16 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
 /// the manifest channel, which walks each direct reference's transitive manifest and is <em>not</em> deduplicated.
 /// </item>
 /// </list>
-/// A same-version, in-process consumer always has channel 1 (its reference carries the live result; see the
-/// both-or-neither invariant on <c>DesignTimeProjectReference</c>), so the in-process manifests must not carry
-/// validators. A cross-version (RPC) consumer has only channel 2, so its manifest must.
+/// A consumer built against the same version of Metalama always has channel 1, because its reference carries the
+/// producer's live result, so the same-version manifests must not carry validators. A consumer built against a
+/// different version of Metalama has only channel 2: the producer's result is an object of the other version's
+/// <c>Metalama.Framework.Engine</c> and cannot be handed across, so its manifest must carry them.
 /// </summary>
 /// <remarks>
-/// This regressed once already (issue #1710): the design-time reference path was rerouted from the live result,
-/// whose <c>ITransitiveAspectsManifest.Extensions</c> filters validators out, onto the manifest built for RPC,
-/// which keeps them. Both channels then fired, and a downstream consumer reported every cross-project reference
-/// diagnostic twice — six times across a diamond, where the undeduplicated manifest channel compounds.
+/// This regressed once already (issue #1710): the same-version reference path was rerouted from the live result,
+/// which filtered validators out, onto the manifest built for the cross-version consumer, which keeps them. Both
+/// channels then fired, and a downstream consumer reported every cross-project reference diagnostic twice — six
+/// times across a diamond, where the undeduplicated manifest channel compounds.
 /// </remarks>
 public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
 {


### PR DESCRIPTION
> **Stacked on #1735.** Base is that PR's branch, so the diff here is only the cleanup. Retarget to `develop/2026.1` once #1735 merges.

Docs-and-dead-code follow-up to #1735. No behavioral change intended beyond removing work whose result was discarded.

## What "cross-version" actually means

Two projects in the same solution, one referencing the other, each built against a **different version of Metalama**. Both versions are loaded in the **same process** and reach each other through the version-neutral `Metalama.Framework.DesignTime.Contracts` assembly (`[ComImport]`/`[Guid]` for type equivalence, an `AppDomain` data slot as the rendezvous). Their `Metalama.Framework.Engine` types have distinct identities, so no manifest object can be passed across — the manifest is serialized by the producing version and deserialized into the consuming version's object model. That is the same assembly-identity problem #1710 addressed, not a transport problem.

## Summary

- **Removes a deserialization whose result has had no reader since #1710.** The cross-version branch of `GetDesignTimeProjectVersionAsync` deserialized the referenced project's manifest and stored it on the `DesignTimeProjectReference`. Its two readers — `ReferencedExtensions` and `TryGetReusableTransitiveAspectsManifest` — both narrow to the concrete `DesignTimeAspectPipelineResult`, which a deserialized `TransitiveAspectsManifest` never is, so both silently ignored it. Its only remaining effect was satisfying the reference's both-or-neither invariant.
- **Types `TransitiveAspectsManifest` as the concrete result**, so "a cross-version reference has no live result" is stated by the type instead of by two readers narrowing and discarding whatever does not match. The invariant relaxes accordingly: a live result implies a serialized manifest, not the converse.
- **Renames `SerializeTransitiveAspectManifestForRpc` → `...ForOtherVersion`.** Nothing on that path is RPC. The genuine RPC in this codebase — user process ↔ analysis process, `Metalama.Framework.DesignTime.Rpc`, consumed by Metalama.Vsx — is untouched.
- **Rewords the docs across the area**: the distinction is same-version vs different-version, not in-process vs out-of-process. Both are in-process.

### Why it was left behind

It was load-bearing before #1710. `DesignTimeProjectVersion` then exposed `GetTransitiveAspectsManifest`, which returned this object, and that is what `TransitivePipelineContributorSource` consumed for a `CompilationReference`. #1710 replaced it with `GetSerializedTransitiveAspectsManifest` and routed the consumer through the serialized bytes — where the deserialization *is* cached, by `TransitiveManifestDeserializationCache`. The eager deserialize simply stayed.

This is why caching it would have been the wrong fix: the cache would have been keyed against the *referenced* project's compile-time copy, not the consuming project's that the cache documents, to memoize a value nobody reads.

## Second commit, separable

`e586f9d` drops `DesignTimeAspectPipelineResult : ITransitiveAspectsManifest`, which becomes unused once the property is typed concretely — no remaining cast to that interface, no interface-typed slot it flows into. It also deletes the "still used for PE references" comment, stale since #1710: a PE reference reads its manifest from the assembly metadata resource produced by the compile-time pipeline and never touches a `DesignTimeAspectPipelineResult`. Kept as its own commit so it can be reverted alone if the interface is wanted for a reason not visible in the code.

## Testing

`Metalama.Framework.Tests.UnitTests` design-time suite: 437 passed, 5 skipped, 0 failed. Premium's `Metalama.Extensions.Validation.UnitTests` (13 tests, including the three `CrossProject` failures #1735 fixes) pass against a locally built Metalama carrying both branches.

**The cross-version path itself has no automated coverage** — no test in the repo touches `ITransitiveCompilationService`, `GetTransitiveAspectManifestAsync`, or the entry-point consumer, which is why a vestigial deserialization sat there unnoticed. Exercising it needs two Metalama versions in one process, so the change to that branch is reviewed, not tested. Reviewers may want to sanity-check a two-version solution in VS before merging.

One judgement call worth a look: the branch still calls `GetOrCreatePipelineAsync` / `GetConfigurationAsync` for the reference. Those are now only a gate — the referenced project must be compilable by the current version, and a failure aborts here rather than surfacing later as a consumer-side binding error. I kept them and documented that. If they are genuinely unnecessary they could go too, but I could not verify that without the coverage above.

## Issues Fixed

None — follow-up cleanup to the (closed) #1710 work.