### PR TITLE
Keep asking about exception reports until the user decides (#1751)

### DIFF
--- a/Metalama.Backstage/docs/telemetry.md
+++ b/Metalama.Backstage/docs/telemetry.md
@@ -111,9 +111,11 @@ An issue with no terminal decision is captured and prompted again once `Exceptio
 | Snooze | user action | `ManualSnoozePeriod` |
 | Mute | user action, sets `Disabled` | forever, and there is no un-mute in the product |
 
-Mute is permanent and cannot be undone from the product, so it is unacceptable on a notification that is the only way to take an action. `ToastNotificationKind.CanBeMuted` expresses this: for such a kind the notification offers no Mute button, `Mute` is a no-op, and a `Disabled` flag written by an older version is **ignored** on read, so users who muted before the button was removed start seeing the notification again.
+Mute is permanent and cannot be undone from the product, so it is unacceptable on a notification that is the only way to take an action. `ToastNotificationKind.CanBeMuted` expresses this: for such a kind the notification offers no Mute button, `Mute` is a no-op, and a `Disabled` flag is ignored on read.
 
-`ToastNotificationKinds.Exception` is shared by the exception and performance channels.
+`ToastNotificationKinds.ExceptionReport` is shared by the exception and performance channels, and cannot be muted.
+
+> **Migration.** Per-kind state is keyed by `kind.Name`, so **renaming a kind discards everything stored for it**. That is how the mutes written by 2026.1.18 to 2026.1.21, when the error-report notification still had a Mute button, were cleared: the kind was renamed from `Exception` to `ExceptionReport` in 2026.1.22. Renaming a kind is therefore a deliberate, one-time reset of its snooze and mute state, never a cosmetic change.
 
 ## Uploading
 

--- a/Metalama.Backstage/docs/telemetry.md
+++ b/Metalama.Backstage/docs/telemetry.md
@@ -157,6 +157,10 @@ Mute is permanent and cannot be undone from the product, so it is unacceptable o
 
 `StartUpload` is throttled to once a day unless `force: true`, which the review page uses because the user explicitly asked. It delegates to a separate worker process, so it needs `IBackstageToolsExecutor`; when that service is absent it is a no-op and the file simply waits for the next process start (`BackstageServicesInitializer`).
 
+Writing `LastUploadTime` is how the once-a-day upload is claimed against other processes, so it necessarily happens *before* the upload starts. The claim is therefore optimistic and is released again if the upload process cannot be started, otherwise a single failed start would consume the day for the whole machine.
+
+> **Rule.** A background task that fails must not leave a claim behind, and must not fail silently. `StartUpload` runs as a background task and enqueues another one, so nothing above it observes an exception: both the log and the release have to happen inside the task. See #1764.
+
 ## Configuration files
 
 | File | Scope | Contents |

--- a/Metalama.Backstage/docs/telemetry.md
+++ b/Metalama.Backstage/docs/telemetry.md
@@ -59,29 +59,55 @@ An exception report is rendered twice, by `ExceptionReporter.BuildReport`:
 
 ## The life of an exception report
 
-```
-ITelemetryContext.ReportException
-  └─ consent != No ──> IExceptionCapturer.Capture
-        ├─ ShouldReportIssue(hash)?            <- decision + 1 h prompt throttle
-        ├─ write exception-<hash>.xml (+ .local.xml)
-        ├─ consent == Yes ──> enqueue + mark Reported
-        └─ show the review notification
-                            │
-                            v  (user clicks Review)
-              worker web server, /ExceptionReport
-                            │
-        ┌───────────────────┼────────────────────┐
-        v                   v                    v
-   SendReport         SendReport +          IgnoreReport
-   (mark Reported)    consent = Yes         (mark Ignored,
-        │                                    delete files)
-        v
-   TelemetryQueue.EnqueueFile  ──> Telemetry\UploadQueue
-        │
-        v
-   ITelemetryUploader.StartUpload(force: true)
-        └─ worker process `upload` ──> UploadAsync
-              └─ zip + RSA/AES encrypt ──> PUT https://bits.postsharp.net:44301/upload
+```mermaid
+flowchart TD
+    Report["ITelemetryContext.ReportException"]
+    Capture["IExceptionCapturer.Capture"]
+    LocalOnly["Local crash report only,<br/>no telemetry"]
+    Should{"ShouldReportIssue"}
+    Drop["Nothing"]
+    Write["Write exception-hash.xml<br/>and .local.xml,<br/>record the prompt"]
+    Consent{"Consent"}
+    Auto["Mark Reported"]
+    Pending["Leave pending"]
+    Notify["Show the review notification"]
+    Page["Worker web server,<br/>/ExceptionReport"]
+    Send["Report"]
+    SendAlways["Report, plus<br/>automatically report all"]
+    Ignore["Never report this error"]
+    MarkSent["Mark Reported"]
+    MarkSentAlways["Mark Reported,<br/>consent = Yes"]
+    MarkIgnored["Mark Ignored,<br/>delete the local files"]
+    Queue["TelemetryQueue.EnqueueFile<br/>into Telemetry/UploadQueue"]
+    Start["ITelemetryUploader.StartUpload"]
+    Worker["Worker process, upload command"]
+    Encrypt["Zip, then AES with an<br/>RSA-encrypted key"]
+    Put["PUT bits.postsharp.net/upload"]
+
+    Report -->|"consent is No"| LocalOnly
+    Report -->|"consent is not No"| Capture
+    Capture --> Should
+    Should -->|"already decided, or prompted<br/>less than 1 h ago"| Drop
+    Should -->|"ask"| Write
+    Write --> Consent
+    Consent -->|"Yes"| Auto
+    Consent -->|"Default"| Pending
+    Auto --> Notify
+    Auto --> Queue
+    Pending --> Notify
+    Notify -->|"user clicks Review"| Page
+    Page --> Send
+    Page --> SendAlways
+    Page --> Ignore
+    Send --> MarkSent
+    SendAlways --> MarkSentAlways
+    Ignore --> MarkIgnored
+    MarkSent --> Queue
+    MarkSentAlways --> Queue
+    Queue --> Start
+    Start --> Worker
+    Worker --> Encrypt
+    Encrypt --> Put
 ```
 
 ### The issue signature

--- a/Metalama.Backstage/docs/telemetry.md
+++ b/Metalama.Backstage/docs/telemetry.md
@@ -64,8 +64,9 @@ flowchart TD
     Report["ITelemetryContext.ReportException"]
     Capture["IExceptionCapturer.Capture"]
     LocalOnly["Local crash report only,<br/>no telemetry"]
-    Should{"ShouldReportIssue"}
-    Drop["Nothing"]
+    Decided{"Already sent, or marked<br/>never report?"}
+    Throttled{"Asked about it less<br/>than 1 h ago?"}
+    Drop["Nothing: do not capture,<br/>do not ask"]
     Write["Write exception-hash.xml<br/>and .local.xml,<br/>record the prompt"]
     Consent{"Consent"}
     Auto["Mark Reported"]
@@ -86,9 +87,11 @@ flowchart TD
 
     Report -->|"consent is No"| LocalOnly
     Report -->|"consent is not No"| Capture
-    Capture --> Should
-    Should -->|"already decided, or prompted<br/>less than 1 h ago"| Drop
-    Should -->|"ask"| Write
+    Capture --> Decided
+    Decided -->|"yes: Issues holds<br/>Reported or Ignored"| Drop
+    Decided -->|"no decision yet"| Throttled
+    Throttled -->|"yes: IssuePrompts is<br/>within the retry period"| Drop
+    Throttled -->|"no"| Write
     Write --> Consent
     Consent -->|"Yes"| Auto
     Consent -->|"Default"| Pending

--- a/Metalama.Backstage/docs/telemetry.md
+++ b/Metalama.Backstage/docs/telemetry.md
@@ -136,7 +136,7 @@ An issue with no terminal decision is captured and prompted again once `Exceptio
 
 | Control | Effect | Duration |
 |---|---|---|
-| auto-snooze | applied by `TryAcquire` when a notification is shown | `AutoSnoozePeriod` (5 s for `Exception`) |
+| auto-snooze | applied by `TryAcquire` when a notification is shown | `AutoSnoozePeriod` (5 s for `ExceptionReport`) |
 | Snooze | user action | `ManualSnoozePeriod` |
 | Mute | user action, sets `Disabled` | forever, and there is no un-mute in the product |
 

--- a/Metalama.Backstage/docs/telemetry.md
+++ b/Metalama.Backstage/docs/telemetry.md
@@ -99,6 +99,7 @@ flowchart TD
     Auto --> Queue
     Pending --> Notify
     Notify -->|"user clicks Review"| Page
+    Notify -->|"user clicks Report"| MarkSent
     Page --> Send
     Page --> SendAlways
     Page --> Ignore
@@ -129,6 +130,10 @@ Including the version means signatures do not survive an upgrade. That is delibe
 > **Rule.** Capturing a report is not a decision. `Reported` is written when the report is on its way: by `SendReport`, and by `Capture` when the consent is `Yes`. Writing it at capture time is precisely the bug that produced zero exception reports for four releases: a notification the user ignored silenced the issue forever.
 
 An issue with no terminal decision is captured and prompted again once `ExceptionReporter.PromptRetryPeriod` (1 hour) has elapsed, every time it recurs, until the user picks one of the three outcomes. The pending report file is keyed by hash alone and overwritten, so a recurring issue produces one report, not one per hour.
+
+The notification offers **Review** and **Report**. Report (`ReportExceptionCommand`) sends the same scrubbed report without opening the review page, so the fast path to yes costs one click while opting an issue out still costs a page visit.
+
+> **Rule.** A process that acts on a user gesture and then exits must await `BackstageBackgroundTasksService.Default.CompleteAsync()` first. Sending a report starts the upload through that queue, and `Environment.Exit` would kill a task that has not started yet. The desktop application does it in `App.RunAppAsync`.
 
 ## Notifications
 

--- a/Metalama.Backstage/docs/telemetry.md
+++ b/Metalama.Backstage/docs/telemetry.md
@@ -1,0 +1,156 @@
+# Telemetry
+
+This document describes how telemetry works inside `Metalama.Backstage`: what the channels are, how consent is resolved, how an exception report travels from the failure that produced it to our servers, and which invariants must not be broken. It exists because the subsystem spans five processes and three configuration files, and because a mistake in it is invisible: nothing fails, reports simply stop arriving. That is exactly what happened in 2026.1.18 (see [#1751](https://github.com/metalama/Metalama/issues/1751)).
+
+For the user-facing description, see `content/conceptual/configuration/telemetry.md` in `Metalama.Documentation`.
+
+## Channels
+
+| Scenario | What it carries | Sent |
+|---|---|---|
+| `TelemetryScenario.Usage` | Per-project metrics: hashed project name, target framework, project size, aspect count, timings | Automatically, opt-out |
+| `TelemetryScenario.Exception` | An anonymized exception report | Review-first by default |
+| `TelemetryScenario.Performance` | The same report shape, for a performance degradation | Review-first by default |
+
+The **license audit** (`Metalama.Backstage.Licensing.Audit`) is not one of these. It deliberately ignores every telemetry setting, so it must never be routed through `ITelemetryPolicy`.
+
+## Consent
+
+`TelemetryConsent` has three values, and their meaning depends on the scenario:
+
+| | `Usage` | `Exception` / `Performance` |
+|---|---|---|
+| `Default` | collect and send (promoted to `Yes` on first use) | **ask**: capture locally, notify, do not send |
+| `Yes` | collect and send | capture, notify, and send immediately |
+| `No` | do not collect | do not capture, do not ask |
+
+`Default` is *not* "unset then treated as `No`" for exceptions: it is a real, distinct state, and it is the state almost every installation is in. Any change that treats `Default` as equivalent to either neighbour will silently change what users are asked or what we receive.
+
+Only `Usage` is ever promoted automatically (`TelemetryContext.EnableTelemetryIfDefault`). Nothing promotes `Exception` or `Performance`: the user must act, through the privacy page, the review page checkbox, or `metalama telemetry`.
+
+## Resolving whether we may report
+
+Three gates apply, in this order. `ITelemetryPolicy` composes them, and `ITelemetryContext` is the only public way to report.
+
+1. **Process-level** (`TelemetryConfigurationService.ComputeGlobalTelemetryDisabledReason`): the application declares `IsTelemetryEnabled`, the process is unattended (CI, build server, `Environment.UserInteractive == false`), or `METALAMA_TELEMETRY_OPT_OUT` is set. Any of these disables every scenario. This is why CI never reports and why no prompt loop can run there.
+2. **Repository** (`TelemetryService.GetPolicy`): `metalama.json` at the repository root may set `telemetry.enabled = false`. A directory that is not inside a git repository has no repository to consult and yields `NullTelemetryPolicy.NoContext`, which disables everything.
+3. **Per-scenario consent**, as above.
+
+`GetConsentAndReason` returns the `TelemetryDisabledReason` alongside the consent so that `metalama telemetry status` can explain *why* a category is off. Keep that reason accurate: it is the only diagnostic a user has.
+
+> **Rule.** Never call `IExceptionCapturer` directly. It carries an already-resolved consent and exists only so `TelemetryContext` can pass it. Reporting outside `ITelemetryContext` bypasses all three gates.
+
+## Lazy activation
+
+The device identifier and the anonymization salts are created on demand by `ITelemetryConfigurationService.EnsureActivated`, not at startup. A process that never reports must leave `telemetry.json` untouched and must never create a device identifier.
+
+`GetSalt` throws if the configuration is not activated rather than returning a zeroed salt, because a zero salt would produce the *same* pseudonym on every not-yet-activated machine. Call `EnsureActivated` before reading a salt.
+
+## Anonymization
+
+Each channel hashes the device identifier with its **own** salt (`TelemetrySaltKind`), so the Matomo dataset, the usage-tracking data and the exception reports cannot be joined. The raw `DeviceId` GUID never leaves the machine.
+
+An exception report is rendered twice, by `ExceptionReporter.BuildReport`:
+
+- the **scrubbed** rendering (`exception-<hash>.xml`), which is the exact upload payload: exception messages, paths and user or third-party assembly identities are removed (`ExceptionSensitiveDataHelper`, `ExceptionReporter.WriteAssemblyElement`);
+- the **full local** rendering (`exception-<hash>.local.xml`), which keeps everything so the review page can show both side by side.
+
+> **Rule.** The `.local.xml` file must never be uploaded. `IsValidScrubbedReportFileName` rejects it, and it is never enqueued. Anything that moves files into the upload queue must preserve that.
+
+## The life of an exception report
+
+```
+ITelemetryContext.ReportException
+  └─ consent != No ──> IExceptionCapturer.Capture
+        ├─ ShouldReportIssue(hash)?            <- decision + 1 h prompt throttle
+        ├─ write exception-<hash>.xml (+ .local.xml)
+        ├─ consent == Yes ──> enqueue + mark Reported
+        └─ show the review notification
+                            │
+                            v  (user clicks Review)
+              worker web server, /ExceptionReport
+                            │
+        ┌───────────────────┼────────────────────┐
+        v                   v                    v
+   SendReport         SendReport +          IgnoreReport
+   (mark Reported)    consent = Yes         (mark Ignored,
+        │                                    delete files)
+        v
+   TelemetryQueue.EnqueueFile  ──> Telemetry\UploadQueue
+        │
+        v
+   ITelemetryUploader.StartUpload(force: true)
+        └─ worker process `upload` ──> UploadAsync
+              └─ zip + RSA/AES encrypt ──> PUT https://bits.postsharp.net:44301/upload
+```
+
+### The issue signature
+
+`ComputeExceptionHash` builds the signature from the **package version**, the exception type name and the cleaned stack frames. Consecutive user frames collapse to a single `#user`.
+
+Including the version means signatures do not survive an upgrade. That is deliberate: a new version may behave differently, so we ask again. It also means no configuration migration is ever needed when the meaning of an entry in `Issues` changes.
+
+### Deciding, and asking again
+
+`TelemetryConfiguration` holds two dictionaries keyed by the signature:
+
+- `Issues` holds only **terminal decisions**: `Reported` (the report was actually sent) and `Ignored` (the user asked never to report it).
+- `IssuePrompts` holds **when the user was last asked**, and is pruned as it is written so it only ever holds the last hour.
+
+> **Rule.** Capturing a report is not a decision. `Reported` is written when the report is on its way: by `SendReport`, and by `Capture` when the consent is `Yes`. Writing it at capture time is precisely the bug that produced zero exception reports for four releases: a notification the user ignored silenced the issue forever.
+
+An issue with no terminal decision is captured and prompted again once `ExceptionReporter.PromptRetryPeriod` (1 hour) has elapsed, every time it recurs, until the user picks one of the three outcomes. The pending report file is keyed by hash alone and overwritten, so a recurring issue produces one report, not one per hour.
+
+## Notifications
+
+`ToastNotificationKind` describes a notification kind; `ToastNotificationStatusService` stores per-kind state in `toastNotifications.json`.
+
+| Control | Effect | Duration |
+|---|---|---|
+| auto-snooze | applied by `TryAcquire` when a notification is shown | `AutoSnoozePeriod` (5 s for `Exception`) |
+| Snooze | user action | `ManualSnoozePeriod` |
+| Mute | user action, sets `Disabled` | forever, and there is no un-mute in the product |
+
+Mute is permanent and cannot be undone from the product, so it is unacceptable on a notification that is the only way to take an action. `ToastNotificationKind.CanBeMuted` expresses this: for such a kind the notification offers no Mute button, `Mute` is a no-op, and a `Disabled` flag written by an older version is **ignored** on read, so users who muted before the button was removed start seeing the notification again.
+
+`ToastNotificationKinds.Exception` is shared by the exception and performance channels.
+
+## Uploading
+
+`TelemetryQueue.EnqueueFile` moves a file into `Telemetry\UploadQueue`. `TelemetryUploader.UploadAsync` packs **everything** in that directory into one zip, encrypts it (random AES key, itself RSA-encrypted with the embedded public key) and PUTs it. Usage reports, license-audit reports and exception reports all travel this way.
+
+`StartUpload` is throttled to once a day unless `force: true`, which the review page uses because the user explicitly asked. It delegates to a separate worker process, so it needs `IBackstageToolsExecutor`; when that service is absent it is a no-op and the file simply waits for the next process start (`BackstageServicesInitializer`).
+
+## Configuration files
+
+| File | Scope | Contents |
+|---|---|---|
+| `telemetry.json` | user | consent per scenario, device id, salts, `Issues`, `IssuePrompts`, `Sessions`, retention |
+| `toastNotifications.json` | user | per-kind snooze / mute, last notification time |
+| `metalama.json` | repository, committed | `telemetry.enabled` |
+
+All of these are editable with `metalama config edit <alias>`, so **assume any property may be missing or null**.
+
+> **Rule.** A property absent from the JSON deserializes to `null`, *not* to its property initializer. Every collection property on a `ConfigurationFile` must therefore normalize `null` in its `init` accessor (`with` expressions go through it too). Relying on the initializer alone produces a `NullReferenceException` on the first read after the property is introduced, on every existing installation.
+
+Data under `Telemetry` is deleted after `RetentionPeriodInDays` (30 by default) by `TempFileManager`, including reports still awaiting review.
+
+## Testing it
+
+```powershell
+# Capture a report and show the review notification. Requires the current directory to be inside a git repository.
+metalama throw
+
+# A distinct signature, to check that a decision on one issue does not affect another.
+metalama throw --variant b
+
+# Forget all decisions and prompts, so the next occurrence asks again immediately.
+metalama telemetry reset-dedup
+
+# What is configured, what is in effect, and why they differ.
+metalama telemetry status
+```
+
+`metalama throw` turns on the user-interface services itself; other commands only add them with the hidden `--with-ui` flag, and without them a report is captured with no notification at all.
+
+Unit tests live in `Metalama.Backstage.Tests/Telemetry` (capture, decisions, prompting), `Metalama.Backstage.Tests/UserInterface` (notification state) and `Metalama.Backstage.Worker.Tests` (the review page). Use `TestDateTimeProvider.AddTime` to cross the retry period; never use a real delay.

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ActivationArguments.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ActivationArguments.cs
@@ -32,4 +32,7 @@ internal sealed class ActivationArguments
     // The toast Uri carries only the bare exception-report id (token-safe, no spaces). The activation argument is later
     // split on spaces, so the report id stays a single argument; the command builds the review-page path itself. See #1674.
     public string OpenExceptionReport => $"{OpenExceptionReportCommand.Name} {this._uri} {this._options}";
+
+    // Sends the same report without opening the review page. See #1751.
+    public string ReportException => $"{ReportExceptionCommand.Name} {this._uri} {this._options}";
 }

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/App.xaml.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/App.xaml.cs
@@ -5,6 +5,7 @@
 using Metalama.Backstage.Desktop.Windows.Commands;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.Infrastructure;
 using Microsoft.Toolkit.Uwp.Notifications;
 using Spectre.Console.Cli;
 using System;
