### PR TITLE
Deduplicate compile-time projects and improve crash reports

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionXmlFormatter.cs
@@ -4,6 +4,7 @@
 
 using System;
 using System.Collections;
+using System.Reflection;
 using System.Xml;
 using JetBrains.Annotations;
 
@@ -116,6 +117,28 @@ namespace Metalama.Backstage.Telemetry
                 writer.WriteStartElement( "InnerException" );
                 WriteException( writer, e.InnerException, scrubber );
                 writer.WriteEndElement();
+            }
+
+            // A ReflectionTypeLoadException says only that some types could not be loaded; the loader exceptions name the
+            // assembly that failed to bind, which is the only actionable part of the report. They are written as regular
+            // nested exceptions so that the same scrubbing rules apply to them.
+            if ( e is ReflectionTypeLoadException reflectionTypeLoadException )
+            {
+                var loaderExceptions = LoaderExceptionsHelper.GetDirectLoaderExceptions( reflectionTypeLoadException );
+
+                if ( !loaderExceptions.IsEmpty )
+                {
+                    writer.WriteStartElement( "LoaderExceptions" );
+
+                    foreach ( var loaderException in loaderExceptions )
+                    {
+                        writer.WriteStartElement( "Exception" );
+                        WriteException( writer, loaderException, scrubber );
+                        writer.WriteEndElement();
+                    }
+
+                    writer.WriteEndElement();
+                }
             }
 
             if ( e is AggregateException aggregate )

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LoaderExceptionsHelper.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LoaderExceptionsHelper.cs
@@ -1,0 +1,174 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Reflection;
+using System.Text;
+
+namespace Metalama.Backstage.Telemetry;
+
+/// <summary>
+/// Extracts the <see cref="ReflectionTypeLoadException.LoaderExceptions"/> of any <see cref="ReflectionTypeLoadException"/>
+/// found in an exception tree.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="Exception.ToString"/> does not render <see cref="ReflectionTypeLoadException.LoaderExceptions"/>,
+/// so a report built from <see cref="Exception.ToString"/> alone says only that some types could not be loaded, never which
+/// assembly failed to bind. The loader exceptions carry that information (typically a <see cref="System.IO.FileNotFoundException"/>
+/// naming the unresolved assembly), which is the only actionable part of the report.
+/// </para>
+/// <para>
+/// A single <see cref="ReflectionTypeLoadException"/> normally carries one loader exception per failing type, so the same
+/// underlying binding failure is repeated many times. The results are therefore deduplicated by type and message.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public static class LoaderExceptionsHelper
+{
+    /// <summary>
+    /// The maximum number of distinct loader exceptions reported. A tree can legitimately contain thousands of them, and
+    /// beyond a handful they no longer add information.
+    /// </summary>
+    private const int _maxReportedExceptions = 32;
+
+    /// <summary>
+    /// Gets the distinct <see cref="ReflectionTypeLoadException.LoaderExceptions"/> of a single
+    /// <see cref="ReflectionTypeLoadException"/>, without walking its inner exceptions.
+    /// </summary>
+    /// <remarks>
+    /// Use this overload from a renderer that already walks the exception tree itself, so that the loader exceptions of a
+    /// nested <see cref="ReflectionTypeLoadException"/> are attributed to the exception that actually carries them.
+    /// </remarks>
+    public static ImmutableArray<Exception> GetDirectLoaderExceptions( ReflectionTypeLoadException exception )
+    {
+        var builder = ImmutableArray.CreateBuilder<Exception>();
+        AddLoaderExceptions( exception, builder, new HashSet<string>( StringComparer.Ordinal ) );
+
+        return builder.ToImmutable();
+    }
+
+    /// <summary>
+    /// Gets the distinct loader exceptions of every <see cref="ReflectionTypeLoadException"/> in the tree of
+    /// <paramref name="exception"/>, including its inner exceptions and, for an <see cref="AggregateException"/>, its
+    /// inner exceptions. Returns an empty array when the tree contains no <see cref="ReflectionTypeLoadException"/>.
+    /// </summary>
+    public static ImmutableArray<Exception> GetLoaderExceptions( Exception? exception )
+    {
+        var builder = ImmutableArray.CreateBuilder<Exception>();
+        var distinctKeys = new HashSet<string>( StringComparer.Ordinal );
+        // Exception does not override Equals, so the default comparer is reference equality.
+        var visited = new HashSet<Exception>();
+
+        Visit( exception );
+
+        return builder.ToImmutable();
+
+        void Visit( Exception? e )
+        {
+            // The tree can contain the same instance twice (e.g. an AggregateException wrapping an exception that is also
+            // the InnerException), so guard against visiting it repeatedly.
+            if ( e == null || builder.Count >= _maxReportedExceptions || !visited.Add( e ) )
+            {
+                return;
+            }
+
+            if ( e is ReflectionTypeLoadException reflectionTypeLoadException )
+            {
+                AddLoaderExceptions( reflectionTypeLoadException, builder, distinctKeys );
+
+                if ( builder.Count >= _maxReportedExceptions )
+                {
+                    return;
+                }
+            }
+
+            Visit( e.InnerException );
+
+            if ( e is AggregateException aggregateException )
+            {
+                foreach ( var innerException in aggregateException.InnerExceptions )
+                {
+                    Visit( innerException );
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Adds the loader exceptions of <paramref name="exception"/> to <paramref name="builder"/>, skipping null elements
+    /// and those whose type and message are already represented in <paramref name="distinctKeys"/>.
+    /// </summary>
+    private static void AddLoaderExceptions( ReflectionTypeLoadException exception, ImmutableArray<Exception>.Builder builder, HashSet<string> distinctKeys )
+    {
+        // The declared element type is not nullable on all target frameworks, but the elements can be null.
+        foreach ( var loaderException in exception.LoaderExceptions )
+        {
+            if ( builder.Count >= _maxReportedExceptions )
+            {
+                break;
+            }
+
+            if ( loaderException == null )
+            {
+                continue;
+            }
+
+            if ( distinctKeys.Add( $"{loaderException.GetType().FullName}: {loaderException.Message}" ) )
+            {
+                builder.Add( loaderException );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Renders the result of <see cref="GetLoaderExceptions"/> as text suitable for a crash report, or returns <c>null</c>
+    /// when there is nothing to report.
+    /// </summary>
+    /// <param name="exception">The exception whose tree is searched.</param>
+    /// <param name="scrub">An optional function removing sensitive data from the rendered messages and stack traces.</param>
+    public static string? GetLoaderExceptionsText( Exception? exception, Func<string?, string>? scrub = null )
+    {
+        var loaderExceptions = GetLoaderExceptions( exception );
+
+        if ( loaderExceptions.IsEmpty )
+        {
+            return null;
+        }
+
+        scrub ??= s => s ?? "";
+
+        var stringBuilder = new StringBuilder();
+
+        for ( var i = 0; i < loaderExceptions.Length; i++ )
+        {
+            var loaderException = loaderExceptions[i];
+
+            stringBuilder.AppendLine(
+                string.Format(
+                    CultureInfo.InvariantCulture,
+                    "[{0}] {1}: {2}",
+                    i + 1,
+                    loaderException.GetType().FullName,
+                    scrub( loaderException.Message ) ) );
+
+            if ( !string.IsNullOrEmpty( loaderException.StackTrace ) )
+            {
+                stringBuilder.AppendLine( scrub( loaderException.StackTrace ) );
+            }
+        }
+
+        if ( loaderExceptions.Length >= _maxReportedExceptions )
+        {
+            stringBuilder.AppendLine(
+                string.Format( CultureInfo.InvariantCulture, "(truncated after {0} distinct loader exceptions)", _maxReportedExceptions ) );
+        }
+
+        return stringBuilder.ToString();
+    }
+}

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LocalExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/LocalExceptionReporter.cs
@@ -100,6 +100,26 @@ internal sealed class LocalExceptionReporter : IBackstageService
             // ReSharper disable once EmptyGeneralCatchClause
             catch { }
 
+            // ReflectionTypeLoadException.ToString does not render LoaderExceptions, so without this section the report
+            // says only that some types could not be loaded, never which assembly failed to bind.
+            try
+            {
+                var loaderExceptionsText = LoaderExceptionsHelper.GetLoaderExceptionsText(
+                    exception,
+                    ExceptionSensitiveDataHelper.Instance.RemoveSensitiveData );
+
+                if ( loaderExceptionsText != null )
+                {
+                    exceptionText.AppendLine( "===== Loader Exceptions =====" );
+                    exceptionText.AppendLine( loaderExceptionsText );
+
+                    this._logger.Error?.Log( $"Loader exceptions of {exception.GetType().Name}:{Environment.NewLine}{loaderExceptionsText}" );
+                }
+            }
+
+            // ReSharper disable once EmptyGeneralCatchClause
+            catch { }
+
             // Include the call stack at the point where the exception is being reported.
             // This is essential for async exceptions where the exception's own StackTrace
             // only shows the throw-to-catch chain, but not the broader context of the entry

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/LoaderExceptionsHelperTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/LoaderExceptionsHelperTests.cs
@@ -1,0 +1,155 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Telemetry;
+using System;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Xml;
+using System.Xml.Linq;
+using Xunit;
+
+namespace Metalama.Backstage.Tests.Telemetry
+{
+    /// <summary>
+    /// Unit tests for <see cref="LoaderExceptionsHelper"/> and for the <c>LoaderExceptions</c> element it feeds in
+    /// <see cref="ExceptionXmlFormatter"/>.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Exception.ToString"/> does not render <see cref="ReflectionTypeLoadException.LoaderExceptions"/>, so
+    /// without this capture a crash report never names the assembly that failed to bind.
+    /// </remarks>
+    public sealed class LoaderExceptionsHelperTests
+    {
+        /// <summary>
+        /// Creates a <see cref="ReflectionTypeLoadException"/> carrying the given loader exceptions.
+        /// </summary>
+        private static ReflectionTypeLoadException CreateReflectionTypeLoadException( params Exception?[] loaderExceptions )
+            => new( new Type?[loaderExceptions.Length], loaderExceptions );
+
+        private static string WriteExceptionXml( Exception exception )
+        {
+            var builder = new StringBuilder();
+
+            using ( var writer = XmlWriter.Create( builder, new XmlWriterSettings { Indent = true } ) )
+            {
+                writer.WriteStartElement( "Exception" );
+                ExceptionXmlFormatter.WriteException( writer, exception );
+                writer.WriteEndElement();
+            }
+
+            return builder.ToString();
+        }
+
+        [Fact]
+        public void NoLoaderExceptionsWhenNotAReflectionTypeLoadException()
+        {
+            Assert.Empty( LoaderExceptionsHelper.GetLoaderExceptions( new InvalidOperationException( "test" ) ) );
+            Assert.Null( LoaderExceptionsHelper.GetLoaderExceptionsText( new InvalidOperationException( "test" ) ) );
+            Assert.Null( LoaderExceptionsHelper.GetLoaderExceptionsText( null ) );
+        }
+
+        [Fact]
+        public void LoaderExceptionsAreDeduplicatedByTypeAndMessage()
+        {
+            // A ReflectionTypeLoadException normally carries one loader exception per failing type, so the same binding
+            // failure is repeated once per type.
+            var exception = CreateReflectionTypeLoadException(
+                new FileNotFoundException( "Could not load 'A'." ),
+                new FileNotFoundException( "Could not load 'A'." ),
+                new FileNotFoundException( "Could not load 'B'." ) );
+
+            var loaderExceptions = LoaderExceptionsHelper.GetLoaderExceptions( exception );
+
+            Assert.Equal( 2, loaderExceptions.Length );
+            Assert.Equal( ["Could not load 'A'.", "Could not load 'B'."], loaderExceptions.Select( e => e.Message ) );
+        }
+
+        [Fact]
+        public void NullLoaderExceptionsAreSkipped()
+        {
+            var exception = CreateReflectionTypeLoadException( null, new FileNotFoundException( "Could not load 'A'." ), null );
+
+            Assert.Single( LoaderExceptionsHelper.GetLoaderExceptions( exception ) );
+        }
+
+        [Fact]
+        public void LoaderExceptionsAreFoundThroughInnerAndAggregateExceptions()
+        {
+            var inner = CreateReflectionTypeLoadException( new FileNotFoundException( "Could not load 'A'." ) );
+            var aggregate = new AggregateException( new InvalidOperationException( "wrapper", inner ) );
+
+            var loaderExceptions = LoaderExceptionsHelper.GetLoaderExceptions( aggregate );
+
+            Assert.Single( loaderExceptions );
+            Assert.Equal( "Could not load 'A'.", loaderExceptions[0].Message );
+        }
+
+        [Fact]
+        public void ResultIsCappedAndTruncationIsReported()
+        {
+            var loaderExceptions = Enumerable.Range( 0, 100 )
+                .Select( i => (Exception?) new FileNotFoundException( $"Could not load 'A{i}'." ) )
+                .ToArray();
+
+            var text = LoaderExceptionsHelper.GetLoaderExceptionsText( CreateReflectionTypeLoadException( loaderExceptions ) );
+
+            Assert.NotNull( text );
+            Assert.Contains( "truncated after", text, StringComparison.Ordinal );
+        }
+
+        [Fact]
+        public void TextRenderingIncludesTypeAndMessageAndIsScrubbed()
+        {
+            var exception = CreateReflectionTypeLoadException( new FileNotFoundException( "Could not load 'Secret'." ) );
+
+            var text = LoaderExceptionsHelper.GetLoaderExceptionsText( exception );
+
+            Assert.NotNull( text );
+            Assert.Contains( typeof(FileNotFoundException).FullName!, text, StringComparison.Ordinal );
+            Assert.Contains( "Could not load 'Secret'.", text, StringComparison.Ordinal );
+
+            // The scrubber is applied to the rendered messages.
+            var scrubbed = LoaderExceptionsHelper.GetLoaderExceptionsText( exception, _ => "<redacted>" );
+
+            Assert.NotNull( scrubbed );
+            Assert.DoesNotContain( "Secret", scrubbed, StringComparison.Ordinal );
+        }
+
+        [Fact]
+        public void LoaderExceptionsAreWrittenToXmlWithoutTheirMessage()
+        {
+            var exception = CreateReflectionTypeLoadException( new FileNotFoundException( "Could not load 'Secret'." ) );
+
+            var xml = WriteExceptionXml( exception );
+
+            // The XML must be well-formed.
+            var doc = XDocument.Parse( xml );
+
+            var loaderExceptions = doc.Descendants( "LoaderExceptions" ).SingleOrDefault();
+
+            Assert.NotNull( loaderExceptions );
+
+            // The exception type is what identifies the failure kind, and it is safe to upload.
+            Assert.Equal(
+                typeof(FileNotFoundException).FullName,
+                loaderExceptions.Descendants( "Type" ).Single().Value );
+
+            // The message can embed user paths, so the default scrubber withholds it from the upload payload, exactly as
+            // it does for any other exception. See #1680.
+            Assert.DoesNotContain( "Secret", xml, StringComparison.Ordinal );
+            Assert.Empty( loaderExceptions.Descendants( "Message" ) );
+        }
+
+        [Fact]
+        public void NoLoaderExceptionsElementWhenThereAreNone()
+        {
+            var xml = WriteExceptionXml( new InvalidOperationException( "test" ) );
+
+            Assert.Empty( XDocument.Parse( xml ).Descendants( "LoaderExceptions" ) );
+        }
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -245,7 +245,7 @@ public abstract partial class ClientEndpoint : BaseEndpoint
         bool firstConnection,
         CancellationToken cancellationToken = default )
     {
-        ImmutableArray<RpcClient> newClients = ImmutableArray<RpcClient>.Empty;
+        var newClients = ImmutableArray<RpcClient>.Empty;
 
         // Tracked outside the try so the catch can dispose them on any failure between
         // RegisterPending and the publish handoff to _connectionByStream.

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcContractMessagePackOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcContractMessagePackOptions.cs
@@ -4,7 +4,6 @@
 
 using MessagePack;
 using System.Collections.Concurrent;
-using System.Collections.Generic;
 using System.Reflection;
 
 namespace Metalama.Framework.DesignTime.Rpc;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AspectOrdering/AspectLayerSorter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AspectOrdering/AspectLayerSorter.cs
@@ -54,8 +54,7 @@ internal static class AspectLayerSorter
         var aspectNameToIndicesMapping =
             unsortedAspectLayers
                 .Select( ( t, i ) => (t.AspectName, Index: i) )
-                .ToDictionaryOfList( p => p.AspectName, p => p.Index )
-                .Freeze();
+                .ToReadOnlyDictionaryOfList( p => p.AspectName, p => p.Index );
 
         var aspectLayerNameToLocationsMapping = new DictionaryOfList<string, AspectOrderSpecification>();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/CompilationAspectSource.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/CompilationAspectSource.cs
@@ -62,8 +62,7 @@ internal sealed class CompilationAspectSource : IAspectSource
 
             this._exclusions =
                 attributes
-                    .ToDictionaryOfList( x => x.AspectType, x => x.TargetDeclaration.ToRef() )
-                    .Freeze();
+                    .ToReadOnlyDictionaryOfList( x => x.AspectType, x => x.TargetDeclaration.ToRef() );
         }
 
         return this._exclusions;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/ReflectionMapper.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/Helpers/ReflectionMapper.cs
@@ -43,8 +43,7 @@ namespace Metalama.Framework.Engine.CodeModel.Helpers
 
                 // This field cannot be set in the constructor because of linker tests.
                 this._referencedAssemblies ??= this._compilation.SourceModule.ReferencedAssemblySymbols
-                    .ToDictionaryOfList( a => a.Identity.Name, a => a )
-                    .Freeze();
+                    .ToReadOnlyDictionaryOfList( a => a.Identity.Name, a => a );
 
                 var assemblyShortName = assemblyName?.Name;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Collections/EnumerableExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Collections/EnumerableExtensions.cs
@@ -55,25 +55,25 @@ namespace Metalama.Framework.Engine.Collections
         /// the input item type. Prefer this over <see cref="ToImmutableDictionaryOfArray{TItem,TKey,TValue}"/> when
         /// the result is built once and thereafter only read.
         /// </summary>
-        public static DictionaryOfList<TKey, TValue> ToDictionaryOfList<TItem, TKey, TValue>(
+        public static IReadOnlyDictionaryOfList<TKey, TValue> ToReadOnlyDictionaryOfList<TItem, TKey, TValue>(
             this IEnumerable<TItem> enumerable,
             Func<TItem, TKey> getKey,
             Func<TItem, TValue> getValue,
             IEqualityComparer<TKey>? keyComparer = null )
             where TKey : notnull
-            => DictionaryOfList<TKey, TValue>.Create( enumerable, getKey, getValue, keyComparer );
+            => DictionaryOfList<TKey, TValue>.Create( enumerable, getKey, getValue, keyComparer ).Freeze();
 
         /// <summary>
         /// Builds a <see cref="DictionaryOfList{TKey,TValue}"/> from a collection, with the same value type as the
         /// input item type. Prefer this over <see cref="ToImmutableDictionaryOfArray{TItem,TKey}"/> when the result
         /// is built once and thereafter only read.
         /// </summary>
-        public static DictionaryOfList<TKey, TItem> ToDictionaryOfList<TItem, TKey>(
+        public static IReadOnlyDictionaryOfList<TKey, TItem> ToReadOnlyDictionaryOfList<TItem, TKey>(
             this IEnumerable<TItem> enumerable,
             Func<TItem, TKey> getKey,
             IEqualityComparer<TKey>? keyComparer = null )
             where TKey : notnull
-            => enumerable.ToDictionaryOfList( getKey, i => i, keyComparer );
+            => enumerable.ToReadOnlyDictionaryOfList( getKey, i => i, keyComparer );
 
         public static IReadOnlyCollection<T> Concat<T>( params IReadOnlyCollection<T>[] collections )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/AssemblyLocator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/AssemblyLocator.cs
@@ -27,11 +27,10 @@ namespace Metalama.Framework.Engine.CompileTime
 
         public AssemblyLocator( IServiceProvider serviceProvider, IEnumerable<PortableExecutableReference> references )
         {
-            this._referencesByName = references.ToDictionaryOfList(
-                    x => GetAssemblyShortName( x ) ?? _unknownAssemblyName,
-                    x => x,
-                    StringComparer.OrdinalIgnoreCase )
-                .Freeze();
+            this._referencesByName = references.ToReadOnlyDictionaryOfList(
+                x => GetAssemblyShortName( x ) ?? _unknownAssemblyName,
+                x => x,
+                StringComparer.OrdinalIgnoreCase );
 
             this._logger = serviceProvider.GetLoggerFactory().GetLogger( "AssemblyLocator" );
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProject.cs
@@ -243,10 +243,15 @@ internal sealed class CompileTimeProject : IProjectService
 
         this._assembly = assembly;
 
-        // In design-time scenarios, we might have duplicated projects for dependencies. For instance, with the project graph `ProjectA -> { ProjectB, Metalama.Framework }; ProjectB -> Metalama.Framework`, 
-        // the project (or dependency) `Metalama.Framework` will be referenced twice. We need to remove the duplicates.
-        var closure = this.SelectManyRecursive( p => p.References, true );
-        this.ClosureProjects = closure.GroupBy( p => p.UniqueKey ).Select( g => g.First() ).ToImmutableArray();
+        // In design-time scenarios, we might have duplicated projects for dependencies. For instance, with the project
+        // graph `ProjectA -> { ProjectB, Metalama.Framework }; ProjectB -> Metalama.Framework`, the project (or
+        // dependency) `Metalama.Framework` will be referenced twice. We need to remove the duplicates. The
+        // deduplication happens during the walk and not afterwards, because a walk that does not prune already-visited
+        // projects enumerates every distinct path through the reference graph, and that count grows exponentially with
+        // the number of diamonds in it.
+        this.ClosureProjects = new[] { this }
+            .SelectManyRecursiveDistinct( p => p.References, UniqueKeyComparer.Instance )
+            .ToImmutableArray();
         this.DiagnosticManifest = diagnosticManifest ?? this.GetDiagnosticManifest( serviceProvider );
         this.ClosureDiagnosticManifest = new DiagnosticManifest( this.ClosureProjects.SelectAsImmutableArray( p => p.DiagnosticManifest ) );
 
@@ -578,11 +583,28 @@ internal sealed class CompileTimeProject : IProjectService
         }
     }
 
+    /// <summary>
+    /// Gets a key that identifies the project within a closure. It combines both identities because a closure can
+    /// legitimately contain several compile-time copies of the same run-time assembly (one per target framework),
+    /// which share a <see cref="RunTimeIdentity"/> and differ only in their <see cref="CompileTimeIdentity"/>.
+    /// </summary>
     [Memo]
     public string UniqueKey => $"{this.RunTimeIdentity} -> {this.CompileTimeIdentity}";
 
-
     public override string ToString() => this.UniqueKey;
+
+    /// <summary>
+    /// Compares projects by <see cref="UniqueKey"/>, so that the several instances a design-time closure can hold
+    /// for the same project collapse into one.
+    /// </summary>
+    private sealed class UniqueKeyComparer : IEqualityComparer<CompileTimeProject>
+    {
+        public static UniqueKeyComparer Instance { get; } = new();
+
+        public bool Equals( CompileTimeProject? x, CompileTimeProject? y ) => string.Equals( x?.UniqueKey, y?.UniqueKey, StringComparison.Ordinal );
+
+        public int GetHashCode( CompileTimeProject obj ) => StringComparer.Ordinal.GetHashCode( obj.UniqueKey );
+    }
 
     /// <summary>
     /// Gets a <see cref="TextMapFile"/> given a the path of the transformed code file.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProject.cs
@@ -120,7 +120,7 @@ internal sealed class CompileTimeProject : IProjectService
     /// </remarks>
     [Memo]
     internal IReadOnlyDictionaryOfList<string, CompileTimeProject> ClosureProjectsGroupedByRunTimeAssemblyName
-        => this.ClosureProjects.ToDictionaryOfList( p => p.RunTimeIdentity.Name, p => p ).Freeze();
+        => this.ClosureProjects.ToReadOnlyDictionaryOfList( p => p.RunTimeIdentity.Name, p => p );
 
     private bool TryGetProjectByRunTimeAssemblyName( string runTimeName, [NotNullWhen( true )] out CompileTimeProject? project )
         => this.ClosureProjectsByRunTimeAssemblyName.TryGetValue( runTimeName, out project );
@@ -136,8 +136,7 @@ internal sealed class CompileTimeProject : IProjectService
     [Memo]
     private IReadOnlyDictionaryOfList<string, (CompileTimeFileManifest File, CompileTimeProject Project)> ClosureCodeFiles
         => this.ClosureProjects.SelectMany( p => p.CodeFiles.SelectAsReadOnlyList( f => (f, p) ) )
-            .ToDictionaryOfList( f => f.f.TransformedPath, f => f )
-            .Freeze();
+            .ToReadOnlyDictionaryOfList( f => f.f.TransformedPath, f => f );
 
     [Memo]
     public IReadOnlyList<string> ClosureOptionTypes
@@ -243,7 +242,11 @@ internal sealed class CompileTimeProject : IProjectService
         this.References = references;
 
         this._assembly = assembly;
-        this.ClosureProjects = this.SelectManyRecursiveDistinct( p => p.References ).ToImmutableArray();
+
+        // In design-time scenarios, we might have duplicated projects for dependencies. For instance, with the project graph `ProjectA -> { ProjectB, Metalama.Framework }; ProjectB -> Metalama.Framework`, 
+        // the project (or dependency) `Metalama.Framework` will be referenced twice. We need to remove the duplicates.
+        var closure = this.SelectManyRecursive( p => p.References, true );
+        this.ClosureProjects = closure.GroupBy( p => p.UniqueKey ).Select( g => g.First() ).ToImmutableArray();
         this.DiagnosticManifest = diagnosticManifest ?? this.GetDiagnosticManifest( serviceProvider );
         this.ClosureDiagnosticManifest = new DiagnosticManifest( this.ClosureProjects.SelectAsImmutableArray( p => p.DiagnosticManifest ) );
 
@@ -575,7 +578,11 @@ internal sealed class CompileTimeProject : IProjectService
         }
     }
 
-    public override string ToString() => this.RunTimeIdentity.ToString();
+    [Memo]
+    public string UniqueKey => $"{this.RunTimeIdentity} -> {this.CompileTimeIdentity}";
+
+
+    public override string ToString() => this.UniqueKey;
 
     /// <summary>
     /// Gets a <see cref="TextMapFile"/> given a the path of the transformed code file.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProjectRepository.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProjectRepository.Builder.cs
@@ -252,6 +252,14 @@ internal sealed partial class CompileTimeProjectRepository
                         out referencedProject );
 
                 case CompilationReference compilationReference:
+                    // The same assembly identity can be reached through more than one reference, so serve a project
+                    // this Builder has already resolved from the cache, as the PortableExecutableReference path does.
+                    // This also keeps the Add below from throwing on a duplicate key.
+                    if ( this._projects.TryGetValue( compilationReference.Compilation.Assembly.Identity, out referencedProject ) )
+                    {
+                        return true;
+                    }
+
                     // Issue #1611: at design time, when the upstream's pipeline is already running and has a built
                     // CompileTimeProject, reuse it rather than recursively building a fresh projection. This ensures
                     // both pipelines share the same physical loaded assembly for the upstream and prevents the

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProjectRepository.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeProjectRepository.Builder.cs
@@ -261,10 +261,10 @@ internal sealed partial class CompileTimeProjectRepository
                          && upstreamProvider.TryGetUpstreamConfiguration( compilationReference.Compilation, out var upstreamConfig )
                          && upstreamConfig.CompileTimeProject is { } upstreamProject )
                     {
-                        // Cache by AssemblyIdentity so subsequent identity-keyed lookups within this Builder
-                        // hit the same instance.
-                        this._projects[upstreamProject.RunTimeIdentity] = upstreamProject;
+                        // Cache by AssemblyIdentity so subsequent identity-keyed lookups within this Builder hit the same instance.
+                        this._projects.Add( upstreamProject.RunTimeIdentity, upstreamProject );
                         referencedProject = upstreamProject;
+
                         this._logger.Trace?.Log(
                             $"Reusing upstream pipeline's CompileTimeProject for '{compilationReference.Compilation.AssemblyName}' (issue #1611)." );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/DesignTime/JsonSerializationHelper.AnnotationWriter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/DesignTime/JsonSerializationHelper.AnnotationWriter.cs
@@ -20,7 +20,7 @@ public static partial class JsonSerializationHelper
         public AnnotationWriter( SerializableSyntaxTree parent, CancellationToken cancellationToken )
         {
             this._cancellationToken = cancellationToken;
-            this._annotations = parent.Annotations.ToDictionaryOfList( a => a.SpanStart ).Freeze();
+            this._annotations = parent.Annotations.ToReadOnlyDictionaryOfList( a => a.SpanStart );
         }
 
         public override SyntaxToken VisitToken( SyntaxToken token )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Infrastructure;
 using Metalama.Backstage.Telemetry;
@@ -23,12 +24,14 @@ namespace Metalama.Framework.Engine.Pipeline.CompileTime
         private readonly ITelemetryService? _telemetryService;
         private readonly IStandardDirectories? _standardDirectories;
         private readonly IProjectOptions? _projectOptions;
+        private readonly ILogger _logger;
 
         public CompileTimeExceptionHandler( IServiceProvider serviceProvider )
         {
             this._telemetryService = serviceProvider.GetBackstageService<ITelemetryService>();
             this._standardDirectories = serviceProvider.GetBackstageService<IStandardDirectories>();
             this._projectOptions = (IProjectOptions?) serviceProvider.GetService( typeof(IProjectOptions) );
+            this._logger = serviceProvider.GetLoggerFactory().GetLogger( nameof(CompileTimeExceptionHandler) );
         }
 
         // Writes the rich crash report. Returns <c>true</c> and sets <paramref name="reportFile"/> to the written path on
@@ -119,6 +122,18 @@ namespace Metalama.Framework.Engine.Pipeline.CompileTime
                 var exceptionToString = exception.ToString();
                 exceptionText.AppendLine( "===== Exception ===== " );
                 exceptionText.AppendLine( exceptionToString );
+
+                // ReflectionTypeLoadException.ToString does not render LoaderExceptions, so without this section the
+                // report says only that some types could not be loaded, never which assembly failed to bind.
+                var loaderExceptionsText = LoaderExceptionsHelper.GetLoaderExceptionsText( exception );
+
+                if ( loaderExceptionsText != null )
+                {
+                    exceptionText.AppendLine( "===== Loader Exceptions =====" );
+                    exceptionText.AppendLine( loaderExceptionsText );
+
+                    this._logger.Error?.Log( $"Loader exceptions of {exception.GetType().Name}:{Environment.NewLine}{loaderExceptionsText}" );
+                }
 
                 if ( node != null )
                 {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Collections/DictionaryOfListTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Collections/DictionaryOfListTests.cs
@@ -142,7 +142,7 @@ namespace Metalama.Framework.Tests.UnitTests.Collections
         {
             List<(int, string)> list = [(1, "a"), (2, "b"), (1, "c")];
 
-            var dictionary = list.ToDictionaryOfList( i => i.Item1 );
+            var dictionary = list.ToReadOnlyDictionaryOfList( i => i.Item1 );
 
             Assert.Equal( [1, 2], dictionary.Keys );
             Assert.Equal( [(1, "a"), (1, "c")], dictionary[1] );
@@ -153,7 +153,7 @@ namespace Metalama.Framework.Tests.UnitTests.Collections
         {
             List<(int, string)> list = [(1, "a"), (2, "b"), (1, "c")];
 
-            var dictionary = list.ToDictionaryOfList( i => i.Item1, i => i.Item2 );
+            var dictionary = list.ToReadOnlyDictionaryOfList( i => i.Item1, i => i.Item2 );
 
             Assert.Equal( [1, 2], dictionary.Keys );
             Assert.Equal( ["a", "c"], dictionary[1] );
@@ -199,7 +199,7 @@ namespace Metalama.Framework.Tests.UnitTests.Collections
         public void Freeze_IsFluentAndReturnsTheInterface()
         {
             var published =
-                new[] { (1, "a") }.ToDictionaryOfList( i => i.Item1, i => i.Item2 ).Freeze();
+                new[] { (1, "a") }.ToReadOnlyDictionaryOfList( i => i.Item1, i => i.Item2 );
 
             Assert.Equal( ["a"], published[1] );
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/UpstreamCompileTimeProjectReuseTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/UpstreamCompileTimeProjectReuseTests.cs
@@ -1,0 +1,153 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Pipeline;
+using Metalama.Framework.Engine.Pipeline.DesignTime;
+using Metalama.Framework.Engine.Services;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
+using System.Linq;
+using System.Threading;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime;
+
+/// <summary>
+/// Regression tests for the compile-time project closure built when a downstream project reuses an upstream
+/// pipeline's <see cref="CompileTimeProject"/> (issue #1611).
+/// </summary>
+/// <remarks>
+/// <para>
+/// Reproduces the scenario of opening a solution in Visual Studio without the Metalama extension: two projects,
+/// each with its own design-time pipeline, one referencing the other as a project (hence a
+/// <see cref="CompilationReference"/>). The downstream pipeline's <c>CompileTimeProjectRepository.Builder</c> takes
+/// the <see cref="IUpstreamCompileTimeProjectProvider"/> shortcut and imports a project built by the
+/// <em>upstream</em> Builder.
+/// </para>
+/// <para>
+/// Each Builder creates its own <c>Metalama.Framework</c> compile-time project instance
+/// (<c>FrameworkCompileTimeProjectFactory.CreateFrameworkProject</c> caches only the manifest, not the project), and
+/// the closure is deduplicated by reference equality. So the imported upstream project drags the upstream Builder's
+/// framework instance into a closure that already holds the downstream Builder's own, and
+/// <c>ClosureProjectsByCompileTimeAssemblyName</c> then throws
+/// <c>ArgumentException: An item with the same key has already been added. Key: Metalama.Framework</c>.
+/// </para>
+/// </remarks>
+public sealed class UpstreamCompileTimeProjectReuseTests : UnitTestClass
+{
+    public UpstreamCompileTimeProjectReuseTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    private const string _upstreamCode = @"
+using Metalama.Framework.Aspects;
+
+public class UpstreamAspect : OverrideMethodAspect
+{
+    public override dynamic? OverrideMethod() => meta.Proceed();
+}
+";
+
+    private const string _downstreamCode = @"
+public class DownstreamClass
+{
+    [UpstreamAspect]
+    public void M() { }
+}
+";
+
+    [Fact]
+    public void ClosureHasSingleFrameworkProjectWhenUpstreamProjectIsReused()
+    {
+        var upstreamProvider = new TestUpstreamCompileTimeProjectProvider();
+        var services = CreateAdditionalServiceCollection();
+        services.AddGlobalService<IUpstreamCompileTimeProjectProvider>( upstreamProvider, true );
+
+        using var testContext = this.CreateTestContext( services );
+
+        var upstreamCompilation = testContext.CreateCSharpCompilation( _upstreamCode, assemblyName: "UpstreamProject" );
+
+        // Stand in for the upstream project's own design-time pipeline: it initializes first, and the
+        // CompileTimeProject it produces comes from a CompileTimeProjectRepository.Builder of its own.
+        var upstreamPipeline = new TestablePipeline( testContext.ServiceProvider );
+        var initDiagnostics = new DiagnosticBag();
+
+        Assert.True(
+            upstreamPipeline.InvokeTryInitialize( initDiagnostics, upstreamCompilation, out var upstreamConfiguration ),
+            $"Upstream pipeline initialization failed.\n{FormatDiagnostics( initDiagnostics )}" );
+
+        upstreamProvider.Add( upstreamCompilation, upstreamConfiguration.AssertNotNull() );
+
+        // The downstream project references the upstream one as a project, i.e. by CompilationReference.
+        var downstreamCompilation = testContext.CreateCSharpCompilation(
+            _downstreamCode,
+            additionalReferences: [upstreamCompilation.ToMetadataReference()],
+            assemblyName: "DownstreamProject" );
+
+        var repository = CompileTimeProjectRepository.Create( testContext.Domain, testContext.ServiceProvider, downstreamCompilation )
+            .AssertNotNull();
+
+        // The upstream shortcut must actually have been taken, otherwise the test proves nothing.
+        Assert.True( upstreamProvider.WasHit, "The upstream CompileTimeProject was not reused; the test does not cover the intended path." );
+
+        // This is the call that actually throws in the reported stack trace, reached through
+        // CompileTimeSerializationBinder.BindToName during transitive-manifest serialization.
+        Assert.True( repository.RootProject.TryGetProjectByCompileTimeAssemblyName( "Metalama.Framework", out _ ) );
+
+        // The underlying cause: the closure holds two 'Metalama.Framework' projects, one per Builder.
+        var frameworkProjects = repository.RootProject.ClosureProjects.Where( p => p.IsFramework ).ToReadOnlyList();
+
+        Assert.Single( frameworkProjects );
+    }
+
+    private static string FormatDiagnostics( DiagnosticBag bag )
+        => string.Join( "\n  ", bag.SelectAsArray( d => d.GetMessage( CultureInfo.InvariantCulture ) ) );
+
+    /// <summary>
+    /// Test double for <see cref="IUpstreamCompileTimeProjectProvider"/> that resolves the configurations
+    /// registered by the test, keyed by <see cref="Compilation"/> instance.
+    /// </summary>
+    private sealed class TestUpstreamCompileTimeProjectProvider : IUpstreamCompileTimeProjectProvider
+    {
+        private readonly Dictionary<Compilation, AspectPipelineConfiguration> _configurations = new();
+
+        /// <summary>
+        /// Gets a value indicating whether a lookup ever succeeded, so the test can assert that the
+        /// upstream-reuse branch of the Builder was really exercised.
+        /// </summary>
+        public bool WasHit { get; private set; }
+
+        public void Add( Compilation compilation, AspectPipelineConfiguration configuration ) => this._configurations[compilation] = configuration;
+
+        public bool TryGetUpstreamConfiguration( Compilation compilation, [NotNullWhen( true )] out AspectPipelineConfiguration? configuration )
+        {
+            if ( this._configurations.TryGetValue( compilation, out configuration ) )
+            {
+                this.WasHit = true;
+
+                return true;
+            }
+
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Test-only subclass exposing the <c>protected</c> <see cref="AspectPipeline.TryInitialize"/>, so the test can
+    /// obtain a real <see cref="AspectPipelineConfiguration"/> for the upstream project.
+    /// </summary>
+    private sealed class TestablePipeline : PreviewAspectPipeline
+    {
+        public TestablePipeline( ProjectServiceProvider serviceProvider ) : base( serviceProvider, ExecutionScenario.Preview ) { }
+
+        public bool InvokeTryInitialize( IDiagnosticAdder diagnosticAdder, Compilation compilation, out AspectPipelineConfiguration? configuration )
+            => this.TryInitialize( diagnosticAdder, compilation, null, CancellationToken.None, out configuration );
+    }
+}


### PR DESCRIPTION
## Summary

Two independent changes made on the same branch.

**Compile-time project closure deduplication**

- A design-time closure can reach the same dependency through several paths (`ProjectA -> { ProjectB, Metalama.Framework }; ProjectB -> Metalama.Framework`), so `ClosureProjects` contained duplicates.
- Deduplication now happens *during* the walk rather than afterwards. A walk that does not prune already-visited projects enumerates every distinct path through the reference graph, and that count grows exponentially with the number of diamonds in it.
- Projects are compared by `UniqueKey`, which combines both identities: a closure can legitimately contain several compile-time copies of the same run-time assembly (one per target framework), sharing a `RunTimeIdentity` and differing only in `CompileTimeIdentity`.
- `CompileTimeProjectRepository.Builder` now serves an already-resolved project from its cache for a `CompilationReference`, as the `PortableExecutableReference` path already did. This also keeps the subsequent `Add` from throwing on a duplicate key.

**Crash report improvement (#1738)**

- `ReflectionTypeLoadException.ToString()` does not render `LoaderExceptions`, so crash reports and telemetry payloads discarded the only actionable detail: the name and version of the assembly that failed to bind.
- New `LoaderExceptionsHelper` walks an exception tree, collects the loader exceptions, deduplicates them by type and message (a single binding failure is otherwise repeated once per failing type) and caps the result.
- `ExceptionXmlFormatter` emits a `<LoaderExceptions>` element through the regular `WriteException` path, so the redaction rules from #1680 apply unchanged: the exception type and stack trace are uploaded, the message is not.
- `LocalExceptionReporter` and `CompileTimeExceptionHandler` gain a `===== Loader Exceptions =====` section and log the detail at `ILogger.Error`.

## Breaking Changes

None. `LoaderExceptionsHelper` is a new public type in `Metalama.Backstage.Telemetry`; the rest is internal or additive.

## Issues Fixed

- Closes #1738 - Capture `ReflectionTypeLoadException.LoaderExceptions` in crash reports

— Claude for @gfraiteur