@@ -49,10 +50,10 @@ internal sealed partial class App
         return BackstageServiceFactory.ServiceProvider;
     }
 
-    private static Task RunAppAsync( IEnumerable<string> args )
+    private static async Task RunAppAsync( IEnumerable<string> args )
     {
         // Make sure to run the app in a background thread.
-        return Task.Run(
+        await Task.Run(
             () =>
             {
                 CommandApp commandApp = new();
@@ -67,10 +68,20 @@ internal sealed partial class App
                         configuration.AddCommand<OpenWorkerRssOptionsCommand>( OpenWorkerRssOptionsCommand.Name );
                         configuration.AddCommand<OpenWorkerPrivacyOptionsCommand>( OpenWorkerPrivacyOptionsCommand.Name );
                         configuration.AddCommand<OpenExceptionReportCommand>( OpenExceptionReportCommand.Name );
+                        configuration.AddCommand<ReportExceptionCommand>( ReportExceptionCommand.Name );
                     } );
 
                 return commandApp.RunAsync( args );
             } );
+
+        // A command returns as soon as it has done its work, but it may have enqueued background work: sending a report
+        // starts the upload process that way. This process exits immediately afterwards (through Environment.Exit for a
+        // toast activation), which would kill a task that has not started yet, so we wait for the queue to drain here
+        // rather than rely on the ProcessExit handler having time to run. See #1751.
+        if ( BackstageServiceFactory.IsInitialized )
+        {
+            await BackstageBackgroundTasksService.Default.CompleteAsync();
+        }
     }
 
     protected override void OnStartup( StartupEventArgs e )

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/ExceptionReportCommandSettings.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/ExceptionReportCommandSettings.cs
@@ -8,7 +8,7 @@ using Spectre.Console.Cli;
 namespace Metalama.Backstage.Desktop.Windows.Commands;
 
 [UsedImplicitly( ImplicitUseTargetFlags.WithMembers )]
-public class OpenExceptionReportCommandSettings : BaseSettings
+public class ExceptionReportCommandSettings : BaseSettings
 {
     /// <summary>
     /// Gets the bare file name of the captured exception report to review (e.g. <c>exception-….xml</c>). It is

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/NotifyCommand.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/NotifyCommand.cs
@@ -39,12 +39,22 @@ public sealed class NotifyCommand : BaseCommand<NotifyCommandSettings>
             builder.AddVisualChild( new AdaptiveText() { Text = notificationViewModel.Body, HintMinLines = 4, HintStyle = AdaptiveTextStyle.Body } );
         }
 
+        // AddArgument sets what happens when the user clicks the notification body rather than one of its buttons, so it
+        // must be set at most once. A notification with several command actions (the exception one offers Review and
+        // Report) takes the first as its body action. See #1751.
+        var hasBodyAction = false;
+
         foreach ( var action in notificationViewModel.Actions )
         {
             switch ( action )
             {
                 case CommandActionViewModel commandAction:
-                    builder.AddArgument( commandAction.Command );
+                    if ( !hasBodyAction )
+                    {
+                        builder.AddArgument( commandAction.Command );
+                        hasBodyAction = true;
+                    }
+
                     builder.AddButton( commandAction.Text, ToastActivationType.Foreground, commandAction.Command );
 
                     break;

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/OpenExceptionReportCommand.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/OpenExceptionReportCommand.cs
@@ -13,11 +13,11 @@ namespace Metalama.Backstage.Desktop.Windows.Commands;
 // Opens the exception-report review page (formatted report + Report button + per-category auto-report checkbox) using
 // the worker-process web server. Activated when the user clicks the exception toast. See #1674.
 [UsedImplicitly( ImplicitUseTargetFlags.WithMembers )]
-internal sealed class OpenExceptionReportCommand : BaseAsyncCommand<OpenExceptionReportCommandSettings>
+internal sealed class OpenExceptionReportCommand : BaseAsyncCommand<ExceptionReportCommandSettings>
 {
     public const string Name = "exception-report";
 
-    protected override async Task<int> ExecuteAsync( ExtendedCommandContext context, OpenExceptionReportCommandSettings settings )
+    protected override async Task<int> ExecuteAsync( ExtendedCommandContext context, ExceptionReportCommandSettings settings )
     {
         var serviceProvider = App.GetBackstageServices( settings );
         var userInterfaceService = serviceProvider.GetRequiredBackstageService<IUserInterfaceService>();

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/ReportExceptionCommand.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/Commands/ReportExceptionCommand.cs
@@ -1,0 +1,43 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.Telemetry;
+
+namespace Metalama.Backstage.Desktop.Windows.Commands;
+
+/// <summary>
+/// Sends a captured exception report straight away, without opening the review page. Activated by the Report button of
+/// the exception notification.
+/// </summary>
+/// <remarks>
+/// This is the one-click alternative to Review, for the user who is willing to report but does not want to inspect the
+/// payload first. The consent is still explicit (the user clicked Report), and what is sent is the same scrubbed report
+/// the review page would have shown: this button changes how much the user reads, never what leaves the machine.
+/// See #1751.
+/// </remarks>
+[UsedImplicitly( ImplicitUseTargetFlags.WithMembers )]
+internal sealed class ReportExceptionCommand : BaseCommand<ExceptionReportCommandSettings>
+{
+    public const string Name = "report-exception";
+
+    protected override int Execute( ExtendedCommandContext context, ExceptionReportCommandSettings settings )
+    {
+        var exceptionReportManager = context.ServiceProvider.GetRequiredBackstageService<IExceptionReportManager>();
+
+        if ( !exceptionReportManager.SendReport( settings.Report ) )
+        {
+            // The report was removed in the meantime, or the name is invalid. There is no interface to report this to
+            // (the notification is gone), so we only trace it.
+            context.Logger.Warning?.Log( $"The exception report '{settings.Report}' could not be sent." );
+
+            return 1;
+        }
+
+        context.Logger.Trace?.Log( $"The exception report '{settings.Report}' was sent." );
+
+        return 0;
+    }
+}

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
@@ -80,11 +80,18 @@ internal static class ViewModelBuilder
         {
             // Open the worker review page (formatted report + Report button + per-category auto-report checkbox)
             // instead of opening the raw report file. See #1674.
+            //
+            // This is the only notification kind without Snooze and Mute. Both act on the whole kind, so on this
+            // notification they silenced every error report on the machine: Mute permanently and irreversibly from the
+            // product, Snooze for an hour. Since the notification is the only way to approve a report, that turned a
+            // single click into the end of error reporting. The review page offers the per-issue equivalent ("never
+            // report this error"), and the privacy page remains the visible, reversible way to turn the whole channel
+            // off. Every other notification kind keeps both buttons. See #1751.
             viewModel = new NotificationViewModel(
                 settings.Kind,
                 settings.Title ?? "Metalama failed",
                 settings.Text ?? "Metalama encountered an unhandled exception.",
-                new CommandActionViewModel( "Review", activationArguments.OpenExceptionReport ) );
+                new CommandActionViewModel( "Review", activationArguments.OpenExceptionReport ) ) { CanMute = false, CanSnooze = false };
 
             return true;
         }

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
@@ -87,11 +87,16 @@ internal static class ViewModelBuilder
             // single click into the end of error reporting. The review page offers the per-issue equivalent ("never
             // report this error"), and the privacy page remains the visible, reversible way to turn the whole channel
             // off. Every other notification kind keeps both buttons. See #1751.
+            // Review comes first and stays the primary action, so the default gesture is still to look before sending.
+            // Report is the one-click path for the user who is willing to report without inspecting the payload: it
+            // sends the very same scrubbed report. "Never report this error" deliberately stays on the review page, so
+            // that opting an issue out costs a page visit while opting in does not. See #1751.
             viewModel = new NotificationViewModel(
                 settings.Kind,
                 settings.Title ?? "Metalama failed",
                 settings.Text ?? "Metalama encountered an unhandled exception.",
-                new CommandActionViewModel( "Review", activationArguments.OpenExceptionReport ) ) { CanMute = false, CanSnooze = false };
+                new CommandActionViewModel( "Review", activationArguments.OpenExceptionReport ),
+                new CommandActionViewModel( "Report", activationArguments.ReportException ) ) { CanMute = false, CanSnooze = false };
 
             return true;
         }

--- a/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Desktop.Windows/ViewModel/ViewModelBuilder.cs
@@ -76,7 +76,7 @@ internal static class ViewModelBuilder
 
             return true;
         }
-        else if ( settings.Kind == ToastNotificationKinds.Exception.Name )
+        else if ( settings.Kind == ToastNotificationKinds.ExceptionReport.Name )
         {
             // Open the worker review page (formatted report + Report button + per-category auto-report checkbox)
             // instead of opening the raw report file. See #1674.

--- a/Metalama.Backstage/src/Metalama.Backstage.DotNetTool/ThrowCommand.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.DotNetTool/ThrowCommand.cs
@@ -4,12 +4,56 @@
 
 using JetBrains.Annotations;
 using Metalama.Backstage.Commands;
+using Metalama.Backstage.Extensibility;
 
 namespace Metalama.Backstage.DotNetTool;
 
+/// <summary>
+/// Throws an exception so that the exception-reporting pipeline can be exercised end to end: the report is captured, the
+/// review notification is shown, and the review page offers to send it, to report all future ones automatically, or
+/// never to report this particular error.
+/// </summary>
+/// <remarks>
+/// The exception is reported through the tooling policy, which requires the current directory to be inside a git
+/// repository. Use <c>--variant</c> to produce a distinct signature, e.g. to check that discarding one error does not
+/// silence the others. Since the same variant is only prompted once per hour, use <c>metalama telemetry reset-dedup</c>
+/// to be prompted again immediately.
+/// </remarks>
 [UsedImplicitly( ImplicitUseTargetFlags.WithMembers )]
-internal class ThrowCommand : BaseCommand<BaseCommandSettings>
+internal class ThrowCommand : BaseCommand<ThrowCommandSettings>
 {
-    protected override void Execute( ExtendedCommandContext context, BaseCommandSettings settings )
-        => throw new InvalidOperationException( "This exception is intentional." );
+    // The point of this command is to exercise exception reporting end to end, and the review notification is part of
+    // it. Other commands only add the user interface on demand (the hidden '--with-ui' flag); without it there is no
+    // IToastNotificationService, the report is captured silently and there is nothing to review. See #1751.
+    protected override BackstageInitializationOptions AddBackstageOptions( BackstageInitializationOptions options )
+        => options with { AddUserInterface = true };
+
+    protected override void Execute( ExtendedCommandContext context, ThrowCommandSettings settings )
+    {
+        // The signature of an issue is built from the exception type and its stack frames, so each variant must throw
+        // from a distinct method to be treated as a distinct issue.
+        switch ( settings.Variant )
+        {
+            case ThrowCommandVariant.B:
+                ThrowVariantB();
+
+                break;
+
+            case ThrowCommandVariant.C:
+                ThrowVariantC();
+
+                break;
+
+            default:
+                ThrowVariantA();
+
+                break;
+        }
+    }
+
+    private static void ThrowVariantA() => throw new InvalidOperationException( "This exception is intentional (variant A)." );
+
+    private static void ThrowVariantB() => throw new InvalidOperationException( "This exception is intentional (variant B)." );
+
+    private static void ThrowVariantC() => throw new InvalidOperationException( "This exception is intentional (variant C)." );
 }

--- a/Metalama.Backstage/src/Metalama.Backstage.DotNetTool/ThrowCommandSettings.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.DotNetTool/ThrowCommandSettings.cs
@@ -1,0 +1,29 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using Metalama.Backstage.Commands;
+using Spectre.Console.Cli;
+using System.ComponentModel;
+
+namespace Metalama.Backstage.DotNetTool;
+
+/// <summary>
+/// The distinct exceptions that <see cref="ThrowCommand"/> can throw. Each one is thrown from a different method, so
+/// each is a different issue as far as exception reporting is concerned.
+/// </summary>
+internal enum ThrowCommandVariant
+{
+    A,
+    B,
+    C
+}
+
+[UsedImplicitly( ImplicitUseTargetFlags.WithMembers )]
+internal class ThrowCommandSettings : BaseCommandSettings
+{
+    [Description( "The variant of the exception to throw. Each variant is reported as a distinct issue." )]
+    [CommandOption( "--variant" )]
+    public ThrowCommandVariant Variant { get; init; } = ThrowCommandVariant.A;
+}

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ExceptionReport.cshtml
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ExceptionReport.cshtml
@@ -6,6 +6,15 @@
     <h1>Report queued</h1>
     <p>Thank you. The report has been queued for upload and will help us improve Metalama.</p>
 }
+else if (Model.IsIgnored)
+{
+    <h1>Error ignored</h1>
+    <p>
+        This error will not be reported and you will not be asked about it again. Other errors will still be
+        reported to you for review. You can change how @Model.CategoryDisplayName are handled at any time on the
+        <a href="/Privacy">privacy options</a> page.
+    </p>
+}
 else if (!Model.HasReport)
 {
     <h1>Report unavailable</h1>
@@ -93,7 +102,9 @@ else
         }
         else
         {
-            @* The report is awaiting review: the Report button sends it and, if ticked, also enables auto-reporting. *@
+            @* The report is awaiting review. The three ways out are all one click away and all specific: send this one
+               (optionally enabling auto-reporting), or never report this particular error. There is deliberately no way
+               here to silence all error reports — that lives on the privacy page. See #1751. *@
             <form method="post" asp-page-handler="Report" class="report-actions">
                 <input type="hidden" asp-for="Report"/>
 
@@ -106,6 +117,8 @@ else
                 </div>
 
                 <div class="navigation-buttons">
+                    <button type="submit" asp-page-handler="Ignore" class="discard-button">Never report this error
+                    </button>
                     <div class="continue-button">
                         <button type="submit">Report</button>
                     </div>

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ExceptionReport.cshtml.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/Pages/ExceptionReport.cshtml.cs
@@ -59,6 +59,12 @@ internal class ExceptionReportPageModel : PageModel
     public bool IsReported { get; private set; }
 
     /// <summary>
+    /// Gets a value indicating whether the user has just asked never to report this particular issue. The page then
+    /// confirms the choice instead of showing the report again, which has been deleted. See #1751.
+    /// </summary>
+    public bool IsIgnored { get; private set; }
+
+    /// <summary>
     /// Gets a value indicating whether the report has already been sent (auto-reported, or sent on a previous review).
     /// The page then shows the report renderings for transparency but without offering the Report button again. See #1674.
     /// </summary>
@@ -101,6 +107,30 @@ internal class ExceptionReportPageModel : PageModel
             // Only report the report as queued if it was actually enqueued: SendReport can fail (e.g. the file was
             // removed). Keeping the report content set means the page still renders the report rather than a blank form.
             this.IsReported = this._exceptionReporter.SendReport( this.Report! );
+        }
+
+        return this.Page();
+    }
+
+    /// <summary>
+    /// Records that this particular issue must never be reported. The user is not prompted about it again, while other
+    /// issues keep prompting normally. See #1751.
+    /// </summary>
+    public IActionResult OnPostIgnore()
+    {
+        if ( !string.IsNullOrEmpty( this.Report ) && this._exceptionReporter.TryGetReport( this.Report!, out var capturedReport ) )
+        {
+            this.Scenario = capturedReport.Category;
+            this.IsIgnored = this._exceptionReporter.IgnoreReport( this.Report! );
+
+            if ( !this.IsIgnored )
+            {
+                // Ignoring failed (e.g. the report was removed in the meantime), so keep rendering the report rather
+                // than an empty form.
+                this.ScrubbedContent = capturedReport.ScrubbedContent;
+                this.LocalContent = capturedReport.LocalContent;
+                this.IsAlreadySent = capturedReport.IsQueued;
+            }
         }
 
         return this.Page();

--- a/Metalama.Backstage/src/Metalama.Backstage.Worker/wwwroot/css/site.css
+++ b/Metalama.Backstage/src/Metalama.Backstage.Worker/wwwroot/css/site.css
@@ -362,3 +362,14 @@ body:has(.exception-report) {
   margin-top: 10px;
   flex: 0 0 auto; /* keep the checkbox and Report button at their natural height, always visible */
 }
+
+/* "Never report this error" is a real button and a peer of Report, not a de-emphasised link: it is one of the three
+   ways out of the review, and the user must be able to find it. It is only toned down in colour so that Report stays
+   the primary action. See #1751. */
+.exception-report .discard-button {
+  background-color: #5a5a66;
+}
+
+.exception-report .discard-button:hover {
+  background-color: #6d6d7a;
+}

--- a/Metalama.Backstage/src/Metalama.Backstage/Extensibility/BackstageServicesInitializer.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Extensibility/BackstageServicesInitializer.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Infrastructure;
 using Metalama.Backstage.Telemetry;
 using System;
@@ -29,6 +30,9 @@ internal sealed class BackstageServicesInitializer : IBackstageService
 
     public void Initialize()
     {
+        // Before anything is enqueued, so that a background task that fails is reported instead of vanishing. See #1765.
+        this._backgroundTasksService.SetLogger( this._serviceProvider.GetLoggerFactory().GetLogger( "BackgroundTasks" ) );
+
         this._profilingService?.Initialize();
         this._telemetryConfigurationService?.Initialize();
         this._shutdownService?.Initialize();

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
@@ -47,9 +47,16 @@ public sealed class BackstageBackgroundTasksService : IBackstageService
     }
 
     /// <summary>
-    /// Prevents new tasks to be enqueued and awaits for the completion of previously enqueued tasks. 
+    /// Prevents new tasks to be enqueued and awaits for the completion of previously enqueued tasks.
     /// </summary>
-    internal Task CompleteAsync()
+    /// <remarks>
+    /// A short-lived process must await this before it exits, otherwise a task that has been enqueued but has not
+    /// started yet is killed. <see cref="ShutdownService"/> does it on <c>ProcessExit</c>, but a process that acts on a
+    /// user gesture and then exits immediately should await it explicitly rather than rely on the shutdown handler
+    /// having time to run. Calling it more than once is harmless. See #1751.
+    /// </remarks>
+    [PublicAPI]
+    public Task CompleteAsync()
     {
         lock ( this._lock )
         {

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
@@ -101,7 +101,7 @@ public sealed class BackstageBackgroundTasksService : IBackstageService
             // telemetry upload does exactly that, since the enqueued StartUpload itself enqueues the start of the
             // upload process. Refusing it silently lost the nested task, because the exception is thrown inside a task
             // nobody observes, so the upload process was never started and the queue was never uploaded. Completion
-            // waits for the nested task as well, since it is counted here before the outer one completes. See #1751.
+            // waits for the nested task as well, since it is counted here before the outer one completes. See #1764.
             if ( !this._canEnqueue && this._pendingTasks == 0 )
             {
                 throw new InvalidOperationException(

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
@@ -97,9 +97,15 @@ public sealed class BackstageBackgroundTasksService : IBackstageService
     {
         lock ( this._lock )
         {
-            if ( !this._canEnqueue )
+            // A task that is still running may legitimately enqueue another one while completion is under way: the
+            // telemetry upload does exactly that, since the enqueued StartUpload itself enqueues the start of the
+            // upload process. Refusing it silently lost the nested task, because the exception is thrown inside a task
+            // nobody observes, so the upload process was never started and the queue was never uploaded. Completion
+            // waits for the nested task as well, since it is counted here before the outer one completes. See #1751.
+            if ( !this._canEnqueue && this._pendingTasks == 0 )
             {
-                throw new InvalidOperationException();
+                throw new InvalidOperationException(
+                    $"Cannot enqueue a background task after {nameof(this.CompleteAsync)} has completed." );
             }
 
             this._pendingTasks++;

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/BackstageBackgroundTasksService.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using JetBrains.Annotations;
+using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using System;
 using System.Collections.Generic;
@@ -24,6 +25,17 @@ public sealed class BackstageBackgroundTasksService : IBackstageService
 
     private int _pendingTasks;
     private bool _canEnqueue = true;
+    private volatile ILogger? _logger;
+
+    /// <summary>
+    /// Sets the logger used to report the faults of background tasks. Called once the services are built, because this
+    /// service exists before them, and because <see cref="Default"/> is a process-wide singleton.
+    /// </summary>
+    /// <remarks>
+    /// Faults enqueued before the logger is set are still observed, but cannot be reported anywhere. In practice that
+    /// window is the construction of the service provider, during which nothing is enqueued yet.
+    /// </remarks>
+    internal void SetLogger( ILogger logger ) => this._logger = logger;
 
     /// <summary>
     /// Gets the default instance, which is intentionally shared in the process.
@@ -112,9 +124,17 @@ public sealed class BackstageBackgroundTasksService : IBackstageService
         }
     }
 
-    // ReSharper disable once UnusedParameter.Local
-    private void OnTaskCompleted( Task t )
+    private void OnTaskCompleted( Task task )
     {
+        if ( task.IsFaulted )
+        {
+            // Nothing ever awaits an enqueued task: every caller discards the returned task, and this continuation is
+            // the only thing that observes the antecedent. So this is the one place where the failure of a background
+            // task can be reported at all. Without it the exception disappears entirely, which is how the telemetry
+            // upload managed to be dead for a year without a single log line. See #1765.
+            this._logger.LogException( task.Exception!, "A background task failed" );
+        }
+
         IEnumerable<TaskCompletionSource<bool>> waiters;
         bool canEnqueue;
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/ITestSynchronizationProvider.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/ITestSynchronizationProvider.cs
@@ -1,0 +1,30 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Extensibility;
+using System.Threading;
+
+namespace Metalama.Backstage.Infrastructure;
+
+/// <summary>
+/// Provides synchronization points, so that a test can drive concurrent code into a specific interleaving instead of
+/// hoping for it. This service is never registered in production, so a sync point is a null check there.
+/// </summary>
+/// <remarks>
+/// This mirrors the service of the same name in <c>Metalama.Framework.DesignTime.Rpc</c>, which cannot be referenced
+/// from here. Add a sync point only where a race is otherwise not reproducible: each one is production code that exists
+/// for a test, so it must be justified by a defect that escaped review. See #1764.
+/// </remarks>
+internal interface ITestSynchronizationProvider : IBackstageService
+{
+    /// <summary>
+    /// Called by the code under test. Signals that the sync point was reached and blocks until the test releases it.
+    /// Does nothing when the test has not enabled this particular sync point.
+    /// </summary>
+    /// <param name="syncPointName">
+    /// A unique name identifying this sync point, in the form <c>{ClassName}.{Member}:{Location}</c>.
+    /// </param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    void SyncPoint( string syncPointName, CancellationToken cancellationToken = default );
+}

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
@@ -232,26 +232,30 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
 
         this.SetIssueStatus( ParseHash( this._fileSystem.ReadAllText( fullPath ) ), ReportingStatus.Ignored );
 
-        // The user asked never to report this issue, so there is nothing left to review: delete the local renderings. A
-        // report that is already in the upload queue is left alone, because it has already been sent.
-        if ( !isQueued )
-        {
-            this.DeleteReportFiles( reportFileName, fullPath );
-        }
+        // The user asked never to report this issue, so there is nothing left to review. The full local rendering always
+        // lives under the exceptions directory and is always deleted. The scrubbed report is deleted too, unless it is
+        // already in the upload queue: there it is on its way out, and deleting it would only break the upload.
+        this.DeleteReportFiles( reportFileName, isQueued ? null : fullPath );
 
         return true;
     }
 
     /// <summary>
-    /// Deletes a captured report and its full local rendering. Best-effort: failing to delete a review artefact must not
-    /// turn the user's decision into an error, because the decision itself has already been recorded.
+    /// Deletes the full local rendering of a report, and the scrubbed report itself when <paramref name="scrubbedReportPath"/>
+    /// is given. Best-effort: failing to delete a review artefact must not turn the user's decision into an error,
+    /// because the decision itself has already been recorded.
     /// </summary>
-    private void DeleteReportFiles( string reportFileName, string scrubbedReportPath )
+    private void DeleteReportFiles( string reportFileName, string? scrubbedReportPath )
     {
         var localRenderingPath = Path.Combine( this._directories.TelemetryExceptionsDirectory, GetLocalRenderingFileName( reportFileName ) );
 
         foreach ( var path in new[] { scrubbedReportPath, localRenderingPath } )
         {
+            if ( path == null )
+            {
+                continue;
+            }
+
             try
             {
                 if ( this._fileSystem.FileExists( path ) )

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
@@ -582,8 +582,6 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
             // exist). Activation is lazy so that a process which never reports never creates a device identifier. See #1701.
             this._telemetryConfigurationService.EnsureActivated();
 
-            this._logger.Trace?.Log( $"Capturing the exception report." );
-
             adapter ??= DefaultExceptionAdapter.Instance;
             var applicationInfo = this._applicationInfoProvider.CurrentApplication;
 
@@ -603,6 +601,10 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
             {
                 return;
             }
+
+            // Logged only once the issue has passed the check, so that the trace of a suppressed issue does not claim a
+            // report was captured.
+            this._logger.Trace?.Log( $"Capturing the exception report." );
 
             // Create the exception report file.
             var directory = this._directories.TelemetryExceptionsDirectory;

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
@@ -285,7 +285,7 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
         // path itself. The category is stored inside the report, so it is not passed here. See #1674.
         this._toastNotificationService.Show(
             new ToastNotification(
-                ToastNotificationKinds.Exception,
+                ToastNotificationKinds.ExceptionReport,
                 Text: $"The process {applicationName} encountered an unexpected {category}. {callToAction}",
                 Uri: reportFileName ) );
     }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/ExceptionReporter.cs
@@ -11,10 +11,12 @@ using Metalama.Backstage.UserInterface.Toasts;
 using Metalama.Backstage.Utilities;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
+using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Xml;
@@ -155,21 +157,32 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
     // Reads the self-contained <Category> element from a captured report. Defaults to Exception if absent or unparsable.
     private static TelemetryScenario ParseCategory( string reportContent )
     {
-        try
-        {
-            var category = XDocument.Parse( reportContent ).Root?.Element( "Category" )?.Value;
+        var category = ParseElement( reportContent, "Category" );
 
-            if ( !string.IsNullOrEmpty( category ) && Enum.TryParse<TelemetryScenario>( category, out var scenario ) )
-            {
-                return scenario;
-            }
-        }
-        catch ( XmlException )
+        if ( !string.IsNullOrEmpty( category ) && Enum.TryParse<TelemetryScenario>( category, out var scenario ) )
         {
-            // Fall through to the default.
+            return scenario;
         }
 
         return TelemetryScenario.Exception;
+    }
+
+    /// <summary>
+    /// Reads the invariant hash of the issue from a captured report, so that a decision taken on the report (sent, or
+    /// never report) can be recorded against the issue. Returns <c>null</c> if the report cannot be parsed.
+    /// </summary>
+    private static string? ParseHash( string reportContent ) => ParseElement( reportContent, "InvariantHash" );
+
+    private static string? ParseElement( string reportContent, string elementName )
+    {
+        try
+        {
+            return XDocument.Parse( reportContent ).Root?.Element( elementName )?.Value;
+        }
+        catch ( XmlException )
+        {
+            return null;
+        }
     }
 
     public bool SendReport( string reportFileName )
@@ -192,12 +205,65 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
 
         this._logger.Trace?.Log( $"Sending the exception report '{reportFileName}' upon user request." );
 
+        var hash = ParseHash( this._fileSystem.ReadAllText( fullPath ) );
+
         this._uploadManager.EnqueueFile( fullPath );
+
+        // The issue reaches its terminal 'Reported' state only now, when the report is actually on its way. Recording it
+        // at capture time would silence the issue even though nothing had been sent. See #1751.
+        this.SetIssueStatus( hash, ReportingStatus.Reported );
 
         // Force the upload now: the user explicitly asked to send this report, so we bypass the once-per-day throttling.
         this._serviceProvider.GetBackstageService<ITelemetryUploader>()?.StartUpload( force: true );
 
         return true;
+    }
+
+    public bool IgnoreReport( string reportFileName )
+    {
+        if ( !this.TryResolveReportPath( reportFileName, out var fullPath, out var isQueued ) )
+        {
+            this._logger.Warning?.Log( $"Cannot ignore the exception report '{reportFileName}' because it does not exist." );
+
+            return false;
+        }
+
+        this._logger.Trace?.Log( $"Ignoring the exception report '{reportFileName}' upon user request." );
+
+        this.SetIssueStatus( ParseHash( this._fileSystem.ReadAllText( fullPath ) ), ReportingStatus.Ignored );
+
+        // The user asked never to report this issue, so there is nothing left to review: delete the local renderings. A
+        // report that is already in the upload queue is left alone, because it has already been sent.
+        if ( !isQueued )
+        {
+            this.DeleteReportFiles( reportFileName, fullPath );
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Deletes a captured report and its full local rendering. Best-effort: failing to delete a review artefact must not
+    /// turn the user's decision into an error, because the decision itself has already been recorded.
+    /// </summary>
+    private void DeleteReportFiles( string reportFileName, string scrubbedReportPath )
+    {
+        var localRenderingPath = Path.Combine( this._directories.TelemetryExceptionsDirectory, GetLocalRenderingFileName( reportFileName ) );
+
+        foreach ( var path in new[] { scrubbedReportPath, localRenderingPath } )
+        {
+            try
+            {
+                if ( this._fileSystem.FileExists( path ) )
+                {
+                    this._fileSystem.DeleteFile( path );
+                }
+            }
+            catch ( Exception e )
+            {
+                this._logger.Warning?.Log( $"Cannot delete the exception report '{path}': {e.Message}" );
+            }
+        }
     }
 
     private void ShowToastNotification( string reportFileName, TelemetryScenario scenario, string applicationName, bool autoSent )
@@ -332,6 +398,28 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
         return HashUtilities.HashToString( signature.ToString().Normalize() );
     }
 
+    /// <summary>
+    /// The period after which an issue on which the user has taken no decision is captured again and the review
+    /// notification shown again.
+    /// </summary>
+    /// <remarks>
+    /// The review notification is the only way to approve a report, and it is easily missed (the user may be away from
+    /// the keyboard, or may dismiss it). Asking only once therefore silenced the issue forever. We instead keep asking,
+    /// at this interval, until the user sends the report, enables automatic reporting, or asks never to report this
+    /// particular issue. See #1751.
+    /// </remarks>
+    internal static readonly TimeSpan PromptRetryPeriod = TimeSpan.FromHours( 1 );
+
+    /// <summary>
+    /// Determines whether the issue identified by <paramref name="hash"/> should be captured and the user prompted to
+    /// review the report, and records the prompt when it should. Returns <c>false</c> when a decision has already been
+    /// taken on the issue (it was sent, or the user asked never to report it) and when the user was already prompted
+    /// less than <see cref="PromptRetryPeriod"/> ago.
+    /// </summary>
+    /// <remarks>
+    /// Capturing an issue no longer marks it as reported: <see cref="ReportingStatus.Reported"/> is written by
+    /// <see cref="SendReport"/>, when the report is actually on its way. See #1751.
+    /// </remarks>
     public bool ShouldReportIssue( string hash )
     {
         if ( !this._applicationInfoProvider.CurrentApplication.ShouldCreateLocalCrashReports )
@@ -342,32 +430,86 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
             return false;
         }
 
-        if ( this._configurationManager.Get<TelemetryConfiguration>().Issues.TryGetValue( hash, out var currentStatus )
-             && currentStatus is ReportingStatus.Ignored or ReportingStatus.Reported )
-        {
-            this._logger.Trace?.Log( $"The issue {hash} should not be reported because its status is {currentStatus}." );
+        var now = this._time.UtcNow;
 
+        if ( !this.ShouldPromptForIssue( this._configurationManager.Get<TelemetryConfiguration>(), hash, now, logReason: true ) )
+        {
             return false;
         }
 
         return this._configurationManager.UpdateIf<TelemetryConfiguration>(
-            c =>
-            {
-                if ( c.Issues.TryGetValue( hash, out var raceStatus ) && raceStatus is ReportingStatus.Ignored or ReportingStatus.Reported )
-                {
-                    this._logger.Trace?.Log( $"The issue {hash} should not be reported because another process is reporting it." );
-
-                    return false;
-                }
-
-                return true;
-            },
+            c => this.ShouldPromptForIssue( c, hash, now, logReason: false ),
             c =>
             {
                 this._logger.Trace?.Log( $"The issue {hash} should be reported." );
 
-                return c with { Issues = c.Issues.SetItem( hash, ReportingStatus.Reported ) };
+                return c with { IssuePrompts = PruneIssuePrompts( c.IssuePrompts, now ).SetItem( hash, now ) };
             } );
+    }
+
+    /// <summary>
+    /// Determines, against the given <paramref name="configuration"/>, whether the user should be prompted about the
+    /// issue identified by <paramref name="hash"/>. Evaluated twice: once optimistically, then again inside the
+    /// optimistic-concurrency update, where a concurrent process may have prompted in the meantime.
+    /// </summary>
+    private bool ShouldPromptForIssue( TelemetryConfiguration configuration, string hash, DateTime now, bool logReason )
+    {
+        if ( configuration.Issues.TryGetValue( hash, out var status ) && status is ReportingStatus.Ignored or ReportingStatus.Reported )
+        {
+            if ( logReason )
+            {
+                this._logger.Trace?.Log( $"The issue {hash} should not be reported because its status is {status}." );
+            }
+
+            return false;
+        }
+
+        if ( configuration.IssuePrompts.TryGetValue( hash, out var lastPrompt ) && lastPrompt + PromptRetryPeriod > now )
+        {
+            if ( logReason )
+            {
+                this._logger.Trace?.Log(
+                    $"The issue {hash} should not be reported because the user was already prompted on {lastPrompt} and has not decided yet." );
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /// <summary>
+    /// Removes the prompts that are older than <see cref="PromptRetryPeriod"/>, i.e. those that no longer withhold a new
+    /// prompt, so that the dictionary does not grow with the issues seen over the lifetime of the installation.
+    /// </summary>
+    private static ImmutableDictionary<string, DateTime> PruneIssuePrompts( ImmutableDictionary<string, DateTime> prompts, DateTime now )
+    {
+        // A prompt no longer withholds a new one once 'PromptRetryPeriod' has elapsed, so it carries no information.
+        var threshold = now - PromptRetryPeriod;
+        var expired = prompts.Where( p => p.Value <= threshold ).Select( p => p.Key ).ToArray();
+
+        return expired.Length == 0 ? prompts : prompts.RemoveRange( expired );
+    }
+
+    /// <summary>
+    /// Records the terminal decision taken on an issue and drops its pending prompt, so the issue is never asked about
+    /// again (until a new version of the product changes its hash).
+    /// </summary>
+    private void SetIssueStatus( string? hash, ReportingStatus status )
+    {
+        if ( string.IsNullOrEmpty( hash ) )
+        {
+            // The hash is read back from the report being acted on. A report we cannot parse can still be sent or
+            // discarded; we simply cannot remember the decision, so the issue may be asked about again.
+            this._logger.Warning?.Log( $"Cannot record the '{status}' status of an exception report whose hash cannot be read." );
+
+            return;
+        }
+
+        this._logger.Trace?.Log( $"Setting the status of the issue {hash} to {status}." );
+
+        this._configurationManager.Update<TelemetryConfiguration>(
+            c => c with { Issues = c.Issues.SetItem( hash!, status ), IssuePrompts = c.IssuePrompts.Remove( hash! ) } );
     }
 
     private static void PopulateStackTraces( List<string?> stackTraces, Exception exception, IExceptionAdapter adapter )
@@ -466,7 +608,10 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
                 this._fileSystem.CreateDirectory( directory );
             }
 
-            var baseName = "exception-" + hash + "-" + Guid.NewGuid();
+            // The pending report is keyed by the issue hash alone. The same issue is captured again every time the user
+            // is prompted anew (see PromptRetryPeriod), so a per-occurrence name would accumulate one report per hour
+            // and leave the review page sending an arbitrary one of them. Re-capturing overwrites instead. See #1751.
+            var baseName = "exception-" + hash;
             var fileName = Path.Combine( directory, baseName + ".xml" );
 
             // The scrubbed report is the exact payload that would be uploaded.
@@ -501,6 +646,10 @@ internal sealed class ExceptionReporter : IExceptionReportManager, IExceptionCap
                 this._logger.Trace?.Log( $"Auto-sending the exception report because the category is set to '{TelemetryConsent.Yes}'." );
 
                 this._uploadManager.EnqueueFile( fileName );
+
+                // The report is on its way, so the issue reaches its terminal 'Reported' state right away and is never
+                // captured again. Only a review-first capture stays pending and is therefore prompted again. See #1751.
+                this.SetIssueStatus( hash, ReportingStatus.Reported );
             }
             else
             {

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/IExceptionReportManager.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/IExceptionReportManager.cs
@@ -32,4 +32,16 @@ public interface IExceptionReportManager : IBackstageService
     /// (including the full <c>.local.xml</c> rendering, which must never be uploaded) or the report does not exist. See #1674.
     /// </summary>
     bool SendReport( string reportFileName );
+
+    /// <summary>
+    /// Records that the issue described by the report identified by <paramref name="reportFileName"/> must never be
+    /// reported, and deletes the locally-captured renderings. The user is not prompted about that issue again, while
+    /// other issues keep prompting normally. Returns <c>false</c> if the name is invalid or the report does not exist.
+    /// </summary>
+    /// <remarks>
+    /// This is the per-issue counterpart of the notification's former Mute button, which disabled every error-report
+    /// notification on the machine, silently and irreversibly. The only way to stop error reporting altogether is now
+    /// the privacy page, where the setting is visible and reversible. See #1751.
+    /// </remarks>
+    bool IgnoreReport( string reportFileName );
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/IExceptionReportManager.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/IExceptionReportManager.cs
@@ -35,8 +35,10 @@ public interface IExceptionReportManager : IBackstageService
 
     /// <summary>
     /// Records that the issue described by the report identified by <paramref name="reportFileName"/> must never be
-    /// reported, and deletes the locally-captured renderings. The user is not prompted about that issue again, while
-    /// other issues keep prompting normally. Returns <c>false</c> if the name is invalid or the report does not exist.
+    /// reported, and deletes what remains to be reviewed: always the full local rendering, and the scrubbed report
+    /// itself unless it is already in the upload queue, where it is on its way out. The user is not prompted about that
+    /// issue again, while other issues keep prompting normally. Returns <c>false</c> if the name is invalid or the
+    /// report does not exist.
     /// </summary>
     /// <remarks>
     /// This is the per-issue counterpart of the notification's former Mute button, which disabled every error-report

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfiguration.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfiguration.cs
@@ -87,8 +87,11 @@ public sealed record TelemetryConfiguration : ConfigurationFile
     /// See #1751.
     /// </remarks>
     [JsonConverter( typeof(CaseInsensitiveImmutableDictionaryConverterFactory<ReportingStatus>) )]
-    public ImmutableDictionary<string, ReportingStatus> Issues { get; init; } =
-        ImmutableDictionary<string, ReportingStatus>.Empty.WithComparers( StringComparer.OrdinalIgnoreCase );
+    public ImmutableDictionary<string, ReportingStatus> Issues
+    {
+        get => this._issues;
+        init => this._issues = value ?? _emptyIssues;
+    }
 
     /// <summary>
     /// Gets the UTC time at which the user was last prompted to review the report of an issue, keyed by its invariant
@@ -101,12 +104,32 @@ public sealed record TelemetryConfiguration : ConfigurationFile
     /// issues. See #1751.
     /// </remarks>
     [JsonConverter( typeof(CaseInsensitiveImmutableDictionaryConverterFactory<DateTime>) )]
-    public ImmutableDictionary<string, DateTime> IssuePrompts { get; init; } =
-        ImmutableDictionary<string, DateTime>.Empty.WithComparers( StringComparer.OrdinalIgnoreCase );
+    public ImmutableDictionary<string, DateTime> IssuePrompts
+    {
+        get => this._issuePrompts;
+        init => this._issuePrompts = value ?? _emptyDates;
+    }
 
     [JsonConverter( typeof(CaseInsensitiveImmutableDictionaryConverterFactory<DateTime>) )]
-    public ImmutableDictionary<string, DateTime> Sessions { get; init; } =
+    public ImmutableDictionary<string, DateTime> Sessions
+    {
+        get => this._sessions;
+        init => this._sessions = value ?? _emptyDates;
+    }
+
+    // A property that is absent from the JSON file deserializes to null rather than to its initializer, so every
+    // dictionary normalizes null in its 'init' accessor (which 'with' expressions also go through). Without this, a
+    // configuration file written before one of these properties existed - or one the user edited through
+    // 'metalama config edit telemetry' - makes the consumers throw a NullReferenceException. See #1751.
+    private static readonly ImmutableDictionary<string, ReportingStatus> _emptyIssues =
+        ImmutableDictionary<string, ReportingStatus>.Empty.WithComparers( StringComparer.OrdinalIgnoreCase );
+
+    private static readonly ImmutableDictionary<string, DateTime> _emptyDates =
         ImmutableDictionary<string, DateTime>.Empty.WithComparers( StringComparer.OrdinalIgnoreCase );
+
+    private readonly ImmutableDictionary<string, ReportingStatus> _issues = _emptyIssues;
+    private readonly ImmutableDictionary<string, DateTime> _issuePrompts = _emptyDates;
+    private readonly ImmutableDictionary<string, DateTime> _sessions = _emptyDates;
 
     public DateTime? LastMatomoPostTime { get; init; }
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfiguration.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfiguration.cs
@@ -76,9 +76,33 @@ public sealed record TelemetryConfiguration : ConfigurationFile
     /// </summary>
     public DateTime? LastSaltChangeTime { get; init; }
 
+    /// <summary>
+    /// Gets the terminal decision taken for an issue, keyed by its invariant hash: <see cref="ReportingStatus.Reported"/>
+    /// once the report has actually been sent, and <see cref="ReportingStatus.Ignored"/> once the user has asked never to
+    /// report that issue. An issue on which no decision has been taken yet is absent.
+    /// </summary>
+    /// <remarks>
+    /// Only decisions are recorded here. Merely capturing a report does not add an entry, otherwise an issue the user
+    /// never approved would be silenced forever. The state of the pending question lives in <see cref="IssuePrompts"/>.
+    /// See #1751.
+    /// </remarks>
     [JsonConverter( typeof(CaseInsensitiveImmutableDictionaryConverterFactory<ReportingStatus>) )]
     public ImmutableDictionary<string, ReportingStatus> Issues { get; init; } =
         ImmutableDictionary<string, ReportingStatus>.Empty.WithComparers( StringComparer.OrdinalIgnoreCase );
+
+    /// <summary>
+    /// Gets the UTC time at which the user was last prompted to review the report of an issue, keyed by its invariant
+    /// hash. An issue on which no decision has been taken yet is prompted again once the retry period has elapsed.
+    /// </summary>
+    /// <remarks>
+    /// The review notification is the only way to approve a report, so a notification the user missed or dismissed must
+    /// not silence the issue forever: the question is asked again the next time the issue occurs. Entries older than the
+    /// retry period are pruned as they are written, so this dictionary only ever holds the very recently prompted
+    /// issues. See #1751.
+    /// </remarks>
+    [JsonConverter( typeof(CaseInsensitiveImmutableDictionaryConverterFactory<DateTime>) )]
+    public ImmutableDictionary<string, DateTime> IssuePrompts { get; init; } =
+        ImmutableDictionary<string, DateTime>.Empty.WithComparers( StringComparer.OrdinalIgnoreCase );
 
     [JsonConverter( typeof(CaseInsensitiveImmutableDictionaryConverterFactory<DateTime>) )]
     public ImmutableDictionary<string, DateTime> Sessions { get; init; } =

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryConfigurationService.cs
@@ -399,7 +399,11 @@ internal sealed class TelemetryConfigurationService : ITelemetryConfigurationSer
             } );
     }
 
-    public void ResetReportedIssues() => this._configurationManager.Update<TelemetryConfiguration>( c => c with { Issues = c.Issues.Clear() } );
+    // Clears both the decisions taken on issues and the record of the questions already asked, so that every issue is
+    // captured and prompted again on its next occurrence. Forgetting the prompts here would leave an issue silent for up
+    // to an hour after a reset, which defeats the purpose of the command. See #1751.
+    public void ResetReportedIssues()
+        => this._configurationManager.Update<TelemetryConfiguration>( c => c with { Issues = c.Issues.Clear(), IssuePrompts = c.IssuePrompts.Clear() } );
 
     // Returns a cryptographically-secure salt.
     private long NextSalt() => this._randomNumberGenerator.NextCryptographicInt64();

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
@@ -280,22 +280,32 @@ namespace Metalama.Backstage.Telemetry
             this._logger.Trace?.Log( "Acquiring mutex." );
 
             // Claiming the upload by writing LastUploadTime is what stops two processes from uploading at the same time,
-            // so it has to happen before the upload is started rather than after. It is therefore optimistic, and is
-            // released below if the upload turns out not to start at all.
-            var previousUploadTime = this._configurationManager.Get<TelemetryConfiguration>().LastUploadTime;
+            // so it has to happen before the upload is started rather than after. The claim is therefore optimistic and
+            // is released below if the upload turns out not to start at all.
+            DateTime? previousUploadTime = null;
 
             if ( !this._configurationManager.UpdateIf<TelemetryConfiguration>(
                     c => force ||
                          c.LastUploadTime == null ||
                          c.LastUploadTime.Value.AddDays( 1 ) < now,
-                    c => c with { LastUploadTime = this._time.UtcNow } ) )
+                    c =>
+                    {
+                        // Captured here, and not from a separate read, because the update is re-evaluated whenever
+                        // another process writes the file first: this is the only place where the value we are about to
+                        // replace is the value we actually replace. Releasing the wrong one would hand the day to a
+                        // process that never uploaded.
+                        previousUploadTime = c.LastUploadTime;
+
+                        // 'now', not a second reading of the clock: the value we claim with must be the one the
+                        // condition was evaluated against, and must be known here so that the release below can tell
+                        // our own claim from somebody else's.
+                        return c with { LastUploadTime = now };
+                    } ) )
             {
                 this._logger.Trace?.Log( $"It's not time to upload the telemetry yet." );
 
                 return false;
             }
-
-            var claimedUploadTime = this._configurationManager.Get<TelemetryConfiguration>().LastUploadTime;
 
             // This method usually runs as a background task itself, because BackstageServicesInitializer enqueues it, so
             // the enqueue below is a nested one. It used to be refused when the process started shutting down in
@@ -304,7 +314,7 @@ namespace Metalama.Backstage.Telemetry
             // than hope for that interleaving. See #1764.
             this._testSynchronizationProvider?.SyncPoint( BeforeEnqueueUploadSyncPoint );
 
-            this._backgroundTasksService.Enqueue( () => this.StartUploadProcess( toolExecutor, previousUploadTime, claimedUploadTime ) );
+            this._backgroundTasksService.Enqueue( () => this.StartUploadProcess( toolExecutor, previousUploadTime, claimedUploadTime: now ) );
 
             return true;
         }
@@ -319,7 +329,7 @@ namespace Metalama.Backstage.Telemetry
         /// silence uploads until the next day. The failure was also entirely silent, because this runs in a task nobody
         /// observes. See #1764.
         /// </remarks>
-        private void StartUploadProcess( IBackstageToolsExecutor toolExecutor, DateTime? previousUploadTime, DateTime? claimedUploadTime )
+        private void StartUploadProcess( IBackstageToolsExecutor toolExecutor, DateTime? previousUploadTime, DateTime claimedUploadTime )
         {
             try
             {
@@ -329,8 +339,8 @@ namespace Metalama.Backstage.Telemetry
             {
                 this._logger.LogException( e, "Cannot start the telemetry upload process" );
 
-                // Only release our own claim: another process may have claimed the upload in the meantime, and its
-                // claim must stand.
+                // Release the claim only while it is still ours: another process may have claimed the upload since, and
+                // that claim must stand.
                 this._configurationManager.UpdateIf<TelemetryConfiguration>(
                     c => c.LastUploadTime == claimedUploadTime,
                     c => c with { LastUploadTime = previousUploadTime } );

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
@@ -279,6 +279,11 @@ namespace Metalama.Backstage.Telemetry
 
             this._logger.Trace?.Log( "Acquiring mutex." );
 
+            // Claiming the upload by writing LastUploadTime is what stops two processes from uploading at the same time,
+            // so it has to happen before the upload is started rather than after. It is therefore optimistic, and is
+            // released below if the upload turns out not to start at all.
+            var previousUploadTime = this._configurationManager.Get<TelemetryConfiguration>().LastUploadTime;
+
             if ( !this._configurationManager.UpdateIf<TelemetryConfiguration>(
                     c => force ||
                          c.LastUploadTime == null ||
@@ -290,6 +295,8 @@ namespace Metalama.Backstage.Telemetry
                 return false;
             }
 
+            var claimedUploadTime = this._configurationManager.Get<TelemetryConfiguration>().LastUploadTime;
+
             // This method usually runs as a background task itself, because BackstageServicesInitializer enqueues it, so
             // the enqueue below is a nested one. It used to be refused when the process started shutting down in
             // between, and since the resulting exception was raised in a task nobody observes, the upload process was
@@ -297,9 +304,37 @@ namespace Metalama.Backstage.Telemetry
             // than hope for that interleaving. See #1764.
             this._testSynchronizationProvider?.SyncPoint( BeforeEnqueueUploadSyncPoint );
 
-            this._backgroundTasksService.Enqueue( () => toolExecutor.Start( BackstageTool.Worker, "upload" ) );
+            this._backgroundTasksService.Enqueue( () => this.StartUploadProcess( toolExecutor, previousUploadTime, claimedUploadTime ) );
 
             return true;
+        }
+
+        /// <summary>
+        /// Starts the process that performs the upload, and releases the claim made by <see cref="StartUpload"/> if it
+        /// cannot be started.
+        /// </summary>
+        /// <remarks>
+        /// Without the release, a start that fails (for instance because the tools have not been extracted) would still
+        /// consume the once-a-day upload budget for the whole machine, so a single unlucky process in the morning would
+        /// silence uploads until the next day. The failure was also entirely silent, because this runs in a task nobody
+        /// observes. See #1764.
+        /// </remarks>
+        private void StartUploadProcess( IBackstageToolsExecutor toolExecutor, DateTime? previousUploadTime, DateTime? claimedUploadTime )
+        {
+            try
+            {
+                toolExecutor.Start( BackstageTool.Worker, "upload" );
+            }
+            catch ( Exception e )
+            {
+                this._logger.LogException( e, "Cannot start the telemetry upload process" );
+
+                // Only release our own claim: another process may have claimed the upload in the meantime, and its
+                // claim must stand.
+                this._configurationManager.UpdateIf<TelemetryConfiguration>(
+                    c => c.LastUploadTime == claimedUploadTime,
+                    c => c with { LastUploadTime = previousUploadTime } );
+            }
         }
 
         private static string ComputeHash( string packageName )

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
@@ -39,6 +39,13 @@ namespace Metalama.Backstage.Telemetry
         private readonly TelemetryLogger _telemetryLogger;
         private readonly BackstageBackgroundTasksService _backgroundTasksService;
         private readonly RandomNumberGenerator _randomNumberGenerator;
+        private readonly ITestSynchronizationProvider? _testSynchronizationProvider;
+
+        /// <summary>
+        /// The sync point reached by <see cref="StartUpload"/> after it has claimed the upload but before it enqueues
+        /// the start of the upload process. See #1764.
+        /// </summary>
+        internal const string BeforeEnqueueUploadSyncPoint = "TelemetryUploader.StartUpload:BeforeEnqueue";
 
         public TelemetryUploader( IServiceProvider serviceProvider )
         {
@@ -53,6 +60,9 @@ namespace Metalama.Backstage.Telemetry
             this._telemetryLogger = serviceProvider.GetRequiredBackstageService<TelemetryLogger>();
             this._backgroundTasksService = serviceProvider.GetRequiredBackstageService<BackstageBackgroundTasksService>();
             this._randomNumberGenerator = serviceProvider.GetRequiredBackstageService<RandomNumberGenerator>();
+
+            // Never registered in production, so this stays null there.
+            this._testSynchronizationProvider = serviceProvider.GetBackstageService<ITestSynchronizationProvider>();
         }
 
         private static void CopyStream( Stream inputStream, Stream outputStream )
@@ -279,6 +289,13 @@ namespace Metalama.Backstage.Telemetry
 
                 return false;
             }
+
+            // This method usually runs as a background task itself, because BackstageServicesInitializer enqueues it, so
+            // the enqueue below is a nested one. It used to be refused when the process started shutting down in
+            // between, and since the resulting exception was raised in a task nobody observes, the upload process was
+            // simply never started. The sync point lets a test hold us exactly here while it begins shutdown, rather
+            // than hope for that interleaving. See #1764.
+            this._testSynchronizationProvider?.SyncPoint( BeforeEnqueueUploadSyncPoint );
 
             this._backgroundTasksService.Enqueue( () => toolExecutor.Start( BackstageTool.Worker, "upload" ) );
 

--- a/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Telemetry/TelemetryUploader.cs
@@ -302,7 +302,11 @@ namespace Metalama.Backstage.Telemetry
                         return c with { LastUploadTime = now };
                     } ) )
             {
-                this._logger.Trace?.Log( $"It's not time to upload the telemetry yet." );
+                // UpdateIf tells us that this call did not perform the transition, but not why: the throttle may not
+                // have elapsed, another process may have claimed the upload, or the write may have run out of
+                // contention retries (which UpdateIf logs as an error of its own). Claiming a single one of those in
+                // the message sends whoever reads the trace after it, as it did in #1764.
+                this._logger.Trace?.Log( "Not uploading the telemetry now: it is not time yet, or another process has claimed the upload." );
 
                 return false;
             }

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKind.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKind.cs
@@ -23,4 +23,17 @@ public sealed record ToastNotificationKind( string Name )
     /// (e.g. a required license, which fails the build, or an exception) are not throttled. The default is <c>false</c>.
     /// </summary>
     internal bool IsThrottled { get; init; }
+
+    /// <summary>
+    /// Gets a value indicating whether this kind of notification can be muted, i.e. disabled for good. The default is
+    /// <c>true</c>.
+    /// </summary>
+    /// <remarks>
+    /// Muting is permanent and cannot be undone from the product, so it is unacceptable for a notification that is the
+    /// only way to take an action, such as approving an exception report. Such a kind sets this to <c>false</c>: the
+    /// notification offers no Mute button, <see cref="IToastNotificationStatusService.Mute"/> is a no-op, and a mute
+    /// stored by an earlier version is ignored, so users who muted before the button was removed start seeing the
+    /// notification again. See #1751.
+    /// </remarks>
+    internal bool CanBeMuted { get; init; } = true;
 }

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKinds.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKinds.cs
@@ -25,8 +25,15 @@ public static class ToastNotificationKinds
     public static ToastNotificationKind LicenseExpiring { get; } =
         new( nameof(LicenseExpiring) ) { AutoSnoozePeriod = TimeSpan.FromDays( 1 ), ManualSnoozePeriod = TimeSpan.FromDays( 3 ) };
 
+    // The exception notification is the only way to approve an error report, so it cannot be muted: muting it silenced
+    // error reporting altogether, permanently and with no way back from the product. The review page offers the
+    // per-issue equivalent ("never report this error") and the privacy page remains the visible, reversible way to turn
+    // the whole channel off. See #1751.
     public static ToastNotificationKind Exception { get; } =
-        new( nameof(Exception) ) { AutoSnoozePeriod = TimeSpan.FromSeconds( 5 ), ManualSnoozePeriod = TimeSpan.FromHours( 1 ) };
+        new( nameof(Exception) )
+        {
+            AutoSnoozePeriod = TimeSpan.FromSeconds( 5 ), ManualSnoozePeriod = TimeSpan.FromHours( 1 ), CanBeMuted = false
+        };
 
     // Auto-snooze for RSS news is redundant because we are checking once per day anyway. Setting this to zero eases testing through the `rss notify` CLI command.
     public static ToastNotificationKind News { get; } = new( nameof(News) ) { AutoSnoozePeriod = TimeSpan.Zero };

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKinds.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationKinds.cs
@@ -25,12 +25,24 @@ public static class ToastNotificationKinds
     public static ToastNotificationKind LicenseExpiring { get; } =
         new( nameof(LicenseExpiring) ) { AutoSnoozePeriod = TimeSpan.FromDays( 1 ), ManualSnoozePeriod = TimeSpan.FromDays( 3 ) };
 
-    // The exception notification is the only way to approve an error report, so it cannot be muted: muting it silenced
-    // error reporting altogether, permanently and with no way back from the product. The review page offers the
-    // per-issue equivalent ("never report this error") and the privacy page remains the visible, reversible way to turn
-    // the whole channel off. See #1751.
-    public static ToastNotificationKind Exception { get; } =
-        new( nameof(Exception) )
+    /// <summary>
+    /// The review notification for exception and performance reports.
+    /// </summary>
+    /// <remarks>
+    /// This notification is the only way to approve an error report, so it cannot be muted: muting it silenced error
+    /// reporting altogether, permanently and with no way back from the product. The review page offers the per-issue
+    /// equivalent ("never report this error") and the privacy page remains the visible, reversible way to turn the whole
+    /// channel off.
+    /// <para>
+    /// The kind was renamed from <c>Exception</c> to <c>ExceptionReport</c> in 2026.1.22. Per-kind state in
+    /// <c>toastNotifications.json</c> is keyed by this name, so the rename discards whatever was stored under the old
+    /// name: users who muted the notification while earlier versions still offered a Mute button start seeing it again,
+    /// instead of staying silenced for good. <see cref="ToastNotificationKind.CanBeMuted"/> then keeps it that way.
+    /// See #1751.
+    /// </para>
+    /// </remarks>
+    public static ToastNotificationKind ExceptionReport { get; } =
+        new( nameof(ExceptionReport) )
         {
             AutoSnoozePeriod = TimeSpan.FromSeconds( 5 ), ManualSnoozePeriod = TimeSpan.FromHours( 1 ), CanBeMuted = false
         };
@@ -43,7 +55,7 @@ public static class ToastNotificationKinds
 
     // Must be last.
     public static ImmutableDictionary<string, ToastNotificationKind> All { get; } =
-        new[] { RequiresLicense, VsxNotInstalled, SubscriptionExpiring, TrialExpiring, LicenseExpiring, Exception, News, TelemetryNotice }
+        new[] { RequiresLicense, VsxNotInstalled, SubscriptionExpiring, TrialExpiring, LicenseExpiring, ExceptionReport, News, TelemetryNotice }
             .ToImmutableDictionary(
                 i => i.Name,
                 i => i );

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationStatusService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationStatusService.cs
@@ -43,6 +43,15 @@ public sealed class ToastNotificationStatusService : IToastNotificationStatusSer
 
         if ( kindConfiguration.Disabled )
         {
+            // A kind that cannot be muted ignores a stored mute. Such a mute can only have been written by a version
+            // that still offered the Mute button, and it would otherwise keep the notification silenced for good. See #1751.
+            if ( !kind.CanBeMuted )
+            {
+                this._logger.Trace?.Log( $"The notification kind {kind.Name} is marked as disabled, but this kind cannot be muted." );
+
+                return true;
+            }
+
             this._logger.Trace?.Log( $"The notification kind {kind.Name} is disabled." );
 
             return false;

--- a/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationStatusService.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/UserInterface/Toasts/ToastNotificationStatusService.cs
@@ -100,13 +100,22 @@ public sealed class ToastNotificationStatusService : IToastNotificationStatusSer
             } );
 
     public void Mute( ToastNotificationKind kind )
-        => this._configurationManager.Update<ToastNotificationsConfiguration>(
+    {
+        if ( !kind.CanBeMuted )
+        {
+            this._logger.Trace?.Log( $"The notification kind {kind.Name} cannot be muted." );
+
+            return;
+        }
+
+        this._configurationManager.Update<ToastNotificationsConfiguration>(
             config => config with
             {
                 Notifications = config.Notifications.SetItem(
                     kind.Name,
                     new ToastNotificationConfiguration { Disabled = true } )
             } );
+    }
 
     public IDisposable PauseAll( TimeSpan timeSpan )
     {

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestProcessExecutor.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestProcessExecutor.cs
@@ -15,8 +15,19 @@ public class TestProcessExecutor : IProcessExecutor
 {
     public List<ProcessStartInfo> StartedProcesses { get; } = [];
 
+    /// <summary>
+    /// Gets or sets an exception thrown instead of starting the process, so that a test can exercise what happens when
+    /// a process cannot be started, e.g. because the tools have not been extracted.
+    /// </summary>
+    public Exception? ExceptionToThrow { get; set; }
+
     public IProcess Start( ProcessStartInfo startInfo )
     {
+        if ( this.ExceptionToThrow != null )
+        {
+            throw this.ExceptionToThrow;
+        }
+
         this.StartedProcesses.Add( startInfo );
 
         return new TestProcess();

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestSynchronizationProvider.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Testing/TestSynchronizationProvider.cs
@@ -1,0 +1,109 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using Metalama.Backstage.Infrastructure;
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Testing;
+
+/// <summary>
+/// Lets a test hold the code under test at a named point while it does something else, so that a race can be driven
+/// into one specific interleaving instead of being waited for.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A sync point only blocks when the test has enabled it, so the many sync points a test does not care about cost
+/// nothing. The usual sequence is: enable the sync point, start the operation on another thread, wait until it is
+/// reached, do whatever the test needs to happen in the middle, then release.
+/// </para>
+/// <para>
+/// Dispose (or <see cref="ReleaseAll"/>) releases everything, so a failing assertion does not turn into a hanging test.
+/// </para>
+/// </remarks>
+[PublicAPI]
+public sealed class TestSynchronizationProvider : ITestSynchronizationProvider, IDisposable
+{
+    private readonly ConcurrentDictionary<string, SyncPoint> _syncPoints = new( StringComparer.Ordinal );
+    private readonly ITestOutputHelper? _testOutput;
+
+    public TestSynchronizationProvider( ITestOutputHelper? testOutput = null )
+    {
+        this._testOutput = testOutput;
+    }
+
+    private void Log( string message ) => this._testOutput?.WriteLine( $"TestSynchronizationProvider: {message}" );
+
+    void ITestSynchronizationProvider.SyncPoint( string syncPointName, CancellationToken cancellationToken )
+    {
+        if ( !this._syncPoints.TryGetValue( syncPointName, out var syncPoint ) )
+        {
+            // Nobody is waiting for this one, so it is not a sync point in this test.
+            return;
+        }
+
+        this.Log( $"'{syncPointName}' reached, waiting for release." );
+        syncPoint.ReachedSignal.Release();
+        syncPoint.ReleaseSignal.Wait( cancellationToken );
+        this.Log( $"'{syncPointName}' released." );
+    }
+
+    /// <summary>
+    /// Enables a sync point, so that the code under test blocks when it reaches it. Must be called before the operation
+    /// that reaches it is started.
+    /// </summary>
+    public void EnableSyncPoint( string syncPointName )
+    {
+        this.Log( $"'{syncPointName}' enabled." );
+        _ = this._syncPoints.GetOrAdd( syncPointName, _ => new SyncPoint() );
+    }
+
+    /// <summary>
+    /// Waits until the code under test reaches the named sync point, enabling it if necessary.
+    /// </summary>
+    public async Task WaitForSyncPointReachedAsync( string syncPointName, CancellationToken cancellationToken = default )
+    {
+        var syncPoint = this._syncPoints.GetOrAdd( syncPointName, _ => new SyncPoint() );
+        await syncPoint.ReachedSignal.WaitAsync( cancellationToken );
+        this.Log( $"'{syncPointName}' observed as reached." );
+    }
+
+    /// <summary>
+    /// Releases the code blocked at the named sync point.
+    /// </summary>
+    public void ReleaseSyncPoint( string syncPointName )
+    {
+        this.Log( $"'{syncPointName}' releasing." );
+
+        if ( this._syncPoints.TryGetValue( syncPointName, out var syncPoint ) )
+        {
+            syncPoint.ReleaseSignal.Release();
+        }
+    }
+
+    /// <summary>
+    /// Releases every sync point, so that a failed test cannot leave a thread blocked for ever.
+    /// </summary>
+    public void ReleaseAll()
+    {
+        foreach ( var syncPoint in this._syncPoints.Values )
+        {
+            // Several threads may be waiting on the same sync point.
+            syncPoint.ReleaseSignal.Release( 16 );
+        }
+    }
+
+    public void Dispose() => this.ReleaseAll();
+
+    private sealed class SyncPoint
+    {
+        public SemaphoreSlim ReachedSignal { get; } = new( 0, int.MaxValue );
+
+        public SemaphoreSlim ReleaseSignal { get; } = new( 0, int.MaxValue );
+    }
+}

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/BackstageBackgroundTasksServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/BackstageBackgroundTasksServiceTests.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Backstage.Infrastructure;
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
@@ -58,5 +59,45 @@ public sealed class BackstageBackgroundTasksServiceTests
         await service.WhenNoPendingTaskAsync();
 
         Assert.Equal( n * m, completedTasks );
+    }
+
+    [Fact]
+    public async Task NestedEnqueueDuringCompletionIsNotLost()
+    {
+        // #1751: a background task that enqueues another one is exactly what the telemetry upload does. The services
+        // initializer enqueues StartUpload, and StartUpload enqueues the start of the upload process. If completion
+        // refuses that nested enqueue, the upload process is never started and the queue is never uploaded.
+        var service = new BackstageBackgroundTasksService();
+
+        var outerStarted = new TaskCompletionSource<bool>();
+        var releaseOuter = new TaskCompletionSource<bool>();
+        var nestedRan = 0;
+        Exception? nestedEnqueueException = null;
+
+        _ = service.Enqueue(
+            async () =>
+            {
+                outerStarted.SetResult( true );
+                await releaseOuter.Task;
+
+                try
+                {
+                    await service.Enqueue( () => Interlocked.Increment( ref nestedRan ) );
+                }
+                catch ( Exception e )
+                {
+                    nestedEnqueueException = e;
+                }
+            } );
+
+        // Start completing while the outer task is still running, exactly as the shutdown handler does.
+        await outerStarted.Task;
+        var completion = service.CompleteAsync();
+        releaseOuter.SetResult( true );
+
+        await completion;
+
+        Assert.Null( nestedEnqueueException );
+        Assert.Equal( 1, nestedRan );
     }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/BackstageBackgroundTasksServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/BackstageBackgroundTasksServiceTests.cs
@@ -3,15 +3,25 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Backstage.Infrastructure;
+using Metalama.Backstage.Testing;
+using Metalama.Backstage.Utilities;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
 using Xunit;
+using Xunit.Abstractions;
 
 namespace Metalama.Backstage.Tests.Infrastructure;
 
 public sealed class BackstageBackgroundTasksServiceTests
 {
+    private readonly ITestOutputHelper _testOutput;
+
+    public BackstageBackgroundTasksServiceTests( ITestOutputHelper testOutput )
+    {
+        this._testOutput = testOutput;
+    }
+
     [Fact]
     public async Task LoadTest()
     {
@@ -99,5 +109,31 @@ public sealed class BackstageBackgroundTasksServiceTests
 
         Assert.Null( nestedEnqueueException );
         Assert.Equal( 1, nestedRan );
+    }
+
+    [Fact]
+    public async Task FaultOfABackgroundTaskIsReported()
+    {
+        // #1765: nothing awaits an enqueued task, so a task that throws used to fail in complete silence. That is how
+        // the telemetry upload managed to be dead for a year without a single log line.
+        var loggerFactory = new TestLoggerFactory( this._testOutput );
+        var service = new BackstageBackgroundTasksService();
+        service.SetLogger( loggerFactory.GetLogger( "BackgroundTasks" ) );
+
+        await service.Enqueue( () => throw new InvalidOperationException( "Simulated background task failure." ) );
+        await service.WhenNoPendingTaskAsync();
+
+        Assert.Contains( loggerFactory.Entries, e => e.Message.ContainsOrdinal( "Simulated background task failure." ) );
+    }
+
+    [Fact]
+    public async Task FaultOfABackgroundTaskDoesNotBreakCompletion()
+    {
+        // A failing task must still count as completed, otherwise a process would wait for it for ever on shutdown.
+        var service = new BackstageBackgroundTasksService();
+
+        await service.Enqueue( () => throw new InvalidOperationException( "Simulated background task failure." ) );
+
+        await service.CompleteAsync();
     }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/BackstageBackgroundTasksServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/BackstageBackgroundTasksServiceTests.cs
@@ -4,7 +4,6 @@
 
 using Metalama.Backstage.Infrastructure;
 using Metalama.Backstage.Testing;
-using Metalama.Backstage.Utilities;
 using System;
 using System.Threading;
 using System.Threading.Tasks;

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
@@ -70,6 +70,44 @@ public sealed class ConfigurationFileSerializationTests : JsonSerializationTests
     }
 
     [Fact]
+    public void TelemetryConfiguration_WithoutIssuePrompts_DeserializesToEmptyDictionary()
+    {
+        // #1751: 'IssuePrompts' was added in 2026.1.22, so every telemetry.json written by an earlier version omits it.
+        // Deserializing such a file must yield an empty dictionary rather than null, otherwise the first exception
+        // captured after an upgrade throws a NullReferenceException inside the exception reporter itself.
+        const string json = """
+                            {
+                              "Issues": {
+                                "ISSUE001": 1
+                              }
+                            }
+                            """;
+
+        var configuration = JsonSerializer.Deserialize<TelemetryConfiguration>( json, this.JsonOptions )!;
+
+        Assert.NotNull( configuration.IssuePrompts );
+        Assert.Empty( configuration.IssuePrompts );
+        Assert.Equal( ReportingStatus.Reported, configuration.Issues["ISSUE001"] );
+
+        // The same applies to every dictionary of the record: 'metalama config edit telemetry' lets the user remove any
+        // of them, and a file written before a property existed simply does not have it.
+        var empty = JsonSerializer.Deserialize<TelemetryConfiguration>( "{}", this.JsonOptions )!;
+
+        Assert.Empty( empty.Issues );
+        Assert.Empty( empty.IssuePrompts );
+        Assert.Empty( empty.Sessions );
+
+        // Explicit nulls must be normalized too.
+        var nulls = JsonSerializer.Deserialize<TelemetryConfiguration>(
+            """{ "Issues": null, "IssuePrompts": null, "Sessions": null }""",
+            this.JsonOptions )!;
+
+        Assert.Empty( nulls.Issues );
+        Assert.Empty( nulls.IssuePrompts );
+        Assert.Empty( nulls.Sessions );
+    }
+
+    [Fact]
     public void TelemetryConfiguration_WithIssuesAndSessions_Serialization()
     {
         // Note: Dictionary ordering is not guaranteed, so we test round-trip consistency

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Serialization/ConfigurationFileSerializationTests.cs
@@ -54,6 +54,7 @@ public sealed class ConfigurationFileSerializationTests : JsonSerializationTests
                                       "LicenseAuditSalt": null,
                                       "LastSaltChangeTime": "2025-01-01T00:00:00Z",
                                       "Issues": {},
+                                      "IssuePrompts": {},
                                       "Sessions": {},
                                       "LastMatomoPostTime": "2025-01-10T12:00:00Z",
                                       "RetentionPeriodInDays": null,
@@ -78,6 +79,8 @@ public sealed class ConfigurationFileSerializationTests : JsonSerializationTests
             ExceptionConsent = TelemetryConsent.Default,
             Issues = ImmutableDictionary<string, ReportingStatus>.Empty
                 .Add( "ISSUE001", ReportingStatus.Reported ),
+            IssuePrompts = ImmutableDictionary<string, DateTime>.Empty
+                .Add( "ISSUE002", new DateTime( 2025, 1, 15, 9, 0, 0, DateTimeKind.Utc ) ),
             Sessions = ImmutableDictionary<string, DateTime>.Empty
                 .Add( "session1", new DateTime( 2025, 1, 15, 10, 0, 0, DateTimeKind.Utc ) )
         };
@@ -96,6 +99,9 @@ public sealed class ConfigurationFileSerializationTests : JsonSerializationTests
                                       "LastSaltChangeTime": null,
                                       "Issues": {
                                         "ISSUE001": 1
+                                      },
+                                      "IssuePrompts": {
+                                        "ISSUE002": "2025-01-15T09:00:00Z"
                                       },
                                       "Sessions": {
                                         "session1": "2025-01-15T10:00:00Z"

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
@@ -277,7 +277,7 @@ public sealed class ReportExceptionTests : TestsBase
         this.RecordException( kind: exceptionReportingKind );
 
         var toast = Assert.Single( this.UserInterface.Notifications );
-        Assert.Equal( ToastNotificationKinds.Exception.Name, toast.Kind.Name );
+        Assert.Equal( ToastNotificationKinds.ExceptionReport.Name, toast.Kind.Name );
         Assert.NotNull( toast.Uri );
         Assert.StartsWith( "exception-", toast.Uri, StringComparison.Ordinal );
         Assert.EndsWith( ".xml", toast.Uri, StringComparison.Ordinal );

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
@@ -11,6 +11,7 @@ using Metalama.Backstage.UserInterface.Toasts;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Net;
@@ -426,6 +427,116 @@ public sealed class ReportExceptionTests : TestsBase
         this.RecordException( exception );
         this.RecordException( exception );
         this.AssertFilesCount( 1 );
+    }
+
+    private ImmutableDictionary<string, ReportingStatus> GetIssues() => this.ConfigurationManager!.Get<TelemetryConfiguration>().Issues;
+
+    [Fact]
+    public void ReviewFirstCaptureDoesNotDecideOnTheIssue()
+    {
+        // #1751: capturing a report is not a decision. Recording the issue as 'Reported' at capture time (as we used to)
+        // silenced it forever even though nothing had been sent, which is why no exception report ever reached us.
+        this.ConfigureExceptionReporting( ExceptionReportingKind.Exception, TelemetryConsent.Default );
+        this.RecordException();
+
+        Assert.Empty( this.GetIssues() );
+    }
+
+    [Fact]
+    public void ReviewFirstIssueIsPromptedAgainAfterTheRetryPeriod()
+    {
+        // #1751: the review notification is the only way to approve a report, so an ignored notification must not
+        // silence the issue. The same issue is captured and prompted again once the retry period has elapsed.
+        this.ConfigureExceptionReporting( ExceptionReportingKind.Exception, TelemetryConsent.Default );
+
+        var exception = new TestException( "Test", "Test" );
+
+        this.RecordException( exception );
+        Assert.Single( this.UserInterface.Notifications );
+
+        // Within the retry period the user is not asked again: the pending report is still there to be reviewed.
+        this.Time.AddTime( ExceptionReporter.PromptRetryPeriod - TimeSpan.FromMinutes( 1 ) );
+        this.RecordException( exception );
+        Assert.Single( this.UserInterface.Notifications );
+
+        // Past the retry period the question is asked again.
+        this.Time.AddTime( TimeSpan.FromMinutes( 2 ) );
+        this.RecordException( exception );
+        Assert.Equal( 2, this.UserInterface.Notifications.Count );
+
+        // The pending report was overwritten rather than duplicated, so 'Report' cannot send an arbitrary one of
+        // several copies and the directory does not grow by one report per hour.
+        this.AssertFilesCount( 1 );
+    }
+
+    [Fact]
+    public void SendReportDecidesOnTheIssueAndStopsPrompting()
+    {
+        this.ConfigureExceptionReporting( ExceptionReportingKind.Exception, TelemetryConsent.Default );
+
+        var exception = new TestException( "Test", "Test" );
+        this.RecordException( exception );
+
+        var reporter = new ExceptionReporter( new TelemetryQueue( this.ServiceProvider ), this.ServiceProvider );
+        Assert.True( reporter.SendReport( Path.GetFileName( this.GetScrubbedReportFile() ) ) );
+
+        // Sending is the decision, so it is now (and only now) that the issue is recorded as reported.
+        Assert.Equal( ReportingStatus.Reported, Assert.Single( this.GetIssues() ).Value );
+
+        // The user is not asked about it again, even long after the retry period.
+        this.Time.AddTime( ExceptionReporter.PromptRetryPeriod + TimeSpan.FromMinutes( 1 ) );
+        this.RecordException( exception );
+
+        Assert.Single( this.UserInterface.Notifications );
+        this.AssertFilesCount( 1 );
+    }
+
+    [Fact]
+    public void AutoSentIssueIsNotCapturedAgain()
+    {
+        // An auto-sent report is on its way at capture time, so the issue is decided immediately. Without this, the
+        // hourly retry would upload a duplicate of the same report every hour.
+        this.ConfigureExceptionReporting( ExceptionReportingKind.Exception, TelemetryConsent.Yes );
+
+        var exception = new TestException( "Test", "Test" );
+        this.RecordException( exception );
+
+        Assert.Equal( ReportingStatus.Reported, Assert.Single( this.GetIssues() ).Value );
+
+        this.Time.AddTime( ExceptionReporter.PromptRetryPeriod + TimeSpan.FromMinutes( 1 ) );
+        this.RecordException( exception );
+
+        Assert.Single( this.UserInterface.Notifications );
+        this.AssertFilesCount( 1 );
+    }
+
+    [Fact]
+    public void IgnoreReportStopsPromptingForThatIssueOnly()
+    {
+        // #1751: "never report this error" is the per-issue replacement for the notification's Mute button, which used
+        // to disable every error-report notification on the machine.
+        this.ConfigureExceptionReporting( ExceptionReportingKind.Exception, TelemetryConsent.Default );
+
+        var ignoredException = new TestException( "Ignored", CreateStackFrame( "Ignored", 1 ) );
+        this.RecordException( ignoredException );
+
+        var reporter = new ExceptionReporter( new TelemetryQueue( this.ServiceProvider ), this.ServiceProvider );
+        Assert.True( reporter.IgnoreReport( Path.GetFileName( this.GetScrubbedReportFile() ) ) );
+
+        Assert.Equal( ReportingStatus.Ignored, Assert.Single( this.GetIssues() ).Value );
+
+        // There is nothing left to review, so both renderings are gone and nothing can be uploaded.
+        this.AssertFilesCount( 0 );
+        Assert.DoesNotContain( this.FileSystem.Mock.AllFiles, f => f.EndsWith( ".xml", StringComparison.Ordinal ) );
+
+        // The issue is never asked about again...
+        this.Time.AddTime( ExceptionReporter.PromptRetryPeriod + TimeSpan.FromMinutes( 1 ) );
+        this.RecordException( ignoredException );
+        Assert.Single( this.UserInterface.Notifications );
+
+        // ...but every other issue keeps prompting normally.
+        this.RecordException( new TestException( "Other", CreateStackFrame( "Other", 2 ) ) );
+        Assert.Equal( 2, this.UserInterface.Notifications.Count );
     }
 
     [Fact]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
@@ -540,6 +540,30 @@ public sealed class ReportExceptionTests : TestsBase
     }
 
     [Fact]
+    public void IgnoreReportDeletesTheLocalRenderingOfAnAlreadyQueuedReport()
+    {
+        // Copilot review: ignoring a report that is already in the upload queue must still delete the full local
+        // rendering, which is never enqueued and would otherwise sit under the exceptions directory until the retention
+        // sweep. The queued scrubbed report itself is left alone: it is on its way out, and deleting it would only break
+        // the upload.
+        this.ConfigureExceptionReporting( ExceptionReportingKind.Exception, TelemetryConsent.Yes );
+        this.RecordException();
+
+        var enqueued = this.GetScrubbedReportFile();
+        Assert.Contains( Path.Combine( "Telemetry", "UploadQueue" ), enqueued, StringComparison.Ordinal );
+        Assert.Contains( this.FileSystem.Mock.AllFiles, f => f.EndsWith( ".local.xml", StringComparison.Ordinal ) );
+
+        var reporter = new ExceptionReporter( new TelemetryQueue( this.ServiceProvider ), this.ServiceProvider );
+        Assert.True( reporter.IgnoreReport( Path.GetFileName( enqueued ) ) );
+
+        Assert.Equal( ReportingStatus.Ignored, Assert.Single( this.GetIssues() ).Value );
+        Assert.DoesNotContain( this.FileSystem.Mock.AllFiles, f => f.EndsWith( ".local.xml", StringComparison.Ordinal ) );
+
+        // The report that was already enqueued is still there and will still be uploaded.
+        Assert.Equal( enqueued, this.GetScrubbedReportFile() );
+    }
+
+    [Fact]
     public void AllExceptionsWithDistinctStackTraceOfInnerExceptionAreReportedOnce()
     {
         var stackTrace1 = CreateStackFrame( "Method1", 1 );

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/ReportExceptionTests.cs
@@ -529,14 +529,21 @@ public sealed class ReportExceptionTests : TestsBase
         this.AssertFilesCount( 0 );
         Assert.DoesNotContain( this.FileSystem.Mock.AllFiles, f => f.EndsWith( ".xml", StringComparison.Ordinal ) );
 
-        // The issue is never asked about again...
-        this.Time.AddTime( ExceptionReporter.PromptRetryPeriod + TimeSpan.FromMinutes( 1 ) );
-        this.RecordException( ignoredException );
-        Assert.Single( this.UserInterface.Notifications );
+        // The issue is never captured nor notified about again, however often it recurs and however much time passes.
+        var notificationsBefore = this.UserInterface.Notifications.Count;
+
+        for ( var i = 0; i < 3; i++ )
+        {
+            this.Time.AddTime( ExceptionReporter.PromptRetryPeriod + TimeSpan.FromMinutes( 1 ) );
+            this.RecordException( ignoredException );
+        }
+
+        Assert.Equal( notificationsBefore, this.UserInterface.Notifications.Count );
+        this.AssertFilesCount( 0 );
 
         // ...but every other issue keeps prompting normally.
         this.RecordException( new TestException( "Other", CreateStackFrame( "Other", 2 ) ) );
-        Assert.Equal( 2, this.UserInterface.Notifications.Count );
+        Assert.Equal( notificationsBefore + 1, this.UserInterface.Notifications.Count );
     }
 
     [Fact]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
@@ -20,11 +20,15 @@ using Xunit.Abstractions;
 
 namespace Metalama.Backstage.Tests.Telemetry;
 
-public sealed class TelemetryUploaderTests : TestsBase
+public sealed class TelemetryUploaderTests : TestsBase, IDisposable
 {
     private const string _feedbackDirectory = @"C:\feedback";
 
     private readonly ITelemetryUploader _uploader;
+
+    // Registered for every test in this class. A sync point that no test has enabled does not block, so this is inert
+    // except in the test that drives the shutdown race. See #1764.
+    private readonly TestSynchronizationProvider _synchronizationProvider = new();
 
     public TelemetryUploaderTests( ITestOutputHelper logger ) : base( logger, new TestApplicationInfo() { IsTelemetryEnabled = true } )
     {
@@ -39,10 +43,16 @@ public sealed class TelemetryUploaderTests : TestsBase
         this.TelemetryConfigurationService.EnsureActivated();
     }
 
+    /// <summary>
+    /// Releases every sync point, so that a test that failed while the code under test was blocked cannot hang the run.
+    /// </summary>
+    public void Dispose() => this._synchronizationProvider.Dispose();
+
     protected override void ConfigureServices( ServiceProviderBuilder services )
     {
         services.AddTelemetryServices();
         services.AddTools();
+        services.AddSingleton<ITestSynchronizationProvider>( this._synchronizationProvider );
     }
 
     protected override void OnAfterServicesCreated( Services services )
@@ -197,5 +207,47 @@ public sealed class TelemetryUploaderTests : TestsBase
         Assert.False( this._uploader.StartUpload() );
 
         Assert.Empty( this.ProcessExecutor.StartedProcesses );
+    }
+
+    [Fact]
+    public async Task BackstageWorkerIsStartedWhenTheProcessShutsDownDuringStartUpload()
+    {
+        // #1764: reproduces the interleaving that stopped every telemetry upload. StartUpload normally runs as a
+        // background task (BackstageServicesInitializer enqueues it), and it enqueues the start of the upload process.
+        // When the process began shutting down between the two, that nested enqueue was refused, the exception was
+        // raised inside a task nobody observes, and the upload process was silently never started.
+        //
+        // The sync point makes the interleaving deterministic instead of relying on timing: we hold StartUpload just
+        // before it enqueues, begin the shutdown, and only then let it continue.
+        this.Time.AddTime( TimeSpan.FromMinutes( 20 ) );
+
+        this._synchronizationProvider.EnableSyncPoint( TelemetryUploader.BeforeEnqueueUploadSyncPoint );
+
+        var startUploadResult = false;
+
+        try
+        {
+            // Start the upload the way the initializer does: as a background task, so the enqueue inside it is nested.
+            var startUpload = this.BackgroundTasks.Enqueue( () => startUploadResult = this._uploader.StartUpload() );
+
+            await this._synchronizationProvider.WaitForSyncPointReachedAsync( TelemetryUploader.BeforeEnqueueUploadSyncPoint );
+
+            // The process starts shutting down while StartUpload is still running, exactly as ShutdownService does on
+            // ProcessExit. This must not prevent the upload process from being started.
+            var completion = this.BackgroundTasks.CompleteAsync();
+
+            this._synchronizationProvider.ReleaseSyncPoint( TelemetryUploader.BeforeEnqueueUploadSyncPoint );
+
+            await startUpload;
+            await completion;
+        }
+        finally
+        {
+            // Never leave a thread blocked on a sync point, however the assertions go.
+            this._synchronizationProvider.ReleaseAll();
+        }
+
+        Assert.True( startUploadResult );
+        Assert.Single( this.ProcessExecutor.StartedProcesses );
     }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Backstage.Configuration;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Infrastructure;
@@ -248,6 +249,35 @@ public sealed class TelemetryUploaderTests : TestsBase, IDisposable
         }
 
         Assert.True( startUploadResult );
+        Assert.Single( this.ProcessExecutor.StartedProcesses );
+    }
+
+    [Fact]
+    public async Task DailyUploadBudgetIsNotConsumedWhenTheUploadProcessCannotBeStarted()
+    {
+        // #1764: claiming the upload by writing LastUploadTime has to happen before the upload is started, otherwise two
+        // processes would upload at once. The claim is therefore optimistic, and a start that fails used to keep it:
+        // one unlucky process was then enough to silence uploads for the rest of the day, silently, because the failure
+        // happens in a task nobody observes.
+        this.Time.AddTime( TimeSpan.FromMinutes( 20 ) );
+
+        var uploadTimeBefore = this.ConfigurationManager!.Get<TelemetryConfiguration>().LastUploadTime;
+
+        this.ProcessExecutor.ExceptionToThrow = new IOException( "Simulated: the tools have not been extracted." );
+
+        Assert.True( this._uploader.StartUpload() );
+        await this.BackgroundTasks.WhenNoPendingTaskAsync();
+
+        // Nothing was started, so the claim must have been released rather than consume the day.
+        Assert.Empty( this.ProcessExecutor.StartedProcesses );
+        Assert.Equal( uploadTimeBefore, this.ConfigurationManager.Get<TelemetryConfiguration>().LastUploadTime );
+
+        // Which means the very next attempt may upload, instead of waiting until tomorrow.
+        this.ProcessExecutor.ExceptionToThrow = null;
+
+        Assert.True( this._uploader.StartUpload() );
+        await this.BackgroundTasks.WhenNoPendingTaskAsync();
+
         Assert.Single( this.ProcessExecutor.StartedProcesses );
     }
 }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
@@ -170,6 +170,10 @@ public sealed class TelemetryUploaderTests : TestsBase, IDisposable
         var expectedExecutedFileName = platformInfo.DotNetExePath;
 
         Assert.Equal( expectedExecutedFileName, this.ProcessExecutor.StartedProcesses[0].FileName );
+
+        // The upload is claimed with the very instant the throttle was evaluated against, not with a second reading of
+        // the clock. That is what lets the claim be released again by value if the upload cannot be started. See #1764.
+        Assert.Equal( this.Time.UtcNow, this.ConfigurationManager!.Get<TelemetryConfiguration>().LastUploadTime );
     }
 
     [Fact]

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Telemetry/TelemetryUploaderTests.cs
@@ -274,7 +274,7 @@ public sealed class TelemetryUploaderTests : TestsBase, IDisposable
 
         // Nothing was started, so the claim must have been released rather than consume the day.
         Assert.Empty( this.ProcessExecutor.StartedProcesses );
-        Assert.Equal( uploadTimeBefore, this.ConfigurationManager.Get<TelemetryConfiguration>().LastUploadTime );
+        Assert.Equal( uploadTimeBefore, this.ConfigurationManager!.Get<TelemetryConfiguration>().LastUploadTime );
 
         // Which means the very next attempt may upload, instead of waiting until tomorrow.
         this.ProcessExecutor.ExceptionToThrow = null;

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationStatusServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationStatusServiceTests.cs
@@ -47,6 +47,27 @@ public sealed class ToastNotificationStatusServiceTests : TestsBase
     }
 
     [Fact]
+    public void MuteStoredByAnEarlierVersionIsIgnoredForAKindThatCannotBeMuted()
+    {
+        // #1751: the exception notification is the only way to approve an error report, so it can no longer be muted.
+        // Versions up to 2026.1.21 offered a Mute button on it, and the mutes they stored would otherwise keep error
+        // reporting silenced for good on those machines.
+        Assert.False( ToastNotificationKinds.Exception.CanBeMuted );
+
+        this.ConfigurationManager!.Update<ToastNotificationsConfiguration>(
+            c => c with
+            {
+                Notifications = c.Notifications.SetItem( ToastNotificationKinds.Exception.Name, new ToastNotificationConfiguration { Disabled = true } )
+            } );
+
+        Assert.True( this._toastService.TryAcquire( ToastNotificationKinds.Exception ) );
+
+        // A kind that can be muted still honours a stored mute.
+        this._toastService.Mute( ToastNotificationKinds.LicenseExpiring );
+        Assert.False( this._toastService.TryAcquire( ToastNotificationKinds.LicenseExpiring ) );
+    }
+
+    [Fact]
     public void Snooze()
     {
         // Snooze before anything.

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationStatusServiceTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/UserInterface/ToastNotificationStatusServiceTests.cs
@@ -47,22 +47,32 @@ public sealed class ToastNotificationStatusServiceTests : TestsBase
     }
 
     [Fact]
-    public void MuteStoredByAnEarlierVersionIsIgnoredForAKindThatCannotBeMuted()
+    public void MuteStoredByAnEarlierVersionNoLongerSilencesErrorReports()
     {
-        // #1751: the exception notification is the only way to approve an error report, so it can no longer be muted.
-        // Versions up to 2026.1.21 offered a Mute button on it, and the mutes they stored would otherwise keep error
-        // reporting silenced for good on those machines.
-        Assert.False( ToastNotificationKinds.Exception.CanBeMuted );
+        // #1751: versions up to 2026.1.21 offered a Mute button on the error-report notification, which is the only way
+        // to approve a report. A mute stored by one of them would keep error reporting silenced for good, so the kind
+        // was renamed: per-kind state is keyed by the kind name, and the state stored under the old name no longer
+        // applies to the renamed kind.
+        Assert.Equal( "ExceptionReport", ToastNotificationKinds.ExceptionReport.Name );
 
         this.ConfigurationManager!.Update<ToastNotificationsConfiguration>(
-            c => c with
-            {
-                Notifications = c.Notifications.SetItem( ToastNotificationKinds.Exception.Name, new ToastNotificationConfiguration { Disabled = true } )
-            } );
+            c => c with { Notifications = c.Notifications.SetItem( "Exception", new ToastNotificationConfiguration { Disabled = true } ) } );
 
-        Assert.True( this._toastService.TryAcquire( ToastNotificationKinds.Exception ) );
+        Assert.True( this._toastService.TryAcquire( ToastNotificationKinds.ExceptionReport ) );
+    }
 
-        // A kind that can be muted still honours a stored mute.
+    [Fact]
+    public void MuteIsIgnoredForAKindThatCannotBeMuted()
+    {
+        // #1751: the rename above is a one-time migration. This is the invariant that keeps the notification alive
+        // afterwards: the kind cannot be muted at all, so a 'Disabled' flag written by any means (including a hand-edited
+        // toastNotifications.json) is ignored.
+        Assert.False( ToastNotificationKinds.ExceptionReport.CanBeMuted );
+
+        this._toastService.Mute( ToastNotificationKinds.ExceptionReport );
+        Assert.True( this._toastService.TryAcquire( ToastNotificationKinds.ExceptionReport ) );
+
+        // A kind that can be muted still honours a mute.
         this._toastService.Mute( ToastNotificationKinds.LicenseExpiring );
         Assert.False( this._toastService.TryAcquire( ToastNotificationKinds.LicenseExpiring ) );
     }

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/ExceptionReportPageModelTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Worker.Tests/ExceptionReportPageModelTests.cs
@@ -28,7 +28,11 @@ public sealed class ExceptionReportPageModelTests : TestsBase
 
         public string? SentReport { get; private set; }
 
+        public string? IgnoredReport { get; private set; }
+
         public bool SendReportResult { get; set; } = true;
+
+        public bool IgnoreReportResult { get; set; } = true;
 
         public bool TryGetReport( string reportFileName, [NotNullWhen( true )] out CapturedExceptionReport? report )
         {
@@ -43,6 +47,13 @@ public sealed class ExceptionReportPageModelTests : TestsBase
             this.SentReport = reportFileName;
 
             return this.SendReportResult;
+        }
+
+        public bool IgnoreReport( string reportFileName )
+        {
+            this.IgnoredReport = reportFileName;
+
+            return this.IgnoreReportResult;
         }
     }
 
@@ -217,6 +228,49 @@ public sealed class ExceptionReportPageModelTests : TestsBase
         Assert.False( model.IsReported );
 
         // The report content is still loaded, so the page re-renders the report rather than a blank form.
+        Assert.True( model.HasReport );
+    }
+
+    [Fact]
+    public void OnPostIgnoreIgnoresThatReportOnly()
+    {
+        // #1751: "Never report this error" is the per-issue replacement for the notification's former Mute button. It
+        // acts on this report alone and must not change the consent of the whole category.
+        var reporter = new FakeExceptionReportManager { ReportToReturn = new CapturedExceptionReport( "<r/>", null, TelemetryScenario.Exception ) };
+
+        var model = this.CreateModel( reporter );
+        model.Report = "exception-abc.xml";
+
+        model.OnPostIgnore();
+
+        Assert.Equal( "exception-abc.xml", reporter.IgnoredReport );
+        Assert.True( model.IsIgnored );
+
+        // The report is gone, so the page confirms the choice instead of rendering the report again.
+        Assert.False( model.HasReport );
+
+        // Every category keeps its consent: silencing the whole channel is the privacy page's job, not this button's.
+        Assert.Equal( TelemetryConsent.Default, this.GetConsent( TelemetryScenario.Exception ) );
+        Assert.Equal( TelemetryConsent.Default, this.GetConsent( TelemetryScenario.Performance ) );
+        Assert.Equal( TelemetryConsent.Default, this.GetConsent( TelemetryScenario.Usage ) );
+    }
+
+    [Fact]
+    public void OnPostIgnoreKeepsRenderingTheReportWhenIgnoringFails()
+    {
+        // Symmetrical to OnPostReportDoesNotShowQueuedWhenSendFails: if the report vanished in the meantime, the page
+        // must not claim the issue was ignored.
+        var reporter = new FakeExceptionReportManager
+        {
+            ReportToReturn = new CapturedExceptionReport( "<r/>", "<r local/>", TelemetryScenario.Exception ), IgnoreReportResult = false
+        };
+
+        var model = this.CreateModel( reporter );
+        model.Report = "exception-abc.xml";
+
+        model.OnPostIgnore();
+
+        Assert.False( model.IsIgnored );
         Assert.True( model.HasReport );
     }
 }


### PR DESCRIPTION
Fixes #1751.
Fixes #1764.
Fixes #1765.

Two independent defects had to be fixed before a single exception report could reach us, and they are worth reading separately.

**#1764 is the older and wider one: no telemetry was uploaded at all.** `BackstageBackgroundTasksService` refused any enqueue once `CompleteAsync()` had been called, and the upload enqueues in two nested levels (the services initializer enqueues `StartUpload`, which enqueues the start of the upload process). When the process began shutting down in between, the nested enqueue threw inside a task nobody observes, so the upload process was never started and nothing was ever sent. This suppressed usage and license-audit reports too, not only exception reports, and it dates from 2025.1.5 rather than 2026.1.18.

**#1751 is the one described below: reports were captured but never offered again.**


Since 2026.1.18 an exception report has been captured locally and offered for review through a toast notification. If the user missed or dismissed that notification, the issue was silenced permanently, and the notification's Mute button silenced every error report on the machine. The result was zero exception reports received.

The notification now keeps asking until the user actually decides, and every way of silencing it is per-issue rather than global.

## Behaviour

| | Before | After |
|---|---|---|
| Default consent | ask (`Default`) | unchanged, nothing is auto-sent |
| Repeat of the same issue | never prompted again | prompted again 1 h after the last prompt |
| Toast **Snooze** / **Mute** (all error reports) | present | removed, **on the error toast only** |
| Per-issue "never report" | none | new button on the review page |
| Turn off all error reports | Mute, hidden and irreversible | privacy page, visible and reversible |

The review page now offers three outcomes, all one click away: **Report**, **Report** with "automatically report all ..." ticked, and **Never report this error**.

## Changes

- `TelemetryConfiguration.IssuePrompts` (`hash -> DateTime`) records when the user was last asked, and is pruned as it is written so it only holds the last hour of prompts. `Issues` keeps only terminal decisions, so its existing JSON shape is untouched and old configuration files still parse.
- `ExceptionReporter.ShouldReportIssue` is now time-based (`PromptRetryPeriod`, 1 h) and no longer writes `ReportingStatus.Reported`. That status is written by `SendReport`, and by `Capture` when the category is set to auto-send, i.e. in both cases when the report is actually on its way. Without the latter, auto-send users would have uploaded a duplicate every hour.
- The pending report is named by issue hash alone and overwritten on re-capture, instead of accumulating one `.xml` + `.local.xml` pair per occurrence.
- `IExceptionReportManager.IgnoreReport` records `ReportingStatus.Ignored` and deletes the local renderings.
- `ViewModelBuilder`: `CanSnooze = false, CanMute = false` on the `Exception` branch only. Every other notification kind (license, trial, subscription, VSX) keeps both buttons, and `ToastNotificationStatusService` itself is unchanged.

No configuration migration: `ComputeExceptionHash` prepends `IApplicationInfo.PackageVersion`, so the stale `Reported` entries written by 2026.1.18-.21 stop matching as soon as this ships.

## Tests

`Metalama.Backstage.Tests` (1391 net8.0 / 1390 net472), `Metalama.Backstage.Worker.Tests` (37) and `Metalama.Backstage.Commands.Tests` (24) all pass. New coverage: capture takes no decision, re-prompt after the retry period but not within it, `SendReport` and auto-send decide the issue and stop the prompts, `IgnoreReport` stops prompts for that issue only and leaves other issues prompting, and the page-model orchestration of the new button.

## Also in this PR, for #1764

- `BackstageBackgroundTasksService.OnTaskStarting` refuses an enqueue only once completion has actually finished. A task that is still running may enqueue a nested one, and completion waits for that one too. The exception it throws now carries a message; the original threw a bare `InvalidOperationException`, which is part of why this stayed invisible.
- Claiming the upload by writing `LastUploadTime` has to happen before the upload starts, so the claim is now released when the upload process cannot be started. Otherwise one failed start consumed the once-a-day budget for the whole machine, silently.
- `ITestSynchronizationProvider` is added to `Metalama.Backstage`, mirroring the service of the same name in `Metalama.Framework.DesignTime.Rpc`, with one sync point in `TelemetryUploader.StartUpload`. It is never registered in production.
- Both defects have a test that was confirmed to fail before the fix: `BackstageWorkerIsStartedWhenTheProcessShutsDownDuringStartUpload` drives the shutdown interleaving through the sync point, and `DailyUploadBudgetIsNotConsumedWhenTheUploadProcessCannotBeStarted` covers the claim. `NestedEnqueueDuringCompletionIsNotLost` covers the same contract at the service level.

Verified end to end on a real installation: a queue of 58 files that had not moved in weeks went to 0, with the upload process appearing in the trace for the first time.

## Also in this PR, for #1765

A task enqueued on `BackstageBackgroundTasksService` that threw failed in complete silence: the continuation ignored its antecedent, every caller discards the returned task, and the exception was left to the unobserved-exception machinery, which nothing subscribes to. Nine fire-and-forget call sites were covered by that silence, including the license audit, the Matomo reports and the temp-file cleanup. It is also why #1764 could be dead for a year without a single log line.

`OnTaskCompleted` now reports the fault through an `ILogger` that `BackstageServicesInitializer` sets on the service once the services are built, and reading the exception marks it observed. `FaultOfABackgroundTaskIsReported` was confirmed to fail before the fix; `FaultOfABackgroundTaskDoesNotBreakCompletion` checks that a failing task still counts as completed, so shutdown cannot wait for it for ever.

## Follow-ups

- `Metalama.Documentation`, `content/conceptual/configuration/telemetry.md`, section "Reviewing exception and performance reports" still describes the two-choice review and does not mention the re-prompting or the per-issue opt-out. It needs a separate PR in that repository.
- Performance-problem reports share `ToastNotificationKinds.Exception`, so they inherit the same toast treatment. That looks right (same review page, same consent), but if we want them to keep Snooze/Mute they need their own notification kind.

-- Claude for @gfraiteur

