### PR TITLE
Report nested reference-assembly build failures as diagnostics (#1744)

### DIFF
--- a/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
+++ b/Metalama.Backstage/src/Metalama.Backstage/Infrastructure/PlatformInfo.cs
@@ -166,12 +166,29 @@ namespace Metalama.Backstage.Infrastructure
 
             if ( this._runtimeInformation.IsOSPlatform( OSPlatform.Windows ) )
             {
-                // On Windows, %ProgramFiles% expands to the correct directory for the current architecture.
+                // %ProgramFiles% expands to the directory of the architecture of the current process, which is
+                // 'C:\Program Files (x86)' in a 32-bit process. That is the wrong installation to prefer: a 32-bit host,
+                // such as the MSBuild.exe of Visual Studio, still builds the project with the .NET SDK of the native
+                // architecture, so the version that the nested build is pinned to is the one installed there.
+                // %ProgramW6432% always denotes the native directory, in a process of either architecture, and is
+                // therefore searched first. %ProgramFiles% is still searched afterwards, so that a machine whose only
+                // .NET installation is the 32-bit one continues to work. See issue #1745.
+                var programFilesNative = this._environmentVariableProvider.GetEnvironmentVariable( "ProgramW6432" );
                 var programFiles = this._environmentVariableProvider.GetEnvironmentVariable( "ProgramFiles" );
 
-                if ( programFiles != null )
+                // The two variables have the same value in a 64-bit process, which is the ordinary case.
+                var programFilesDirectories = string.Equals( programFilesNative, programFiles, StringComparison.OrdinalIgnoreCase )
+                    ? new[] { programFiles }
+                    : new[] { programFilesNative, programFiles };
+
+                foreach ( var directory in programFilesDirectories )
                 {
-                    var baseDirectory = Path.Combine( programFiles, "dotnet" );
+                    if ( string.IsNullOrEmpty( directory ) )
+                    {
+                        continue;
+                    }
+
+                    var baseDirectory = Path.Combine( directory!, "dotnet" );
 
                     // On ARM64 OS running x64 process, check the x64 subfolder first.
                     if ( this._runtimeInformation is { OSArchitecture: Architecture.Arm64, ProcessArchitecture: Architecture.X64 } )

--- a/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoArchitectureTests.cs
+++ b/Metalama.Backstage/src/tests/Metalama.Backstage.Tests/Infrastructure/PlatformInfoArchitectureTests.cs
@@ -1,0 +1,140 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Backstage.Extensibility;
+using Metalama.Backstage.Infrastructure;
+using Metalama.Backstage.Testing;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Backstage.Tests.Infrastructure;
+
+/// <summary>
+/// Tests the selection of the <c>dotnet</c> executable when 64-bit Windows carries both a 32-bit and a 64-bit .NET
+/// installation.
+/// </summary>
+/// <remarks>
+/// A 32-bit host, such as the <c>MSBuild.exe</c> of Visual Studio or a 32-bit compiler server, expands
+/// <c>%ProgramFiles%</c> to <c>C:\Program Files (x86)</c>, so the 32-bit installation is found first even though the
+/// project was built with the 64-bit .NET SDK. The nested reference-assembly build then runs against a set of .NET SDKs
+/// that does not contain the version that the outer build used. See issue #1745.
+/// </remarks>
+public sealed class PlatformInfoArchitectureTests : TestsBase
+{
+    private const string _programFilesX86 = "C:\\Program Files (x86)";
+    private const string _programFilesX64 = "C:\\Program Files";
+
+    public PlatformInfoArchitectureTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    private void CreateDotNetWithSdk( string dotnetExePath, params string[] sdkVersions )
+    {
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( dotnetExePath )! );
+        this.FileSystem.WriteAllText( dotnetExePath, string.Empty );
+
+        var sdkDirectory = Path.Combine( Path.GetDirectoryName( dotnetExePath )!, "sdk" );
+        this.FileSystem.CreateDirectory( sdkDirectory );
+
+        foreach ( var sdkVersion in sdkVersions )
+        {
+            this.FileSystem.CreateDirectory( Path.Combine( sdkDirectory, sdkVersion ) );
+        }
+    }
+
+    /// <summary>
+    /// Configures a 32-bit process on 64-bit Windows, which reads <c>C:\Program Files (x86)</c> from
+    /// <c>%ProgramFiles%</c> and <c>C:\Program Files</c> from <c>%ProgramW6432%</c>.
+    /// </summary>
+    private void ArrangeX86ProcessOnX64Windows()
+    {
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X86;
+        this.RuntimeInformation.TestOSArchitecture = Architecture.X64;
+
+        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = _programFilesX86;
+        this.EnvironmentVariableProvider.Environment["ProgramW6432"] = _programFilesX64;
+    }
+
+    /// <summary>
+    /// The defect of issue #1745: a 32-bit process must not prefer the 32-bit installation, because the project was
+    /// built by the .NET SDK of the native architecture and the nested build is pinned to that version.
+    /// </summary>
+    [Fact]
+    public void X86Process_PrefersTheNativeInstallation()
+    {
+        this.ArrangeX86ProcessOnX64Windows();
+
+        var x86Dotnet = Path.Combine( _programFilesX86, "dotnet", "dotnet.exe" );
+        var x64Dotnet = Path.Combine( _programFilesX64, "dotnet", "dotnet.exe" );
+
+        // The 32-bit installation carries an old .NET SDK, the 64-bit one carries the version that the outer build used.
+        this.CreateDotNetWithSdk( x86Dotnet, "8.0.423" );
+        this.CreateDotNetWithSdk( x64Dotnet, "8.0.423", "10.0.302" );
+
+        var result = this.ServiceProvider.GetRequiredBackstageService<IPlatformInfo>().DotNetExePath;
+
+        Assert.Equal( x64Dotnet, result );
+    }
+
+    /// <summary>
+    /// The 32-bit installation must still be used when it is the only one, so that a machine that carries no native
+    /// .NET installation keeps working.
+    /// </summary>
+    [Fact]
+    public void X86Process_FallsBackToTheX86Installation_WhenThereIsNoNativeOne()
+    {
+        this.ArrangeX86ProcessOnX64Windows();
+
+        var x86Dotnet = Path.Combine( _programFilesX86, "dotnet", "dotnet.exe" );
+        this.CreateDotNetWithSdk( x86Dotnet, "8.0.423" );
+
+        var result = this.ServiceProvider.GetRequiredBackstageService<IPlatformInfo>().DotNetExePath;
+
+        Assert.Equal( x86Dotnet, result );
+    }
+
+    /// <summary>
+    /// The native installation must be skipped when it has no .NET SDK, exactly as any other candidate is.
+    /// </summary>
+    [Fact]
+    public void X86Process_SkipsTheNativeInstallation_WhenItHasNoSdk()
+    {
+        this.ArrangeX86ProcessOnX64Windows();
+
+        var x86Dotnet = Path.Combine( _programFilesX86, "dotnet", "dotnet.exe" );
+        var x64Dotnet = Path.Combine( _programFilesX64, "dotnet", "dotnet.exe" );
+
+        this.CreateDotNetWithSdk( x86Dotnet, "8.0.423" );
+
+        // A runtime-only native installation: the executable exists but there is no sdk directory beside it.
+        this.FileSystem.CreateDirectory( Path.GetDirectoryName( x64Dotnet )! );
+        this.FileSystem.WriteAllText( x64Dotnet, string.Empty );
+
+        var result = this.ServiceProvider.GetRequiredBackstageService<IPlatformInfo>().DotNetExePath;
+
+        Assert.Equal( x86Dotnet, result );
+    }
+
+    /// <summary>
+    /// In a 64-bit process the two variables have the same value, so the resolution must be unchanged.
+    /// </summary>
+    [Fact]
+    public void X64Process_IsUnaffected()
+    {
+        this.RuntimeInformation.Platform = OSPlatform.Windows;
+        this.RuntimeInformation.TestProcessArchitecture = Architecture.X64;
+        this.RuntimeInformation.TestOSArchitecture = Architecture.X64;
+
+        this.EnvironmentVariableProvider.Environment["ProgramFiles"] = _programFilesX64;
+        this.EnvironmentVariableProvider.Environment["ProgramW6432"] = _programFilesX64;
+
+        var x64Dotnet = Path.Combine( _programFilesX64, "dotnet", "dotnet.exe" );
+        this.CreateDotNetWithSdk( x64Dotnet, "10.0.302" );
+
+        var result = this.ServiceProvider.GetRequiredBackstageService<IPlatformInfo>().DotNetExePath;
+
+        Assert.Equal( x64Dotnet, result );
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -802,7 +802,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
         // user only that a generator failed. See issue #1744.
         var referenceAssemblyDiagnostics = new DiagnosticBag();
 
-        if ( !this.ServiceProvider.TryResolveReferenceAssemblies( referenceAssemblyDiagnostics ) )
+        if ( !this.TryResolveReferenceAssemblies( referenceAssemblyDiagnostics ) )
         {
             return FallibleResultWithDiagnostics<DesignTimeAspectPipelineResultAndState>.Failed( referenceAssemblyDiagnostics.ToImmutableArray() );
         }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -795,6 +795,18 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
             }
         }
 
+        // The compile-time reference assemblies are resolved here, before anything else needs them, because this is the
+        // first point of the design-time pipeline that can carry diagnostics. Resolving them runs a nested build, which
+        // fails for reasons that belong to the environment. Returning the failure lets TheDiagnosticAnalyzer report it
+        // in the editor, whereas throwing would escape the source generator and be reported as CS8785, which tells the
+        // user only that a generator failed. See issue #1744.
+        var referenceAssemblyDiagnostics = new DiagnosticBag();
+
+        if ( !this.ServiceProvider.TryResolveReferenceAssemblies( referenceAssemblyDiagnostics ) )
+        {
+            return FallibleResultWithDiagnostics<DesignTimeAspectPipelineResultAndState>.Failed( referenceAssemblyDiagnostics.ToImmutableArray() );
+        }
+
         if ( this._compilationResultCache.TryGetValue( compilation, out var compilationResult ) )
         {
             if ( !compilationResult.IsSuccessful )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/DesignTimeExceptionHandler.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/DesignTimeExceptionHandler.cs
@@ -56,7 +56,7 @@ namespace Metalama.Framework.DesignTime.Utilities
             // packages. Such a condition is not a defect of Metalama and must not be sent as a crash report. See #1744.
             if ( DiagnosticException.TryFind( e ) is { } diagnosticException )
             {
-                logger.Warning?.Log( $"A user-attributable failure occurred: {diagnosticException.Message}" );
+                logger.Warning?.Log( $"A user-attributable failure occurred: {diagnosticException.GetSingleLineMessage()}" );
 
                 return;
             }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/DesignTimeExceptionHandler.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/DesignTimeExceptionHandler.cs
@@ -5,6 +5,7 @@
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Backstage.Telemetry;
+using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Options;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities.Diagnostics;
@@ -49,6 +50,16 @@ namespace Metalama.Framework.DesignTime.Utilities
         internal void ReportException( Exception e, IProjectOptions? projectOptions, ILogger? logger = null )
         {
             logger ??= Logger.DesignTime;
+
+            // A DiagnosticException means that the failure has already been analyzed and that the responsibility for it
+            // lies with the user or with the build environment, typically a nested build that cannot restore its NuGet
+            // packages. Such a condition is not a defect of Metalama and must not be sent as a crash report. See #1744.
+            if ( DiagnosticException.TryFind( e ) is { } diagnosticException )
+            {
+                logger.Warning?.Log( $"A user-attributable failure occurred: {diagnosticException.Message}" );
+
+                return;
+            }
 
             var classifiedException = ExceptionClassifier.Classify( e );
             logger.LogException( classifiedException );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
@@ -120,16 +120,19 @@ internal sealed class CompileTimeAssemblyLocator
                 new[] { this.GetType(), typeof(IAspect), typeof(IAspectWeaver), typeof(ITemplateSyntaxFactory), typeof(FieldOrPropertyInfo) }
                     .SelectAsReadOnlyList( x => x.Assembly.Location ) ) );
 
-        var targetFrameworksString = string.IsNullOrEmpty( projectOptions.CompileTimeTargetFrameworks )
-            ? _defaultCompileTimeTargetFrameworks
-            : projectOptions.CompileTimeTargetFrameworks;
+        this._targetFrameworks = ParseTargetFrameworks(
+            string.IsNullOrEmpty( projectOptions.CompileTimeTargetFrameworks )
+                ? _defaultCompileTimeTargetFrameworks
+                : projectOptions.CompileTimeTargetFrameworks! );
 
-        this._targetFrameworks = targetFrameworksString.Split( ';' ).ToImmutableArray();
+        // The parsed value is rejoined with the separator that MSBuild expects, because it is written into the
+        // TargetFrameworks property of the temporary project, and it is what the cache key is computed from, so that
+        // two spellings of one set of target frameworks share a cache directory.
+        var targetFrameworksString = string.Join( ";", this._targetFrameworks );
 
         if ( !this._targetFrameworks.Contains( "netstandard2.0" ) )
         {
-            throw new InvalidOperationException(
-                $"Custom MetalamaCompileTimeTargetFrameworks has to include 'netstandard2.0', but it was {this._targetFrameworks}" );
+            throw CreateInvalidTargetFrameworksException( targetFrameworksString, "it must include 'netstandard2.0'" );
         }
 
         // Load nuget.config.
@@ -245,19 +248,55 @@ internal sealed class CompileTimeAssemblyLocator
         this._referenceCompilationContext = this._referenceCompilation.GetCompilationContext();
     }
 
+    /// <summary>
+    /// Splits the value of the <see cref="MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks"/> property into
+    /// target framework monikers.
+    /// </summary>
+    /// <remarks>
+    /// Both the comma and the semicolon are accepted. The property reaches the compiler through the generated analyzer
+    /// configuration file, in which a semicolon starts a comment, so the build normalizes the semicolon that a user
+    /// naturally writes in MSBuild into a comma. A value set directly through <see cref="IProjectOptions"/>, as in
+    /// tests, does not go through that file and keeps whichever separator it was given. See issue #1789.
+    /// </remarks>
+    internal static ImmutableArray<string> ParseTargetFrameworks( string value )
+        => value
+            .Split( [',', ';'], StringSplitOptions.RemoveEmptyEntries )
+            .SelectAsArray( f => f.Trim() )
+            .Where( f => f.Length > 0 )
+            .ToImmutableArray();
+
+    /// <summary>
+    /// Creates the exception reported when the <see cref="MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks"/>
+    /// property does not describe a usable set of target frameworks.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="DiagnosticException"/> and not an <see cref="InvalidOperationException"/>, because the value comes
+    /// from the project and the user is the one who can correct it. Reported as <c>LAMA0001</c>, it invited a crash
+    /// report for what is a configuration mistake. See issues #1744 and #1789.
+    /// </remarks>
+    private static DiagnosticException CreateInvalidTargetFrameworksException( string value, string requirement )
+    {
+        var diagnostic = GeneralDiagnosticDescriptors.InvalidCompileTimeTargetFrameworks.CreateRoslynDiagnostic(
+            null,
+            (MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks, value, requirement) );
+
+        return new DiagnosticException( $"Invalid {MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks}.", ImmutableArray.Create( diagnostic ), false );
+    }
+
     private string GetAdditionalCompileTimeAssembliesDirectory()
     {
         string platform;
+        var targetFrameworks = string.Join( ";", this._targetFrameworks );
 
         if ( Environment.Version.Major < 6 )
         {
             platform = this._targetFrameworks.FirstOrDefault( f => f.StartsWith( "net4", StringComparison.Ordinal ) )
-                       ?? throw new InvalidOperationException( "Custom MetalamaCompileTimeTargetFrameworks did not include .NET Framework 4.x." );
+                       ?? throw CreateInvalidTargetFrameworksException( targetFrameworks, "it must include a .NET Framework 4.x target framework" );
         }
         else
         {
             platform = this._targetFrameworks.FirstOrDefault( f => f is ['n', 'e', 't', '1' or (>= '6' and <= '9'), ..] )
-                       ?? throw new InvalidOperationException( "Custom MetalamaCompileTimeTargetFrameworks did not include .NET 6+." );
+                       ?? throw CreateInvalidTargetFrameworksException( targetFrameworks, "it must include a .NET 6.0 or later target framework" );
         }
 
         return Path.Combine( this._cacheDirectory, "bin", "Debug", platform );
@@ -514,7 +553,7 @@ internal sealed class CompileTimeAssemblyLocator
   <Import Project=""{hooksDirectory}/Metalama.AssemblyLocator.Build.props"" Condition=""Exists('{hooksDirectory}/Metalama.AssemblyLocator.Build.props')"" />";
 
                 hooksTargetsImport = $@"
-  <Import Project=""{{hooksDirectory}}/Metalama.AssemblyLocator.Build.targets"" Condition=""Exists('{{hooksDirectory}}/Metalama.AssemblyLocator.Build.targets')"" />";
+  <Import Project=""{hooksDirectory}/Metalama.AssemblyLocator.Build.targets"" Condition=""Exists('{hooksDirectory}/Metalama.AssemblyLocator.Build.targets')"" />";
 
                 hooksImportWarnings = $@"
   <Target Name=""_WarnOfImports"">

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
@@ -675,17 +675,32 @@ internal sealed class CompileTimeAssemblyLocator
     {
         this._logger.Error?.Log( exception.Message );
 
-        var diagnostic =
-            exception.HasTimedOut
-                ? GeneralDiagnosticDescriptors.ReferenceAssemblyBuildTimedOut.CreateRoslynDiagnostic(
-                    null,
-                    (projectFilePath, exception.Timeout / 1000f, MSBuildPropertyNames.MetalamaReferenceAssemblyRestoreTimeout, binaryLogPath) )
-                : GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
-                    null,
-                    (projectFilePath, exception.ExitCode!.Value, ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( exception.Output ),
-                     ReferenceAssemblyBuildFailureClassifier.GetProbableCause( exception.Output, this._cacheDirectory, this._sdkVersion ), binaryLogPath) );
+        Diagnostic diagnostic;
+        string summary;
 
+        if ( exception.HasTimedOut )
+        {
+            diagnostic = GeneralDiagnosticDescriptors.ReferenceAssemblyBuildTimedOut.CreateRoslynDiagnostic(
+                null,
+                (projectFilePath, exception.Timeout / 1000f, MSBuildPropertyNames.MetalamaReferenceAssemblyRestoreTimeout, binaryLogPath) );
+
+            summary = $"The build of '{projectFilePath}' did not complete in {exception.Timeout / 1000f} s.";
+        }
+        else
+        {
+            diagnostic = GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
+                null,
+                (projectFilePath, exception.ExitCode!.Value, ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( exception.Output ),
+                 ReferenceAssemblyBuildFailureClassifier.GetProbableCause( exception.Output, this._cacheDirectory, this._sdkVersion ), binaryLogPath) );
+
+            summary = $"The build of '{projectFilePath}' exited with code {exception.ExitCode}.";
+        }
+
+        // A short summary, and not the message of the ProcessFailedException, which embeds the whole console transcript
+        // of the child process. That transcript has just been written to the log, and repeating it in the message of an
+        // exception that higher layers log in turn would reintroduce the illegible wall of text that this diagnostic
+        // exists to replace.
         // inSourceCode: false, because the failure is not attributable to any syntax tree of the compilation.
-        return new DiagnosticException( exception.Message, ImmutableArray.Create( diagnostic ), false );
+        return new DiagnosticException( summary, ImmutableArray.Create( diagnostic ), false );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
@@ -21,6 +21,7 @@ using Newtonsoft.Json.Linq;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -64,7 +65,7 @@ internal sealed class CompileTimeAssemblyLocator
         }
     }
 
-    private readonly string _cacheDirectory;
+    private readonly string _cacheDirectory = null!;
     private readonly ILogger _logger;
     private readonly DotNetTool _dotNetTool;
     private readonly int _restoreTimeout;
@@ -76,22 +77,22 @@ internal sealed class CompileTimeAssemblyLocator
     /// This compilation is used by the <see cref="SymbolClassifier"/> to determine if an API is available
     /// at compile time.
     /// </summary>
-    private readonly Compilation _referenceCompilation;
+    private readonly Compilation _referenceCompilation = null!;
 
-    private readonly CompilationContext _referenceCompilationContext;
+    private readonly CompilationContext _referenceCompilationContext = null!;
     private readonly IReadOnlyList<string>? _nugetConfigFiles;
 
     /// <summary>
     /// Gets the name (without path and extension) of all compile-time assemblies, including Metalama, Roslyn and .NET standard.
     /// </summary>
-    internal ImmutableHashSet<string> AssemblyNames { get; }
+    internal ImmutableHashSet<string> AssemblyNames { get; } = ImmutableHashSet<string>.Empty;
 
     /// <summary>
     /// Gets the full path of executable system assemblies for the current platform.
     /// </summary>
     internal ImmutableArray<string> AdditionalCompileTimeAssemblyPaths { get; }
 
-    internal ImmutableDictionary<string, AssemblyIdentity> AssemblyIdentities { get; }
+    internal ImmutableDictionary<string, AssemblyIdentity> AssemblyIdentities { get; } = ImmutableDictionary<string, AssemblyIdentity>.Empty;
 
     internal bool IsStandardAssemblyName( string assemblyName )
         => string.Equals( assemblyName, "System.Private.CoreLib", StringComparison.OrdinalIgnoreCase )
@@ -102,8 +103,44 @@ internal sealed class CompileTimeAssemblyLocator
     /// </summary>
     internal ImmutableArray<MetadataReference> MetadataReferences { get; }
 
-    internal CompileTimeAssemblyLocator( in ProjectServiceProvider serviceProvider, string additionalReferences, ITempFileManager tempFileManager )
+    /// <summary>
+    /// Creates a <see cref="CompileTimeAssemblyLocator"/>, or reports to <paramref name="diagnostics"/> and returns
+    /// <c>false</c> when the compile-time reference assemblies cannot be resolved.
+    /// </summary>
+    /// <remarks>
+    /// Resolving the reference assemblies runs a nested build, which fails for reasons that belong to the environment
+    /// rather than to Metalama: a NuGet feed that requires credentials, a <c>global.json</c> that pins an absent .NET
+    /// SDK, and so on. Such a failure is reported as a diagnostic and not thrown, so that the caller can abort the
+    /// pipeline the way it aborts for any other diagnostic. See issue #1744.
+    /// </remarks>
+    internal static bool TryCreate(
+        in ProjectServiceProvider serviceProvider,
+        string additionalReferences,
+        ITempFileManager tempFileManager,
+        IDiagnosticAdder diagnostics,
+        [NotNullWhen( true )] out CompileTimeAssemblyLocator? locator )
     {
+        var candidate = new CompileTimeAssemblyLocator( serviceProvider, additionalReferences, tempFileManager, diagnostics, out var success );
+        locator = success ? candidate : null;
+
+        return success;
+    }
+
+    /// <remarks>
+    /// The constructor interleaves the steps that can fail with the assignment of the fields that depend on them, so it
+    /// reports through <paramref name="diagnostics"/> and returns early instead of throwing, setting
+    /// <paramref name="success"/> to <c>false</c>. A partially initialized instance never escapes
+    /// <see cref="TryCreate"/>, which is the only caller.
+    /// </remarks>
+    private CompileTimeAssemblyLocator(
+        in ProjectServiceProvider serviceProvider,
+        string additionalReferences,
+        ITempFileManager tempFileManager,
+        IDiagnosticAdder diagnostics,
+        out bool success )
+    {
+        success = false;
+
         this._logger = serviceProvider.GetLoggerFactory().GetLogger( nameof(CompileTimeAssemblyLocator) );
         this._sdkVersion = serviceProvider.GetRequiredService<IProjectOptions>().SdkVersion;
         this._msBuildBinPath = serviceProvider.GetRequiredService<IProjectOptions>().MSBuildBinPath;
@@ -132,7 +169,9 @@ internal sealed class CompileTimeAssemblyLocator
 
         if ( !this._targetFrameworks.Contains( "netstandard2.0" ) )
         {
-            throw CreateInvalidTargetFrameworksException( targetFrameworksString, "it must include 'netstandard2.0'" );
+            ReportInvalidTargetFrameworks( diagnostics, targetFrameworksString, "it must include 'netstandard2.0'" );
+
+            return;
         }
 
         // Load nuget.config.
@@ -194,11 +233,16 @@ internal sealed class CompileTimeAssemblyLocator
         var metalamaImplementationPaths = metalamaImplementationAssemblies.Values;
 
         // Get system assemblies.
-        var referencePaths = this.GetReferenceAssembliesManifest(
-            targetFrameworksString,
-            additionalReferences,
-            additionalNugetSources,
-            projectOptions.AssemblyLocatorHooksDirectory );
+        if ( !this.TryGetReferenceAssembliesManifest(
+                targetFrameworksString,
+                additionalReferences,
+                additionalNugetSources,
+                projectOptions.AssemblyLocatorHooksDirectory,
+                diagnostics,
+                out var referencePaths ) )
+        {
+            return;
+        }
 
         // Sets the collection of all standard assemblies, i.e. system assemblies and ours.
         this.AssemblyNames = metalamaImplementationAssemblyNames
@@ -233,7 +277,12 @@ internal sealed class CompileTimeAssemblyLocator
             .GroupBy( s => s.Identity.Name )
             .ToImmutableDictionary( s => s.Key, s => s.OrderByDescending( x => x.Identity.Version ).First().Identity );
 
-        var additionalCompileTimeAssemblies = Directory.GetFiles( this.GetAdditionalCompileTimeAssembliesDirectory(), "*.dll" );
+        if ( !this.TryGetAdditionalCompileTimeAssembliesDirectory( diagnostics, out var additionalCompileTimeAssembliesDirectory ) )
+        {
+            return;
+        }
+
+        var additionalCompileTimeAssemblies = Directory.GetFiles( additionalCompileTimeAssembliesDirectory, "*.dll" );
 
         this.AdditionalCompileTimeAssemblyPaths =
             additionalCompileTimeAssemblies.Where( p => !p.EndsWith( "TempProject.dll", StringComparison.OrdinalIgnoreCase ) ).ToImmutableArray();
@@ -246,6 +295,8 @@ internal sealed class CompileTimeAssemblyLocator
                 new CSharpCompilationOptions( OutputKind.DynamicallyLinkedLibrary, deterministic: true, optimizationLevel: OptimizationLevel.Debug ) );
 
         this._referenceCompilationContext = this._referenceCompilation.GetCompilationContext();
+
+        success = true;
     }
 
     /// <summary>
@@ -274,32 +325,35 @@ internal sealed class CompileTimeAssemblyLocator
     /// from the project and the user is the one who can correct it. Reported as <c>LAMA0001</c>, it invited a crash
     /// report for what is a configuration mistake. See issues #1744 and #1789.
     /// </remarks>
-    private static DiagnosticException CreateInvalidTargetFrameworksException( string value, string requirement )
-    {
-        var diagnostic = GeneralDiagnosticDescriptors.InvalidCompileTimeTargetFrameworks.CreateRoslynDiagnostic(
-            null,
-            (MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks, value, requirement) );
+    private static void ReportInvalidTargetFrameworks( IDiagnosticAdder diagnostics, string value, string requirement )
+        => diagnostics.Report(
+            GeneralDiagnosticDescriptors.InvalidCompileTimeTargetFrameworks.CreateRoslynDiagnostic(
+                null,
+                (MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks, value, requirement) ) );
 
-        return new DiagnosticException( $"Invalid {MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks}.", ImmutableArray.Create( diagnostic ), false );
-    }
-
-    private string GetAdditionalCompileTimeAssembliesDirectory()
+    private bool TryGetAdditionalCompileTimeAssembliesDirectory( IDiagnosticAdder diagnostics, [NotNullWhen( true )] out string? directory )
     {
-        string platform;
         var targetFrameworks = string.Join( ";", this._targetFrameworks );
 
-        if ( Environment.Version.Major < 6 )
+        var platform = Environment.Version.Major < 6
+            ? this._targetFrameworks.FirstOrDefault( f => f.StartsWith( "net4", StringComparison.Ordinal ) )
+            : this._targetFrameworks.FirstOrDefault( f => f is ['n', 'e', 't', '1' or (>= '6' and <= '9'), ..] );
+
+        if ( platform == null )
         {
-            platform = this._targetFrameworks.FirstOrDefault( f => f.StartsWith( "net4", StringComparison.Ordinal ) )
-                       ?? throw CreateInvalidTargetFrameworksException( targetFrameworks, "it must include a .NET Framework 4.x target framework" );
-        }
-        else
-        {
-            platform = this._targetFrameworks.FirstOrDefault( f => f is ['n', 'e', 't', '1' or (>= '6' and <= '9'), ..] )
-                       ?? throw CreateInvalidTargetFrameworksException( targetFrameworks, "it must include a .NET 6.0 or later target framework" );
+            var requirement = Environment.Version.Major < 6
+                ? "it must include a .NET Framework 4.x target framework"
+                : "it must include a .NET 6.0 or later target framework";
+
+            ReportInvalidTargetFrameworks( diagnostics, targetFrameworks, requirement );
+            directory = null;
+
+            return false;
         }
 
-        return Path.Combine( this._cacheDirectory, "bin", "Debug", platform );
+        directory = Path.Combine( this._cacheDirectory, "bin", "Debug", platform );
+
+        return true;
     }
 
     public static string GetAdditionalReferences( IProjectOptions options )
@@ -489,11 +543,13 @@ internal sealed class CompileTimeAssemblyLocator
         return true;
     }
 
-    private IReadOnlyList<string> GetReferenceAssembliesManifest(
+    private bool TryGetReferenceAssembliesManifest(
         string targetFrameworks,
         string additionalPackageReferences,
         string? additionalNugetSources,
-        string? hooksDirectory )
+        string? hooksDirectory,
+        IDiagnosticAdder diagnostics,
+        [NotNullWhen( true )] out IReadOnlyList<string>? referencePaths )
     {
         using ( MutexHelper.WithGlobalLock( this._cacheDirectory, this._logger ) )
         {
@@ -510,11 +566,18 @@ internal sealed class CompileTimeAssemblyLocator
 
                 if ( missingFiles.Count == 0 )
                 {
-                    var additionalCompileTimeAssembliesDirectory = this.GetAdditionalCompileTimeAssembliesDirectory();
+                    if ( !this.TryGetAdditionalCompileTimeAssembliesDirectory( diagnostics, out var additionalCompileTimeAssembliesDirectory ) )
+                    {
+                        referencePaths = null;
+
+                        return false;
+                    }
 
                     if ( Directory.Exists( additionalCompileTimeAssembliesDirectory ) )
                     {
-                        return assembliesFromFile;
+                        referencePaths = assembliesFromFile;
+
+                        return true;
                     }
                     else
                     {
@@ -648,7 +711,10 @@ internal sealed class CompileTimeAssemblyLocator
             }
             catch ( ProcessFailedException exception )
             {
-                throw this.CreateReferenceAssemblyBuildException( exception, projectFilePath, binaryLogPath );
+                this.ReportReferenceAssemblyBuildFailure( exception, projectFilePath, binaryLogPath, diagnostics );
+                referencePaths = null;
+
+                return false;
             }
 
             var assemblies = File.ReadAllLines( assembliesListPath );
@@ -658,7 +724,9 @@ internal sealed class CompileTimeAssemblyLocator
                 throw new AssertionFailedException( $"The file '{assembliesListPath}' is empty." );
             }
 
-            return assemblies;
+            referencePaths = assemblies;
+
+            return true;
         }
     }
 
@@ -671,36 +739,24 @@ internal sealed class CompileTimeAssemblyLocator
     /// few of its lines: a Roslyn diagnostic cannot contain line breaks, and a console transcript embedded in a build
     /// error is unreadable. See issue #1744.
     /// </remarks>
-    private DiagnosticException CreateReferenceAssemblyBuildException( ProcessFailedException exception, string projectFilePath, string binaryLogPath )
+    private void ReportReferenceAssemblyBuildFailure(
+        ProcessFailedException exception,
+        string projectFilePath,
+        string binaryLogPath,
+        IDiagnosticAdder diagnostics )
     {
         this._logger.Error?.Log( exception.Message );
 
-        Diagnostic diagnostic;
-        string summary;
+        var diagnostic =
+            exception.HasTimedOut
+                ? GeneralDiagnosticDescriptors.ReferenceAssemblyBuildTimedOut.CreateRoslynDiagnostic(
+                    null,
+                    (projectFilePath, exception.Timeout / 1000f, MSBuildPropertyNames.MetalamaReferenceAssemblyRestoreTimeout, binaryLogPath) )
+                : GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
+                    null,
+                    (projectFilePath, exception.ExitCode!.Value, ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( exception.Output ),
+                     ReferenceAssemblyBuildFailureClassifier.GetProbableCause( exception.Output, this._cacheDirectory, this._sdkVersion ), binaryLogPath) );
 
-        if ( exception.HasTimedOut )
-        {
-            diagnostic = GeneralDiagnosticDescriptors.ReferenceAssemblyBuildTimedOut.CreateRoslynDiagnostic(
-                null,
-                (projectFilePath, exception.Timeout / 1000f, MSBuildPropertyNames.MetalamaReferenceAssemblyRestoreTimeout, binaryLogPath) );
-
-            summary = $"The build of '{projectFilePath}' did not complete in {exception.Timeout / 1000f} s.";
-        }
-        else
-        {
-            diagnostic = GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
-                null,
-                (projectFilePath, exception.ExitCode!.Value, ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( exception.Output ),
-                 ReferenceAssemblyBuildFailureClassifier.GetProbableCause( exception.Output, this._cacheDirectory, this._sdkVersion ), binaryLogPath) );
-
-            summary = $"The build of '{projectFilePath}' exited with code {exception.ExitCode}.";
-        }
-
-        // A short summary, and not the message of the ProcessFailedException, which embeds the whole console transcript
-        // of the child process. That transcript has just been written to the log, and repeating it in the message of an
-        // exception that higher layers log in turn would reintroduce the illegible wall of text that this diagnostic
-        // exists to replace.
-        // inSourceCode: false, because the failure is not attributable to any syntax tree of the compilation.
-        return new DiagnosticException( summary, ImmutableArray.Create( diagnostic ), false );
+        diagnostics.Report( diagnostic );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
@@ -9,6 +9,7 @@ using Metalama.Compiler;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.CompileTimeContracts;
 using Metalama.Framework.Engine.AspectWeavers;
+using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Options;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities;
@@ -575,27 +576,40 @@ internal sealed class CompileTimeAssemblyLocator
 
             this._logger.Trace?.Log( $"Building with restore timeout {this._restoreTimeout}." );
 
-            // When NETCoreSdkVersion is not available (e.g., old-style .NET Framework projects built with msbuild.exe),
-            // use msbuild.exe directly instead of dotnet.exe.
-            if ( string.IsNullOrEmpty( this._sdkVersion ) && !string.IsNullOrEmpty( this._msBuildBinPath ) )
-            {
-                var msBuildTool = new MSBuildTool( this._msBuildBinPath );
-                var arguments = $"\"{projectFilePath}\" /t:Restore;Build /bl:msbuild_{Guid.NewGuid():N}.binlog";
+            // The binary log is written in the working directory, i.e. in the cache directory. Its name is computed here
+            // and not inline in the arguments so that the diagnostic reported on a failure can name its full path, which
+            // is the only artifact from which such a failure can be diagnosed after the fact. See #1740 and #1746.
+            var binaryLogFileName = $"msbuild_{Guid.NewGuid():N}.binlog";
+            var binaryLogPath = Path.Combine( this._cacheDirectory, binaryLogFileName );
 
-                msBuildTool.Execute( arguments, this._cacheDirectory, this._restoreTimeout );
+            try
+            {
+                // When NETCoreSdkVersion is not available (e.g., old-style .NET Framework projects built with msbuild.exe),
+                // use msbuild.exe directly instead of dotnet.exe.
+                if ( string.IsNullOrEmpty( this._sdkVersion ) && !string.IsNullOrEmpty( this._msBuildBinPath ) )
+                {
+                    var msBuildTool = new MSBuildTool( this._msBuildBinPath );
+                    var arguments = $"\"{projectFilePath}\" /t:Restore;Build /bl:{binaryLogFileName}";
+
+                    msBuildTool.Execute( arguments, this._cacheDirectory, this._restoreTimeout );
+                }
+                else
+                {
+                    // Remove configuration environment variable to avoid having different output directory than Debug.
+                    // Build scripts may rely on env var to set the configuration in MSBuild.
+                    // Case insensitive comparison needed because MSBuild is case insensitive.
+                    var arguments = $"build -bl:{binaryLogFileName}";
+
+                    this._dotNetTool.Execute(
+                        arguments,
+                        this._cacheDirectory,
+                        this._restoreTimeout,
+                        envVar => !StringComparer.OrdinalIgnoreCase.Equals( envVar.Key, "configuration" ) );
+                }
             }
-            else
+            catch ( ProcessFailedException exception )
             {
-                // Remove configuration environment variable to avoid having different output directory than Debug.
-                // Build scripts may rely on env var to set the configuration in MSBuild.
-                // Case insensitive comparison needed because MSBuild is case insensitive.
-                var arguments = $"build -bl:msbuild_{Guid.NewGuid():N}.binlog";
-
-                this._dotNetTool.Execute(
-                    arguments,
-                    this._cacheDirectory,
-                    this._restoreTimeout,
-                    envVar => !StringComparer.OrdinalIgnoreCase.Equals( envVar.Key, "configuration" ) );
+                throw this.CreateReferenceAssemblyBuildException( exception, projectFilePath, binaryLogPath );
             }
 
             var assemblies = File.ReadAllLines( assembliesListPath );
@@ -607,5 +621,32 @@ internal sealed class CompileTimeAssemblyLocator
 
             return assemblies;
         }
+    }
+
+    /// <summary>
+    /// Converts the failure of the nested reference-assembly build into a <see cref="DiagnosticException"/>, so that it
+    /// is reported to the user as an actionable diagnostic instead of an unexpected exception and a crash report.
+    /// </summary>
+    /// <remarks>
+    /// The complete output of the child process is written to the Metalama log, because the diagnostic can quote only a
+    /// few of its lines: a Roslyn diagnostic cannot contain line breaks, and a console transcript embedded in a build
+    /// error is unreadable. See issue #1744.
+    /// </remarks>
+    private DiagnosticException CreateReferenceAssemblyBuildException( ProcessFailedException exception, string projectFilePath, string binaryLogPath )
+    {
+        this._logger.Error?.Log( exception.Message );
+
+        var diagnostic =
+            exception.HasTimedOut
+                ? GeneralDiagnosticDescriptors.ReferenceAssemblyBuildTimedOut.CreateRoslynDiagnostic(
+                    null,
+                    (projectFilePath, exception.Timeout / 1000f, MSBuildPropertyNames.MetalamaReferenceAssemblyRestoreTimeout, binaryLogPath) )
+                : GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
+                    null,
+                    (projectFilePath, exception.ExitCode!.Value, ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( exception.Output ),
+                     ReferenceAssemblyBuildFailureClassifier.GetProbableCause( exception.Output, this._cacheDirectory, this._sdkVersion ), binaryLogPath) );
+
+        // inSourceCode: false, because the failure is not attributable to any syntax tree of the compilation.
+        return new DiagnosticException( exception.Message, ImmutableArray.Create( diagnostic ), false );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocatorProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocatorProvider.cs
@@ -3,9 +3,11 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Backstage.Maintenance;
+using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Options;
 using Metalama.Framework.Engine.Services;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.CompileTime;
 
@@ -29,25 +31,50 @@ public sealed class CompileTimeAssemblyLocatorProvider : ICompileTimeAssemblyLoc
         this._tempFileManager = tempFileManager;
     }
 
-    CompileTimeAssemblyLocator ICompileTimeAssemblyLocatorProvider.GetInstance( in ProjectServiceProvider serviceProvider )
+    bool ICompileTimeAssemblyLocatorProvider.TryGetInstance(
+        in ProjectServiceProvider serviceProvider,
+        IDiagnosticAdder diagnostics,
+        [NotNullWhen( true )] out CompileTimeAssemblyLocator? locator )
     {
         var projectOptions = serviceProvider.GetRequiredService<IProjectOptions>();
 
         var additionalReferences = CompileTimeAssemblyLocator.GetAdditionalReferences( projectOptions );
 
-        if ( !this._referenceAssemblyLocators.TryGetValue( additionalReferences, out var referenceAssemblyLocator ) )
+        if ( this._referenceAssemblyLocators.TryGetValue( additionalReferences, out locator ) )
         {
-            // We look instead of using ConcurrentDictionary because instantiating the class is expensive.
-            lock ( this._sync )
-            {
-                if ( !this._referenceAssemblyLocators.TryGetValue( additionalReferences, out referenceAssemblyLocator ) )
-                {
-                    referenceAssemblyLocator = new CompileTimeAssemblyLocator( serviceProvider, additionalReferences, this._tempFileManager );
-                    this._referenceAssemblyLocators = this._referenceAssemblyLocators.Add( additionalReferences, referenceAssemblyLocator );
-                }
-            }
+            return true;
         }
 
-        return referenceAssemblyLocator;
+        // We lock instead of using ConcurrentDictionary because instantiating the class is expensive.
+        lock ( this._sync )
+        {
+            if ( this._referenceAssemblyLocators.TryGetValue( additionalReferences, out locator ) )
+            {
+                return true;
+            }
+
+            if ( !CompileTimeAssemblyLocator.TryCreate( serviceProvider, additionalReferences, this._tempFileManager, diagnostics, out locator ) )
+            {
+                // A failure is deliberately not cached: it is almost always caused by the environment, so the next
+                // compilation must try again instead of repeating a stale verdict. See issue #1744.
+                return false;
+            }
+
+            this._referenceAssemblyLocators = this._referenceAssemblyLocators.Add( additionalReferences, locator );
+
+            return true;
+        }
+    }
+
+    CompileTimeAssemblyLocator ICompileTimeAssemblyLocatorProvider.GetInstance( in ProjectServiceProvider serviceProvider )
+    {
+        // ThrowingDiagnosticAdder, because this overload is for the callers that have no diagnostic sink. A caller on a
+        // pipeline path uses TryGetInstance, in which case the locator is already cached here and this cannot fail.
+        if ( !((ICompileTimeAssemblyLocatorProvider) this).TryGetInstance( serviceProvider, ThrowingDiagnosticAdder.Instance, out var locator ) )
+        {
+            throw new AssertionFailedException( "ThrowingDiagnosticAdder did not throw." );
+        }
+
+        return locator;
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ICompileTimeAssemblyLocatorProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ICompileTimeAssemblyLocatorProvider.cs
@@ -2,12 +2,35 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Services;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.CompileTime;
 
 internal interface ICompileTimeAssemblyLocatorProvider : IGlobalService
 {
+    /// <summary>
+    /// Gets the <see cref="CompileTimeAssemblyLocator"/> of a project, creating it if necessary, and reports to
+    /// <paramref name="diagnostics"/> and returns <c>false</c> when it cannot be created.
+    /// </summary>
+    /// <remarks>
+    /// This is the entry point of every caller that has a diagnostic sink. Only a successfully created locator is
+    /// cached, so a project whose environment is repaired succeeds on the next compilation.
+    /// </remarks>
+    bool TryGetInstance(
+        in ProjectServiceProvider serviceProvider,
+        IDiagnosticAdder diagnostics,
+        [NotNullWhen( true )] out CompileTimeAssemblyLocator? locator );
+
+    /// <summary>
+    /// Gets the <see cref="CompileTimeAssemblyLocator"/> of a project, creating it if necessary and throwing a
+    /// <see cref="DiagnosticException"/> when it cannot be created.
+    /// </summary>
+    /// <remarks>
+    /// For the callers that have no diagnostic sink. A caller on a pipeline path must use
+    /// <see cref="TryGetInstance"/> instead, so that the failure becomes a diagnostic of that pipeline.
+    /// </remarks>
     CompileTimeAssemblyLocator GetInstance( in ProjectServiceProvider serviceProvider );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ReferenceAssemblyBuildFailureClassifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ReferenceAssemblyBuildFailureClassifier.cs
@@ -1,0 +1,254 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.Options;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace Metalama.Framework.Engine.CompileTime;
+
+/// <summary>
+/// Interprets the console output of the nested build that <see cref="CompileTimeAssemblyLocator"/> runs to resolve the
+/// compile-time reference assemblies, so that its failures can be reported as an actionable diagnostic instead of an
+/// unexpected exception.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Practically all failures of that build are caused by the environment (the .NET SDK installation, the NuGet
+/// configuration or the network) rather than by a defect in Metalama, but the child process has already explained the
+/// failure in its own output. See issue #1744.
+/// </para>
+/// <para>
+/// The output is matched on message identifiers such as <c>NU1101</c> whenever possible, because MSBuild localizes the
+/// prose that surrounds them and a substantial share of the affected users run a localized toolchain.
+/// </para>
+/// </remarks>
+internal static class ReferenceAssemblyBuildFailureClassifier
+{
+    /// <summary>
+    /// The maximal length of the text of <see cref="GetReportedErrors"/>, so that the resulting diagnostic remains
+    /// readable in a build log or in the error list of an IDE.
+    /// </summary>
+    private const int _maxReportedErrorsLength = 600;
+
+    /// <summary>
+    /// The maximal number of error lines quoted by <see cref="GetReportedErrors"/>. A multi-targeted build repeats
+    /// the same error once per target framework, so quoting all of them adds length but no information.
+    /// </summary>
+    private const int _maxReportedErrorCount = 4;
+
+    /// <summary>
+    /// Matches a line that carries an MSBuild, NuGet or .NET SDK message identifier followed by a colon, such as
+    /// <c>error NU1101:</c>. The identifier survives localization, unlike the word <c>error</c> that precedes it.
+    /// </summary>
+    private static readonly Regex _messageIdRegex = new(
+        @"\b(?:NU|NETSDK|MSB|CS|AD)[0-9]{3,5}\s*:",
+        RegexOptions.CultureInvariant );
+
+    /// <summary>
+    /// Matches an English error line that carries no message identifier, such as the <c>error :</c> lines that NuGet
+    /// emits for a transport failure.
+    /// </summary>
+    private static readonly Regex _englishErrorRegex = new(
+        @"\berror\s*:",
+        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase );
+
+    /// <summary>
+    /// Matches a run of whitespace, used to fold the output into the single line that a Roslyn diagnostic requires.
+    /// </summary>
+    private static readonly Regex _whitespaceRegex = new( @"\s+", RegexOptions.CultureInvariant );
+
+    /// <summary>
+    /// Returns the sentence that describes the probable cause of the failure and the action that resolves it, or the
+    /// generic sentence when the output matches none of the known conditions.
+    /// </summary>
+    /// <param name="output">The console output of the nested build.</param>
+    /// <param name="projectDirectory">
+    /// The directory of the reference-assembly project, used to determine whether a <c>global.json</c> named by the output
+    /// is the one that Metalama wrote or one that belongs to the user.
+    /// </param>
+    /// <param name="requestedSdkVersion">
+    /// The version of the .NET SDK that Metalama pinned in the <c>global.json</c> that it wrote beside the
+    /// reference-assembly project, or <c>null</c> when it pinned none.
+    /// </param>
+    public static string GetProbableCause( ImmutableArray<string> output, string projectDirectory, string? requestedSdkVersion )
+    {
+        var text = string.Join( "\n", output );
+
+        // The .NET host refuses to run before MSBuild is even loaded, so this condition is recognized by the prose of
+        // the host and not by a message identifier. See issue #1745.
+        if ( Contains( text, "A compatible .NET SDK was not found" ) || Contains( text, "Requested SDK version" ) )
+        {
+            // Metalama writes a global.json beside the reference-assembly project to pin the .NET SDK to the version that
+            // builds the project. Blaming the user's global.json when the file at fault is that one would send the user
+            // looking for a file that does not concern this failure.
+            var isMetalamaGlobalJson = output.Any(
+                line => line.IndexOf( "global.json", StringComparison.OrdinalIgnoreCase ) >= 0
+                        && line.IndexOf( projectDirectory, StringComparison.OrdinalIgnoreCase ) >= 0 );
+
+            if ( isMetalamaGlobalJson && !string.IsNullOrEmpty( requestedSdkVersion ) )
+            {
+                return
+                    $"Metalama requested the .NET SDK version '{requestedSdkVersion}' for this build, because this is the version of the .NET SDK "
+                    + "that builds the project, but that version is not available to the child process. This typically happens when the .NET SDK of "
+                    + "the host, for instance the one that is bundled with the IDE, is not also installed as a stand-alone .NET SDK. Install that "
+                    + "version of the .NET SDK.";
+            }
+
+            return
+                "This build resolved a global.json file that requests a version of the .NET SDK that is not installed on this computer. "
+                + "Install the requested version of the .NET SDK, or change global.json so that it requests a version that is installed.";
+        }
+
+        // The nested build is a separate process and therefore does not inherit the interactive credential provider of
+        // the IDE or of the outer build. See issue #1744.
+        if ( Contains( text, "401 (Unauthorized)" ) || Contains( text, "403 (Forbidden)" ) )
+        {
+            return
+                "A NuGet feed refused the request because no valid credentials were supplied. This build runs in a separate process, "
+                + "which does not inherit the interactive credential provider of the outer build, therefore the credentials of the feed "
+                + "must be available without user interaction, typically in a nuget.config file or through a credential provider.";
+        }
+
+        if ( Contains( text, "NU1302" ) )
+        {
+            return
+                "A NuGet feed is configured with an insecure HTTP address, which NuGet rejects by default. Give that feed an HTTPS address, "
+                + "or set the allowInsecureConnections attribute of that feed in nuget.config.";
+        }
+
+        // packageSourceMapping applies to the nested build because it inherits the nuget.config of the project, and a
+        // Microsoft.CodeAnalysis.* pattern is more specific than a * pattern. See issue #1747.
+        if ( Contains( text, "NU1101" ) )
+        {
+            return
+                "A package that is required to resolve the compile-time reference assemblies was not found on the configured NuGet sources. "
+                + "When nuget.config maps the Microsoft.CodeAnalysis.* pattern to a private feed through packageSourceMapping, this build is "
+                + "restricted to that feed, therefore these packages must be mapped to a source that provides them, such as nuget.org.";
+        }
+
+        if ( Contains( text, "NU1301" ) || Contains( text, "Unable to load the service index for source" ) )
+        {
+            return
+                "A NuGet feed could not be reached. Verify that the feed is available from this computer and that the "
+                + "network configuration of the build environment allows the build to reach it.";
+        }
+
+        if ( Contains( text, "NETSDK1045" ) )
+        {
+            return
+                "The .NET SDK that this build resolved is too old for the target frameworks of the reference-assembly project. "
+                + $"Install a more recent .NET SDK, or set the {MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks} MSBuild property "
+                + "to target frameworks that this .NET SDK supports.";
+        }
+
+        if ( Contains( text, "of MSBuild" ) && Contains( text, "requires at least version" ) )
+        {
+            return
+                "The version of MSBuild that this build used is older than the version required by the .NET SDK that it resolved. "
+                + "Build with a version of MSBuild or of Visual Studio that matches the .NET SDK, or request an older .NET SDK in a "
+                + "global.json file.";
+        }
+
+        // 0xC0000005, that is, STATUS_ACCESS_VIOLATION, reported by MSB6006 for a task that crashed. See issue #1746.
+        if ( Contains( text, "-1073741819" ) )
+        {
+            return
+                "A tool started by this build terminated abnormally with an access violation. This is a failure of the .NET SDK toolchain "
+                + "and not of Metalama. Verify the integrity of the .NET SDK installation, and consider excluding the build directories "
+                + "from real-time antivirus scanning.";
+        }
+
+        return
+            "The cause of this failure is generally the build environment, typically the .NET SDK installation or the NuGet configuration, "
+            + "and not a defect of Metalama.";
+    }
+
+    /// <summary>
+    /// Returns the sentence that quotes the errors that the nested build reported, folded into a single line because a
+    /// Roslyn diagnostic cannot contain line breaks.
+    /// </summary>
+    public static string GetReportedErrors( ImmutableArray<string> output )
+    {
+        var errorLines = GetErrorLines( output );
+
+        if ( errorLines.Count == 0 )
+        {
+            // Either the build failed before it could report a diagnostic, as when the .NET host cannot satisfy a
+            // global.json, or the output was empty. The last lines are then the informative ones.
+            errorLines = output
+                .Select( Normalize )
+                .Where( line => line.Length > 0 )
+                .Reverse()
+                .Take( _maxReportedErrorCount )
+                .Reverse()
+                .ToReadOnlyList();
+
+            if ( errorLines.Count == 0 )
+            {
+                return "It did not produce any output.";
+            }
+
+            return "Its last output lines were the following: " + Truncate( string.Join( " ", errorLines ) );
+        }
+
+        return "It reported the following errors: " + Truncate( string.Join( " ", errorLines ) );
+    }
+
+    /// <summary>
+    /// Returns the distinct error lines of the output, in the order in which they were produced.
+    /// </summary>
+    private static IReadOnlyList<string> GetErrorLines( ImmutableArray<string> output )
+    {
+        var errorLines = new List<string>();
+        var seenErrorLines = new HashSet<string>( StringComparer.Ordinal );
+
+        foreach ( var line in output )
+        {
+            if ( !_messageIdRegex.IsMatch( line ) && !_englishErrorRegex.IsMatch( line ) )
+            {
+                continue;
+            }
+
+            var normalizedLine = Normalize( line );
+
+            // A multi-targeted build reports the same error once per target framework, and the suffix that names the
+            // target framework is the only difference, so compare the lines after removing it.
+            if ( normalizedLine.Length > 0 && seenErrorLines.Add( RemoveTargetFrameworkSuffix( normalizedLine ) ) )
+            {
+                errorLines.Add( normalizedLine );
+
+                if ( errorLines.Count == _maxReportedErrorCount )
+                {
+                    break;
+                }
+            }
+        }
+
+        return errorLines;
+    }
+
+    /// <summary>
+    /// Removes the <c>[project::TargetFramework=x]</c> suffix that MSBuild appends to a message of a multi-targeted build.
+    /// </summary>
+    private static string RemoveTargetFrameworkSuffix( string line )
+    {
+        var index = line.LastIndexOf( " [", StringComparison.Ordinal );
+
+        return index > 0 && line.EndsWith( "]", StringComparison.Ordinal ) ? line.Substring( 0, index ) : line;
+    }
+
+    private static bool Contains( string text, string value ) => text.IndexOf( value, StringComparison.OrdinalIgnoreCase ) >= 0;
+
+    /// <summary>
+    /// Folds a line of the output into a form that can appear in a Roslyn diagnostic, which cannot contain line breaks.
+    /// </summary>
+    private static string Normalize( string line ) => _whitespaceRegex.Replace( line, " " ).Trim();
+
+    private static string Truncate( string text )
+        => text.Length <= _maxReportedErrorsLength ? text : text.Substring( 0, _maxReportedErrorsLength ) + " (truncated)";
+}

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ReferenceAssemblyBuildFailureClassifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ReferenceAssemblyBuildFailureClassifier.cs
@@ -271,8 +271,9 @@ internal static class ReferenceAssemblyBuildFailureClassifier
         {
             var end = index + messageId.Length;
 
-            // Skip the whitespace that some loggers insert between the identifier and the colon.
-            while ( end < text.Length && text[end] == ' ' )
+            // Skip the whitespace that some loggers insert between the identifier and the colon. Any whitespace is
+            // skipped, and not the space alone, so that this method recognizes exactly what _messageIdRegex does.
+            while ( end < text.Length && char.IsWhiteSpace( text[end] ) )
             {
                 end++;
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ReferenceAssemblyBuildFailureClassifier.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/ReferenceAssemblyBuildFailureClassifier.cs
@@ -23,8 +23,12 @@ namespace Metalama.Framework.Engine.CompileTime;
 /// failure in its own output. See issue #1744.
 /// </para>
 /// <para>
-/// The output is matched on message identifiers such as <c>NU1101</c> whenever possible, because MSBuild localizes the
-/// prose that surrounds them and a substantial share of the affected users run a localized toolchain.
+/// The child process writes its output in the language of the toolchain, and a substantial share of the affected users
+/// run a localized toolchain, therefore no rule of this class may depend on the wording of a message. Only the
+/// following signals are recognized, all of which are invariant across languages: message identifiers such as
+/// <c>NU1101</c>, process exit codes, HTTP status codes, and the file name <c>global.json</c>. A condition for which no
+/// invariant signal exists is deliberately left unclassified and falls back to the generic explanation, which is a less
+/// precise message but never a wrong one.
 /// </para>
 /// </remarks>
 internal static class ReferenceAssemblyBuildFailureClassifier
@@ -36,26 +40,35 @@ internal static class ReferenceAssemblyBuildFailureClassifier
     private const int _maxReportedErrorsLength = 600;
 
     /// <summary>
-    /// The maximal number of error lines quoted by <see cref="GetReportedErrors"/>. A multi-targeted build repeats
-    /// the same error once per target framework, so quoting all of them adds length but no information.
+    /// The maximal number of lines quoted by <see cref="GetReportedErrors"/>. A multi-targeted build repeats the same
+    /// error once per target framework, so quoting all of them adds length but no information.
     /// </summary>
     private const int _maxReportedErrorCount = 4;
 
     /// <summary>
-    /// Matches a line that carries an MSBuild, NuGet or .NET SDK message identifier followed by a colon, such as
-    /// <c>error NU1101:</c>. The identifier survives localization, unlike the word <c>error</c> that precedes it.
+    /// Matches a line that carries an MSBuild, NuGet, .NET SDK or compiler message identifier followed by a colon, such
+    /// as <c>error NU1101:</c>.
     /// </summary>
+    /// <remarks>
+    /// The identifier is the only part of such a line that is invariant across languages: both the word that precedes it
+    /// and the text that follows it are localized.
+    /// </remarks>
     private static readonly Regex _messageIdRegex = new(
         @"\b(?:NU|NETSDK|MSB|CS|AD)[0-9]{3,5}\s*:",
         RegexOptions.CultureInvariant );
 
     /// <summary>
-    /// Matches an English error line that carries no message identifier, such as the <c>error :</c> lines that NuGet
-    /// emits for a transport failure.
+    /// Matches an HTTP status code that denotes an authentication or authorization failure, as it appears in the message
+    /// that NuGet produces for a rejected request.
     /// </summary>
-    private static readonly Regex _englishErrorRegex = new(
-        @"\berror\s*:",
-        RegexOptions.CultureInvariant | RegexOptions.IgnoreCase );
+    /// <remarks>
+    /// The status code is a number defined by the HTTP protocol and is therefore invariant, whereas the sentence that
+    /// carries it is localized. The boundaries exclude a digit or a dot on either side so that a version such as
+    /// <c>1.0.401</c> does not match.
+    /// </remarks>
+    private static readonly Regex _unauthorizedStatusCodeRegex = new(
+        @"(?<![\w.])40[13](?![\w.])",
+        RegexOptions.CultureInvariant );
 
     /// <summary>
     /// Matches a run of whitespace, used to fold the output into the single line that a Roslyn diagnostic requires.
@@ -64,7 +77,7 @@ internal static class ReferenceAssemblyBuildFailureClassifier
 
     /// <summary>
     /// Returns the sentence that describes the probable cause of the failure and the action that resolves it, or the
-    /// generic sentence when the output matches none of the known conditions.
+    /// generic sentence when the output carries no signal that identifies a known condition.
     /// </summary>
     /// <param name="output">The console output of the nested build.</param>
     /// <param name="projectDirectory">
@@ -75,13 +88,72 @@ internal static class ReferenceAssemblyBuildFailureClassifier
     /// The version of the .NET SDK that Metalama pinned in the <c>global.json</c> that it wrote beside the
     /// reference-assembly project, or <c>null</c> when it pinned none.
     /// </param>
+    /// <remarks>
+    /// The rules are ordered by decreasing confidence: a message identifier identifies a condition exactly, whereas the
+    /// presence of an HTTP status code or of a file name is circumstantial, so the former must win when both are present.
+    /// </remarks>
     public static string GetProbableCause( ImmutableArray<string> output, string projectDirectory, string? requestedSdkVersion )
     {
         var text = string.Join( "\n", output );
 
-        // The .NET host refuses to run before MSBuild is even loaded, so this condition is recognized by the prose of
-        // the host and not by a message identifier. See issue #1745.
-        if ( Contains( text, "A compatible .NET SDK was not found" ) || Contains( text, "Requested SDK version" ) )
+        if ( ContainsMessageId( text, "NU1302" ) )
+        {
+            return
+                "A NuGet feed is configured with an insecure HTTP address, which NuGet rejects by default. Give that feed an HTTPS address, "
+                + "or set the allowInsecureConnections attribute of that feed in nuget.config.";
+        }
+
+        // packageSourceMapping applies to the nested build because it inherits the nuget.config of the project, and a
+        // Microsoft.CodeAnalysis.* pattern is more specific than a * pattern. See issue #1747.
+        if ( ContainsMessageId( text, "NU1101" ) )
+        {
+            return
+                "A package that is required to resolve the compile-time reference assemblies was not found on the configured NuGet sources. "
+                + "When nuget.config maps the Microsoft.CodeAnalysis.* pattern to a private feed through packageSourceMapping, this build is "
+                + "restricted to that feed, therefore these packages must be mapped to a source that provides them, such as nuget.org.";
+        }
+
+        if ( ContainsMessageId( text, "NETSDK1045" ) )
+        {
+            return
+                "The .NET SDK that this build resolved is too old for the target frameworks of the reference-assembly project. "
+                + $"Install a more recent .NET SDK, or set the {MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks} MSBuild property "
+                + "to target frameworks that this .NET SDK supports.";
+        }
+
+        // 0xC0000005, that is, STATUS_ACCESS_VIOLATION, reported by MSB6006 as the exit code of a task that crashed. Both
+        // the identifier and the exit code are invariant. See issue #1746.
+        if ( ContainsMessageId( text, "MSB6006" ) && text.IndexOf( "-1073741819", StringComparison.Ordinal ) >= 0 )
+        {
+            return
+                "A tool started by this build terminated abnormally with an access violation. This is a failure of the .NET SDK toolchain "
+                + "and not of Metalama. Verify the integrity of the .NET SDK installation, and consider excluding the build directories "
+                + "from real-time antivirus scanning.";
+        }
+
+        // The nested build is a separate process and therefore does not inherit the interactive credential provider of
+        // the IDE or of the outer build. See issue #1744. NuGet reports the transport failure without a message
+        // identifier on some paths, so the HTTP status code is the only invariant signal available here. It is accepted
+        // only in an output that also contains a URL, so that an unrelated occurrence of the number does not match.
+        if ( _unauthorizedStatusCodeRegex.IsMatch( text ) && text.IndexOf( "http", StringComparison.OrdinalIgnoreCase ) >= 0 )
+        {
+            return
+                "A NuGet feed refused the request with an HTTP authentication error. This build runs in a separate process, "
+                + "which does not inherit the interactive credential provider of the outer build, therefore the credentials of the feed "
+                + "must be available without user interaction, typically in a nuget.config file or through a credential provider.";
+        }
+
+        if ( ContainsMessageId( text, "NU1301" ) )
+        {
+            return
+                "A NuGet feed could not be reached. Verify that the feed is available from this computer and that the "
+                + "network configuration of the build environment allows the build to reach it.";
+        }
+
+        // When the .NET host cannot satisfy the SDK version that a global.json requests, it fails before MSBuild is
+        // loaded, so the output carries no message identifier at all. The file name is the only invariant signal, which
+        // is why this rule comes after every rule based on an identifier. See issue #1745.
+        if ( text.IndexOf( "global.json", StringComparison.OrdinalIgnoreCase ) >= 0 )
         {
             // Metalama writes a global.json beside the reference-assembly project to pin the .NET SDK to the version that
             // builds the project. Blaming the user's global.json when the file at fault is that one would send the user
@@ -104,112 +176,57 @@ internal static class ReferenceAssemblyBuildFailureClassifier
                 + "Install the requested version of the .NET SDK, or change global.json so that it requests a version that is installed.";
         }
 
-        // The nested build is a separate process and therefore does not inherit the interactive credential provider of
-        // the IDE or of the outer build. See issue #1744.
-        if ( Contains( text, "401 (Unauthorized)" ) || Contains( text, "403 (Forbidden)" ) )
-        {
-            return
-                "A NuGet feed refused the request because no valid credentials were supplied. This build runs in a separate process, "
-                + "which does not inherit the interactive credential provider of the outer build, therefore the credentials of the feed "
-                + "must be available without user interaction, typically in a nuget.config file or through a credential provider.";
-        }
-
-        if ( Contains( text, "NU1302" ) )
-        {
-            return
-                "A NuGet feed is configured with an insecure HTTP address, which NuGet rejects by default. Give that feed an HTTPS address, "
-                + "or set the allowInsecureConnections attribute of that feed in nuget.config.";
-        }
-
-        // packageSourceMapping applies to the nested build because it inherits the nuget.config of the project, and a
-        // Microsoft.CodeAnalysis.* pattern is more specific than a * pattern. See issue #1747.
-        if ( Contains( text, "NU1101" ) )
-        {
-            return
-                "A package that is required to resolve the compile-time reference assemblies was not found on the configured NuGet sources. "
-                + "When nuget.config maps the Microsoft.CodeAnalysis.* pattern to a private feed through packageSourceMapping, this build is "
-                + "restricted to that feed, therefore these packages must be mapped to a source that provides them, such as nuget.org.";
-        }
-
-        if ( Contains( text, "NU1301" ) || Contains( text, "Unable to load the service index for source" ) )
-        {
-            return
-                "A NuGet feed could not be reached. Verify that the feed is available from this computer and that the "
-                + "network configuration of the build environment allows the build to reach it.";
-        }
-
-        if ( Contains( text, "NETSDK1045" ) )
-        {
-            return
-                "The .NET SDK that this build resolved is too old for the target frameworks of the reference-assembly project. "
-                + $"Install a more recent .NET SDK, or set the {MSBuildPropertyNames.MetalamaCompileTimeTargetFrameworks} MSBuild property "
-                + "to target frameworks that this .NET SDK supports.";
-        }
-
-        if ( Contains( text, "of MSBuild" ) && Contains( text, "requires at least version" ) )
-        {
-            return
-                "The version of MSBuild that this build used is older than the version required by the .NET SDK that it resolved. "
-                + "Build with a version of MSBuild or of Visual Studio that matches the .NET SDK, or request an older .NET SDK in a "
-                + "global.json file.";
-        }
-
-        // 0xC0000005, that is, STATUS_ACCESS_VIOLATION, reported by MSB6006 for a task that crashed. See issue #1746.
-        if ( Contains( text, "-1073741819" ) )
-        {
-            return
-                "A tool started by this build terminated abnormally with an access violation. This is a failure of the .NET SDK toolchain "
-                + "and not of Metalama. Verify the integrity of the .NET SDK installation, and consider excluding the build directories "
-                + "from real-time antivirus scanning.";
-        }
-
         return
             "The cause of this failure is generally the build environment, typically the .NET SDK installation or the NuGet configuration, "
             + "and not a defect of Metalama.";
     }
 
     /// <summary>
-    /// Returns the sentence that quotes the errors that the nested build reported, folded into a single line because a
-    /// Roslyn diagnostic cannot contain line breaks.
+    /// Returns the sentence that quotes the lines of the output that explain the failure, folded into a single line
+    /// because a Roslyn diagnostic cannot contain line breaks.
     /// </summary>
+    /// <remarks>
+    /// The lines that carry a message identifier are preferred, because they are the diagnostics of the child build and
+    /// can be recognized whatever the language of the toolchain. When the output carries none, as when the .NET host
+    /// fails before MSBuild is loaded, the last lines are quoted instead: they cannot be recognized as errors without
+    /// depending on the language, but they are where a failing build explains itself.
+    /// </remarks>
     public static string GetReportedErrors( ImmutableArray<string> output )
     {
-        var errorLines = GetErrorLines( output );
+        var errorLines = GetLinesWithMessageId( output );
 
-        if ( errorLines.Count == 0 )
+        if ( errorLines.Count > 0 )
         {
-            // Either the build failed before it could report a diagnostic, as when the .NET host cannot satisfy a
-            // global.json, or the output was empty. The last lines are then the informative ones.
-            errorLines = output
-                .Select( Normalize )
-                .Where( line => line.Length > 0 )
-                .Reverse()
-                .Take( _maxReportedErrorCount )
-                .Reverse()
-                .ToReadOnlyList();
-
-            if ( errorLines.Count == 0 )
-            {
-                return "It did not produce any output.";
-            }
-
-            return "Its last output lines were the following: " + Truncate( string.Join( " ", errorLines ) );
+            return "It reported the following errors: " + Truncate( string.Join( " ", errorLines ) );
         }
 
-        return "It reported the following errors: " + Truncate( string.Join( " ", errorLines ) );
+        var lastLines = output
+            .Select( Normalize )
+            .Where( line => line.Length > 0 )
+            .Reverse()
+            .Take( _maxReportedErrorCount )
+            .Reverse()
+            .ToReadOnlyList();
+
+        if ( lastLines.Count == 0 )
+        {
+            return "It did not produce any output.";
+        }
+
+        return "Its last output lines were the following: " + Truncate( string.Join( " ", lastLines ) );
     }
 
     /// <summary>
-    /// Returns the distinct error lines of the output, in the order in which they were produced.
+    /// Returns the distinct lines of the output that carry a message identifier, in the order in which they were produced.
     /// </summary>
-    private static IReadOnlyList<string> GetErrorLines( ImmutableArray<string> output )
+    private static IReadOnlyList<string> GetLinesWithMessageId( ImmutableArray<string> output )
     {
         var errorLines = new List<string>();
         var seenErrorLines = new HashSet<string>( StringComparer.Ordinal );
 
         foreach ( var line in output )
         {
-            if ( !_messageIdRegex.IsMatch( line ) && !_englishErrorRegex.IsMatch( line ) )
+            if ( !_messageIdRegex.IsMatch( line ) )
             {
                 continue;
             }
@@ -242,7 +259,34 @@ internal static class ReferenceAssemblyBuildFailureClassifier
         return index > 0 && line.EndsWith( "]", StringComparison.Ordinal ) ? line.Substring( 0, index ) : line;
     }
 
-    private static bool Contains( string text, string value ) => text.IndexOf( value, StringComparison.OrdinalIgnoreCase ) >= 0;
+    /// <summary>
+    /// Determines whether the output contains the given message identifier, which must be followed by a colon so that an
+    /// occurrence in prose, such as a suggestion to consult the documentation of that message, does not match.
+    /// </summary>
+    private static bool ContainsMessageId( string text, string messageId )
+    {
+        var index = 0;
+
+        while ( (index = text.IndexOf( messageId, index, StringComparison.OrdinalIgnoreCase )) >= 0 )
+        {
+            var end = index + messageId.Length;
+
+            // Skip the whitespace that some loggers insert between the identifier and the colon.
+            while ( end < text.Length && text[end] == ' ' )
+            {
+                end++;
+            }
+
+            if ( end < text.Length && text[end] == ':' )
+            {
+                return true;
+            }
+
+            index += messageId.Length;
+        }
+
+        return false;
+    }
 
     /// <summary>
     /// Folds a line of the output into a form that can appear in a Roslyn diagnostic, which cannot contain line breaks.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticException.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticException.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
+using System.Reflection;
 
 namespace Metalama.Framework.Engine.Diagnostics
 {
@@ -15,7 +16,11 @@ namespace Metalama.Framework.Engine.Diagnostics
     /// the responsibility can be put on the user. This exception type is typically not observed out of Metalama code,
     ///  and should be handled properly.
     /// </summary>
-    internal sealed class DiagnosticException : Exception
+    /// <remarks>
+    /// The type is public, although it cannot be instantiated outside of Metalama, because the exception handlers of the
+    /// design-time assemblies must recognize it in order to report the diagnostics that it carries instead of a crash.
+    /// </remarks>
+    public sealed class DiagnosticException : Exception
     {
         public ImmutableArray<Diagnostic> Diagnostics { get; }
 
@@ -40,5 +45,25 @@ namespace Metalama.Framework.Engine.Diagnostics
 
         private static string GetMessage( string message, IReadOnlyList<Diagnostic> diagnostics )
             => message + Environment.NewLine + string.Join( Environment.NewLine, diagnostics.Where( d => d.Severity == DiagnosticSeverity.Error ) );
+
+        /// <summary>
+        /// Returns the <see cref="DiagnosticException"/> carried by <paramref name="exception"/>, or <c>null</c> when
+        /// <paramref name="exception"/> does not represent a user-attributable failure.
+        /// </summary>
+        /// <remarks>
+        /// A <see cref="DiagnosticException"/> thrown deep in the pipeline reaches the exception handlers wrapped in the
+        /// exception types that the intermediate infrastructure adds, typically an <see cref="AggregateException"/> when
+        /// the pipeline was invoked synchronously from a design-time entry point. Only these wrappers are unwrapped: an
+        /// exception of any other type means that a defect intervened between the diagnostic and the handler, and such a
+        /// failure must still be reported as a crash.
+        /// </remarks>
+        public static DiagnosticException? TryFind( Exception exception )
+            => exception switch
+            {
+                DiagnosticException diagnosticException => diagnosticException,
+                AggregateException { InnerExceptions.Count: 1 } aggregateException => TryFind( aggregateException.InnerExceptions[0] ),
+                TargetInvocationException { InnerException: { } innerException } => TryFind( innerException ),
+                _ => null
+            };
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticException.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticException.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Reflection;
+using System.Text.RegularExpressions;
 
 namespace Metalama.Framework.Engine.Diagnostics
 {
@@ -22,6 +23,8 @@ namespace Metalama.Framework.Engine.Diagnostics
     /// </remarks>
     public sealed class DiagnosticException : Exception
     {
+        private static readonly Regex _whitespaceRegex = new( @"\s+", RegexOptions.CultureInvariant );
+
         public ImmutableArray<Diagnostic> Diagnostics { get; }
 
         /// <summary>
@@ -45,6 +48,17 @@ namespace Metalama.Framework.Engine.Diagnostics
 
         private static string GetMessage( string message, IReadOnlyList<Diagnostic> diagnostics )
             => message + Environment.NewLine + string.Join( Environment.NewLine, diagnostics.Where( d => d.Severity == DiagnosticSeverity.Error ) );
+
+        /// <summary>
+        /// Returns <see cref="Exception.Message"/> folded onto a single line, for a log record.
+        /// </summary>
+        /// <remarks>
+        /// The message concatenates the diagnostics with <see cref="Environment.NewLine"/>, and a diagnostic message
+        /// may itself contain a line break, so logging it as it is produces a multi-line log record. The text is not
+        /// truncated: a log record is the only remaining trace of a failure that is deliberately not reported as a
+        /// crash, so its length is preferable to its loss.
+        /// </remarks>
+        public string GetSingleLineMessage() => _whitespaceRegex.Replace( this.Message, " " ).Trim();
 
         /// <summary>
         /// Returns the <see cref="DiagnosticException"/> carried by <paramref name="exception"/>, or <c>null</c> when

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
@@ -502,6 +502,35 @@ namespace Metalama.Framework.Engine.Diagnostics
                 Error,
                 "An aspect weaver is provided by several assemblies." );
 
+        // The nested build that resolves the compile-time reference assemblies fails almost exclusively for reasons that
+        // belong to the environment (a NuGet feed that requires credentials, a global.json that pins an absent .NET SDK,
+        // an MSBuild older than the .NET SDK), and the child process has already explained the failure in its own output.
+        // Surfacing that as LAMA0001 presented a legible, self-service condition as a defect of Metalama and invited a
+        // crash report. These two diagnostics replace the exception. See #1744, #1745, #1746 and #1747.
+        internal static readonly DiagnosticDefinition<(string ProjectPath, int ExitCode, string ReportedErrors, string ProbableCause, string BinaryLogPath)>
+            ReferenceAssemblyBuildFailed =
+                new(
+                    "LAMA0082",
+                    Error,
+                    "Metalama could not build the internal project that resolves the compile-time reference assemblies, therefore the compilation "
+                    + "cannot continue. The build of '{0}' exited with code {1}. {2} {3} The binary log of that build is '{4}'.",
+                    "The build of the reference-assembly project failed.",
+                    _category );
+
+        // A separate diagnostic from ReferenceAssemblyBuildFailed because the remedy is different: there is no output to
+        // interpret, and the timeout itself is configurable. See #1740.
+        internal static readonly DiagnosticDefinition<(string ProjectPath, float Seconds, string TimeoutPropertyName, string BinaryLogPath)>
+            ReferenceAssemblyBuildTimedOut =
+                new(
+                    "LAMA0083",
+                    Error,
+                    "Metalama could not build the internal project that resolves the compile-time reference assemblies, therefore the compilation "
+                    + "cannot continue. The build of '{0}' did not complete within {1} s and was terminated. If this build is merely slow, for "
+                    + "instance because it must download NuGet packages, raise the timeout by setting the '{2}' MSBuild property to a higher value, "
+                    + "expressed in milliseconds. The binary log of that build, if it was written, is '{3}'.",
+                    "The build of the reference-assembly project timed out.",
+                    _category );
+
         // TODO: Use formattable string (C# does not seem to find extension methods).
         internal static readonly DiagnosticDefinition<string>
             UnsupportedFeature = new(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/GeneralDiagnosticDescriptors.cs
@@ -531,6 +531,19 @@ namespace Metalama.Framework.Engine.Diagnostics
                     "The build of the reference-assembly project timed out.",
                     _category );
 
+        // The value of this property is written by the user and can only be corrected by the user, so an invalid one is
+        // a diagnostic and not an exception. It used to throw an InvalidOperationException, which surfaced as LAMA0001
+        // and invited a crash report for a configuration mistake. See #1789.
+        internal static readonly DiagnosticDefinition<(string PropertyName, string Value, string Requirement)>
+            InvalidCompileTimeTargetFrameworks =
+                new(
+                    "LAMA0084",
+                    Error,
+                    "The '{0}' MSBuild property has the value '{1}', which is not valid because {2}. Separate the target "
+                    + "frameworks with a semicolon or with a comma.",
+                    "The MSBuild property that selects the compile-time target frameworks is invalid.",
+                    _category );
+
         // TODO: Use formattable string (C# does not seem to find extension methods).
         internal static readonly DiagnosticDefinition<string>
             UnsupportedFeature = new(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/AspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/AspectPipeline.cs
@@ -82,6 +82,20 @@ public abstract class AspectPipeline : IDisposable
 
     protected abstract SyntaxGenerationOptions GetSyntaxGenerationOptions();
 
+    /// <summary>
+    /// Resolves the compile-time reference assemblies of the project, and reports to <paramref name="diagnostics"/>
+    /// and returns <c>false</c> when they cannot be resolved.
+    /// </summary>
+    /// <remarks>
+    /// Resolving them runs a nested build, which fails for reasons that belong to the environment rather than to
+    /// Metalama. A pipeline calls this method at its entry point, which is the first point that has a diagnostic sink,
+    /// so that the failure becomes one of its own diagnostics instead of an exception thrown through the layers above.
+    /// Every later use of the locator in the same project then finds it already resolved. See issue #1744.
+    /// </remarks>
+    protected bool TryResolveReferenceAssemblies( IDiagnosticAdder diagnostics )
+        => this.ServiceProvider.Global.GetRequiredService<ICompileTimeAssemblyLocatorProvider>()
+            .TryGetInstance( this.ServiceProvider, diagnostics, out _ );
+
     protected virtual bool TryInitialize(
         IDiagnosticAdder diagnosticAdder,
         Compilation compilation,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
@@ -100,6 +100,15 @@ public class CompileTimeAspectPipeline : AspectPipeline
     {
         reportDiagnostic ??= _ => { };
 
+        // The compile-time reference assemblies are resolved here, before anything else needs them, because this is the
+        // first point of the pipeline that has a diagnostic sink. Resolving them runs a nested build, which fails for
+        // reasons that belong to the environment, and such a failure must be reported as a diagnostic of this pipeline
+        // instead of being thrown through the layers above. See issue #1744.
+        if ( !this.ServiceProvider.TryResolveReferenceAssemblies( new DiagnosticAdderAdapter( reportDiagnostic ) ) )
+        {
+            return default;
+        }
+
         var compilationContext = this.ServiceProvider.GetRequiredService<ClassifyingCompilationContextFactory>().GetInstance( compilation );
         var partialCompilation = PartialCompilation.CreateComplete( compilation );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeAspectPipeline.cs
@@ -104,7 +104,7 @@ public class CompileTimeAspectPipeline : AspectPipeline
         // first point of the pipeline that has a diagnostic sink. Resolving them runs a nested build, which fails for
         // reasons that belong to the environment, and such a failure must be reported as a diagnostic of this pipeline
         // instead of being thrown through the layers above. See issue #1744.
-        if ( !this.ServiceProvider.TryResolveReferenceAssemblies( new DiagnosticAdderAdapter( reportDiagnostic ) ) )
+        if ( !this.TryResolveReferenceAssemblies( new DiagnosticAdderAdapter( reportDiagnostic ) ) )
         {
             return default;
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
@@ -105,7 +105,7 @@ namespace Metalama.Framework.Engine.Pipeline.CompileTime
             // NuGet feed that requires credentials, as a defect of Metalama. See #1744.
             if ( DiagnosticException.TryFind( exception ) is { } diagnosticException )
             {
-                this._logger.Warning?.Log( $"A user-attributable failure was reported as a diagnostic: {diagnosticException.Message}" );
+                this._logger.Warning?.Log( $"A user-attributable failure was reported as a diagnostic: {diagnosticException.GetSingleLineMessage()}" );
 
                 foreach ( var diagnostic in diagnosticException.Diagnostics )
                 {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/CompileTimeExceptionHandler.cs
@@ -99,6 +99,24 @@ namespace Metalama.Framework.Engine.Pipeline.CompileTime
                 exception = innerExceptions[0];
             }
 
+            // A DiagnosticException means that the failure has already been analyzed and that the responsibility for it
+            // lies with the user or with the build environment. Report the diagnostics that it carries, and neither write
+            // a crash report nor send telemetry: doing so would present a legible and self-service condition, such as a
+            // NuGet feed that requires credentials, as a defect of Metalama. See #1744.
+            if ( DiagnosticException.TryFind( exception ) is { } diagnosticException )
+            {
+                this._logger.Warning?.Log( $"A user-attributable failure was reported as a diagnostic: {diagnosticException.Message}" );
+
+                foreach ( var diagnostic in diagnosticException.Diagnostics )
+                {
+                    reportDiagnostic( diagnostic );
+                }
+
+                isHandled = true;
+
+                return;
+            }
+
             SyntaxNode? node = null;
 
             if ( exception is SyntaxProcessingException syntaxProcessingException )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Services/ServiceProviderExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Services/ServiceProviderExtensions.cs
@@ -5,7 +5,6 @@
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Framework.Engine.CompileTime;
-using Metalama.Framework.Engine.Diagnostics;
 
 namespace Metalama.Framework.Engine.Services;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Services/ServiceProviderExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Services/ServiceProviderExtensions.cs
@@ -5,6 +5,7 @@
 using Metalama.Backstage.Diagnostics;
 using Metalama.Backstage.Extensibility;
 using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.Diagnostics;
 
 namespace Metalama.Framework.Engine.Services;
 
@@ -20,6 +21,19 @@ public static class ServiceProviderExtensions
     /// </summary>
     internal static CompileTimeAssemblyLocator GetReferenceAssemblyLocator( this ProjectServiceProvider serviceProvider )
         => serviceProvider.Global.GetRequiredService<ICompileTimeAssemblyLocatorProvider>().GetInstance( serviceProvider );
+
+    /// <summary>
+    /// Resolves the compile-time reference assemblies of a project, and reports to <paramref name="diagnostics"/> and
+    /// returns <c>false</c> when they cannot be resolved.
+    /// </summary>
+    /// <remarks>
+    /// Resolving them runs a nested build, which fails for reasons that belong to the environment rather than to
+    /// Metalama. A pipeline calls this method at its entry point, where it has a diagnostic sink, so that the failure
+    /// becomes one of its own diagnostics. Every later use of the locator in the same project then finds it already
+    /// resolved. See issue #1744.
+    /// </remarks>
+    public static bool TryResolveReferenceAssemblies( this ProjectServiceProvider serviceProvider, IDiagnosticAdder diagnostics )
+        => serviceProvider.Global.GetRequiredService<ICompileTimeAssemblyLocatorProvider>().TryGetInstance( serviceProvider, diagnostics, out _ );
 
     public static T GetRequiredBackstageService<T>( this GlobalServiceProvider serviceProvider )
         where T : class, IBackstageService

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Services/ServiceProviderExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Services/ServiceProviderExtensions.cs
@@ -22,18 +22,6 @@ public static class ServiceProviderExtensions
     internal static CompileTimeAssemblyLocator GetReferenceAssemblyLocator( this ProjectServiceProvider serviceProvider )
         => serviceProvider.Global.GetRequiredService<ICompileTimeAssemblyLocatorProvider>().GetInstance( serviceProvider );
 
-    /// <summary>
-    /// Resolves the compile-time reference assemblies of a project, and reports to <paramref name="diagnostics"/> and
-    /// returns <c>false</c> when they cannot be resolved.
-    /// </summary>
-    /// <remarks>
-    /// Resolving them runs a nested build, which fails for reasons that belong to the environment rather than to
-    /// Metalama. A pipeline calls this method at its entry point, where it has a diagnostic sink, so that the failure
-    /// becomes one of its own diagnostics. Every later use of the locator in the same project then finds it already
-    /// resolved. See issue #1744.
-    /// </remarks>
-    public static bool TryResolveReferenceAssemblies( this ProjectServiceProvider serviceProvider, IDiagnosticAdder diagnostics )
-        => serviceProvider.Global.GetRequiredService<ICompileTimeAssemblyLocatorProvider>().TryGetInstance( serviceProvider, diagnostics, out _ );
 
     public static T GetRequiredBackstageService<T>( this GlobalServiceProvider serviceProvider )
         where T : class, IBackstageService

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
@@ -7,6 +7,7 @@ using Metalama.Backstage.Infrastructure;
 using Metalama.Framework.Engine.Services;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 
@@ -99,14 +100,18 @@ public sealed class DotNetTool
                 // ignored
             }
 
-            throw new AssertionFailedException( $"The process '{startInfo.FileName} {startInfo.Arguments}' did not complete in {timeout / 1000f} s." );
+            throw ProcessFailedException.CreateTimeout( startInfo.FileName, startInfo.Arguments, startInfo.WorkingDirectory, timeout );
         }
 
         if ( process.ExitCode != 0 )
         {
-            throw new InvalidOperationException(
-                $"Error calling `\"{this._platformInfo.DotNetExePath}\" {arguments}` in `{startInfo.WorkingDirectory}` returned {process.ExitCode}. Process output:"
-                + Environment.NewLine + Environment.NewLine + string.Join( Environment.NewLine, lines ) );
+            throw ProcessFailedException.CreateNonZeroExitCode(
+                this._platformInfo.DotNetExePath,
+                arguments,
+                startInfo.WorkingDirectory,
+                process.ExitCode,
+                timeout,
+                lines.ToImmutableArray() );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
@@ -5,6 +5,7 @@
 using JetBrains.Annotations;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -97,14 +98,18 @@ public sealed class MSBuildTool
                 // ignored
             }
 
-            throw new AssertionFailedException( $"The process '{this._msBuildExePath} {arguments}' did not complete in {timeout / 1000f} s." );
+            throw ProcessFailedException.CreateTimeout( this._msBuildExePath, arguments, startInfo.WorkingDirectory, timeout );
         }
 
         if ( process.ExitCode != 0 )
         {
-            throw new InvalidOperationException(
-                $"Error calling `\"{this._msBuildExePath}\" {arguments}` in `{startInfo.WorkingDirectory}` returned {process.ExitCode}. Process output:"
-                + Environment.NewLine + Environment.NewLine + string.Join( Environment.NewLine, lines ) );
+            throw ProcessFailedException.CreateNonZeroExitCode(
+                this._msBuildExePath,
+                arguments,
+                startInfo.WorkingDirectory,
+                process.ExitCode,
+                timeout,
+                lines.ToImmutableArray() );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/ProcessFailedException.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/ProcessFailedException.cs
@@ -1,0 +1,106 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using JetBrains.Annotations;
+using System;
+using System.Collections.Immutable;
+
+namespace Metalama.Framework.Engine.Utilities;
+
+/// <summary>
+/// The exception thrown by <see cref="DotNetTool"/> and <see cref="MSBuildTool"/> when the child process fails, either
+/// because it returned a non-zero exit code or because it did not complete within the allowed time.
+/// </summary>
+/// <remarks>
+/// The console output of the child process is exposed as <see cref="Output"/> instead of being available only as prose
+/// inside <see cref="Exception.Message"/>, so that the caller can analyse the failure and report it as a diagnostic.
+/// See issue #1744.
+/// </remarks>
+[PublicAPI]
+public sealed class ProcessFailedException : InvalidOperationException
+{
+    /// <summary>
+    /// Gets the path of the executable that was started.
+    /// </summary>
+    public string FileName { get; }
+
+    /// <summary>
+    /// Gets the command-line arguments that were passed to the process.
+    /// </summary>
+    public string Arguments { get; }
+
+    /// <summary>
+    /// Gets the working directory of the process.
+    /// </summary>
+    public string WorkingDirectory { get; }
+
+    /// <summary>
+    /// Gets the exit code of the process, or <c>null</c> when the process was terminated because it exceeded
+    /// <see cref="Timeout"/>.
+    /// </summary>
+    public int? ExitCode { get; }
+
+    /// <summary>
+    /// Gets the time, in milliseconds, that the process was allowed to run.
+    /// </summary>
+    public int Timeout { get; }
+
+    /// <summary>
+    /// Gets the standard output and standard error of the process, one item per line.
+    /// </summary>
+    /// <remarks>
+    /// The collection is empty when the process was terminated because of a timeout, because the output of an
+    /// unfinished build is not meaningful.
+    /// </remarks>
+    public ImmutableArray<string> Output { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the process was terminated because it exceeded <see cref="Timeout"/>.
+    /// </summary>
+    public bool HasTimedOut => this.ExitCode == null;
+
+    private ProcessFailedException(
+        string message,
+        string fileName,
+        string arguments,
+        string workingDirectory,
+        int? exitCode,
+        int timeout,
+        ImmutableArray<string> output ) : base( message )
+    {
+        this.FileName = fileName;
+        this.Arguments = arguments;
+        this.WorkingDirectory = workingDirectory;
+        this.ExitCode = exitCode;
+        this.Timeout = timeout;
+        this.Output = output;
+    }
+
+    internal static ProcessFailedException CreateTimeout( string fileName, string arguments, string workingDirectory, int timeout )
+        => new(
+            $"The process '{fileName} {arguments}' did not complete in {timeout / 1000f} s.",
+            fileName,
+            arguments,
+            workingDirectory,
+            null,
+            timeout,
+            ImmutableArray<string>.Empty );
+
+    internal static ProcessFailedException CreateNonZeroExitCode(
+        string fileName,
+        string arguments,
+        string workingDirectory,
+        int exitCode,
+        int timeout,
+        ImmutableArray<string> output )
+        => new(
+            $"Error calling `\"{fileName}\" {arguments}` in `{workingDirectory}` returned {exitCode}. Process output:"
+            + Environment.NewLine + Environment.NewLine + string.Join( Environment.NewLine, output ),
+            fileName,
+            arguments,
+            workingDirectory,
+            exitCode,
+            timeout,
+            output );
+}

--- a/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
+++ b/Metalama.Framework/src/Metalama.Framework.Package/build/Metalama.Framework.targets
@@ -71,6 +71,11 @@
         <MetalamaExtensionAssemblies>@(MetalamaExtensionAssembly -> '%(FullPath)|%(TargetFramework)|%(TargetRoslynVersion)', ',')</MetalamaExtensionAssemblies>
         <MetalamaDesignTimeExtensionAssemblies>@(MetalamaDesignTimeExtensionAssembly -> '%(FullPath)|%(TargetFramework)|%(TargetRoslynVersion)', ',')</MetalamaDesignTimeExtensionAssemblies>
 
+        <!-- Normalize the separator of the following property for the same reason. Unlike the properties above, it is
+             written by the user, who naturally separates target frameworks with the ';' that is customary in MSBuild.
+             Left as such, everything after the first ';' would be read as a comment and silently dropped. See #1789. -->
+        <MetalamaCompileTimeTargetFrameworks Condition="'$(MetalamaCompileTimeTargetFrameworks)'!=''">$(MetalamaCompileTimeTargetFrameworks.Replace(';', ','))</MetalamaCompileTimeTargetFrameworks>
+
         <!-- Elevating CS8032: An instance of analyzer X cannot be created. 
              We elevate this warning to an error because otherwise, if Metalama.Framework fails to load, the compilation will be incorrect while there
              will be no warning. Troubleshooting this issue may be very complex without a real error.     -->

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Aspect.cs
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Aspect.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+namespace Issue1744;
+
+/// <summary>
+/// An aspect, whose only purpose is to make the compile-time pipeline initialize, which is what runs the nested
+/// reference-assembly build that this scenario makes fail.
+/// </summary>
+public class Aspect : TypeAspect
+{
+    [Introduce]
+    public string GetMessage() => "ok";
+}

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/AssemblyLocatorHooks/Metalama.AssemblyLocator.Build.targets
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/AssemblyLocatorHooks/Metalama.AssemblyLocator.Build.targets
@@ -1,0 +1,17 @@
+<Project>
+
+    <!--
+        Imported into the temporary project whose build resolves the compile-time reference assemblies, through the
+        MetalamaAssemblyLocatorHooksDirectory property. It fails that build on purpose, which is what this scenario
+        exists to observe.
+
+        The failure has to be one that the build cannot recover from and that leaves no result behind: the assembly
+        locator caches the list of reference assemblies, so a provocation that lets the build complete would populate
+        the cache and every later run would silently assert nothing. Failing before the WriteAssembliesList target
+        keeps the cache empty for good.
+    -->
+    <Target Name="_FailReferenceAssemblyBuildOnPurpose" BeforeTargets="Build">
+        <Error Text="The reference-assembly build is failed on purpose by the Issue1744 test scenario." />
+    </Target>
+
+</Project>

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Issue1744.csproj
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Issue1744.csproj
@@ -4,15 +4,19 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <!-- The shared compiler server outlives a build and can serve a compile-time assembly locator that a
+             previous compilation created successfully, which would keep this scenario from reaching the failure
+             it exists to observe. Each compilation must therefore start from a fresh compiler process. -->
+        <UseSharedCompilation>false</UseSharedCompilation>
     </PropertyGroup>
 
     <PropertyGroup>
-        <!-- Makes the nested reference-assembly build fail, deterministically and without network access: no process
-             can start and complete within one millisecond, so the assembly locator kills it and reports a timeout.
-             The salt keeps this scenario on a cache directory of its own; the cache is never populated, because the
-             build never completes, so every run exercises the failure. See README.md. -->
-        <MetalamaReferenceAssemblyRestoreTimeout>1</MetalamaReferenceAssemblyRestoreTimeout>
-        <MetalamaAssemblyLocatorSalt>Issue1744</MetalamaAssemblyLocatorSalt>
+        <!-- Makes the nested reference-assembly build fail, deterministically and without network access: the hooks
+             directory below is imported into the temporary project and raises an error before anything is produced.
+             The salt keeps this scenario on a cache directory of its own, which the failing build never populates, so
+             every run exercises the failure rather than reading a cached result. See README.md. -->
+        <MetalamaAssemblyLocatorHooksDirectory>$(MSBuildThisFileDirectory)AssemblyLocatorHooks</MetalamaAssemblyLocatorHooksDirectory>
+        <MetalamaAssemblyLocatorSalt>Issue1744.HooksFailure.DesignTime</MetalamaAssemblyLocatorSalt>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Issue1744.csproj
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Issue1744.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Makes the nested reference-assembly build fail, deterministically and without network access: no process
+             can start and complete within one millisecond, so the assembly locator kills it and reports a timeout.
+             The salt keeps this scenario on a cache directory of its own; the cache is never populated, because the
+             build never completes, so every run exercises the failure. See README.md. -->
+        <MetalamaReferenceAssemblyRestoreTimeout>1</MetalamaReferenceAssemblyRestoreTimeout>
+        <MetalamaAssemblyLocatorSalt>Issue1744</MetalamaAssemblyLocatorSalt>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Metalama.Framework" />
+    </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Issue1744.sln
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Issue1744.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Issue1744", "Issue1744.csproj", "{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Debug|x64.Build.0 = Debug|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Debug|x86.Build.0 = Debug|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Release|x64.ActiveCfg = Release|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Release|x64.Build.0 = Release|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Release|x86.ActiveCfg = Release|Any CPU
+		{2CBD0724-6547-49CA-ADC0-E1C09E1C7773}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Program.cs
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/Program.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Issue1744;
+
+[Aspect]
+internal static class Program
+{
+    private static void Main() => System.Console.WriteLine( "ok" );
+}

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/README.md
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/README.md
@@ -1,0 +1,23 @@
+# Issue1744 (design time)
+
+Asserts that a failure of the nested reference-assembly build degrades the design-time experience gracefully: the
+analysis does not crash, does not report `LAMA0001` and does not let the exception escape into `AD0001`. See issues
+#1744, #1745, #1746 and #1747.
+
+The failure is provoked exactly as in the standalone scenario of the same name: `MetalamaReferenceAssemblyRestoreTimeout`
+is set to one millisecond, so the nested build is killed before it can complete. The design-time pipeline reaches that
+build through `SystemTypeResolver`, exactly as the compile-time pipeline does.
+
+The pre-build that the harness runs before the host simulator fails here, which is expected and ignored: a design-time
+scenario is allowed to be one that does not compile.
+
+## What this scenario does and does not assert
+
+It asserts that the design-time host survives the condition. It does **not** assert that the user is told about it: at
+design time the exception is caught by `TheDiagnosticAnalyzer` and no diagnostic reaches the editor, so there is
+nothing for the simulator to observe beyond the absence of a crash. Surfacing the condition in the IDE is a separate
+concern, tracked by #1758.
+
+What changed with #1744 on this path is therefore not observable here: the failure is now recognized as a
+`DiagnosticException`, so it is neither written as a crash report nor sent as a telemetry report. This scenario guards
+the part that is observable, namely that the analysis continues to degrade gracefully rather than throwing.

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/README.md
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/README.md
@@ -1,24 +1,25 @@
 # Issue1744 (design time)
 
-Asserts that a failure of the nested reference-assembly build degrades the design-time experience gracefully: the
-analysis does not crash, does not report `LAMA0001` and does not let the exception escape into `AD0001`. See issues
-#1744, #1745, #1746 and #1747.
+Asserts that a failure of the nested reference-assembly build is reported to the user at design time, as the
+`LAMA0082` diagnostic of the design-time pipeline, and that it does not escape as an exception. See issues #1744,
+#1745, #1746 and #1747.
 
 The failure is provoked exactly as in the standalone scenario of the same name: `MetalamaAssemblyLocatorHooksDirectory`
 points at a targets file that is imported into the temporary reference-assembly project and fails its build. The
-design-time pipeline reaches that build through `SystemTypeResolver`, exactly as the compile-time pipeline does. See
-the standalone `README.md` for why the scenario also sets a locator salt and disables the shared compiler.
+design-time pipeline reaches that build through its own entry point, exactly as the compile-time pipeline does. See the
+standalone `README.md` for why the scenario also sets a locator salt and disables the shared compiler.
 
 The pre-build that the harness runs before the host simulator fails here, which is expected and ignored: a design-time
 scenario is allowed to be one that does not compile.
 
-## What this scenario does and does not assert
+## What this scenario asserts
 
-It asserts that the design-time host survives the condition. It does **not** assert that the user is told about it: at
-design time the exception is caught by `TheDiagnosticAnalyzer` and no diagnostic reaches the editor, so there is
-nothing for the simulator to observe beyond the absence of a crash. Surfacing the condition in the IDE is a separate
-concern, tracked by #1758.
-
-What changed with #1744 on this path is therefore not observable here: the failure is now recognized as a
-`DiagnosticException`, so it is neither written as a crash report nor sent as a telemetry report. This scenario guards
-the part that is observable, namely that the analysis continues to degrade gracefully rather than throwing.
+- `LAMA0082` is reported. The design-time pipeline resolves the compile-time reference assemblies at its entry point,
+  where it has a diagnostic sink, so the failure is returned as a failed result carrying the diagnostic, and
+  `TheDiagnosticAnalyzer` reports the diagnostics of a failed result. The user therefore sees the same actionable
+  message in the editor as in a build.
+- `CS8785` is **not** reported. Before this was fixed, the failure travelled as an exception, which escaped
+  `BaseSourceGenerator`. That class rethrows on purpose, so Roslyn reported `CS8785`, telling the user only that a
+  generator had failed, and the host simulator counted the project as failed.
+- `LAMA0001` and `AD0001` are **not** reported: the condition belongs to the environment and must be presented neither
+  as a defect of Metalama nor as an analyzer that threw.

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/README.md
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/README.md
@@ -4,9 +4,10 @@ Asserts that a failure of the nested reference-assembly build degrades the desig
 analysis does not crash, does not report `LAMA0001` and does not let the exception escape into `AD0001`. See issues
 #1744, #1745, #1746 and #1747.
 
-The failure is provoked exactly as in the standalone scenario of the same name: `MetalamaReferenceAssemblyRestoreTimeout`
-is set to one millisecond, so the nested build is killed before it can complete. The design-time pipeline reaches that
-build through `SystemTypeResolver`, exactly as the compile-time pipeline does.
+The failure is provoked exactly as in the standalone scenario of the same name: `MetalamaAssemblyLocatorHooksDirectory`
+points at a targets file that is imported into the temporary reference-assembly project and fails its build. The
+design-time pipeline reaches that build through `SystemTypeResolver`, exactly as the compile-time pipeline does. See
+the standalone `README.md` for why the scenario also sets a locator salt and disables the shared compiler.
 
 The pre-build that the harness runs before the host simulator fails here, which is expected and ignored: a design-time
 scenario is allowed to be one that does not compile.

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/test.json
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/test.json
@@ -1,0 +1,4 @@
+{
+    "BuildOnly": true,
+    "ForbiddenDiagnosticsRegexes": [ "LAMA0001", "AD0001" ]
+}

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/test.json
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1744/test.json
@@ -1,4 +1,5 @@
 {
     "BuildOnly": true,
-    "ForbiddenDiagnosticsRegexes": [ "LAMA0001", "AD0001" ]
+    "ExpectedDiagnosticsRegexes": [ "LAMA0082" ],
+    "ForbiddenDiagnosticsRegexes": [ "LAMA0001", "AD0001", "CS8785" ]
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeExceptionHandlerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeExceptionHandlerTests.cs
@@ -137,6 +137,28 @@ public sealed class CompileTimeExceptionHandlerTests : UnitTestClass
         Assert.DoesNotContain( "\n", message );
     }
 
+    /// <summary>
+    /// The message of a <see cref="DiagnosticException"/> concatenates its diagnostics with line breaks, so the
+    /// exception handlers log the folded rendering instead, otherwise a single failure produces a multi-line log record.
+    /// </summary>
+    [Fact]
+    public void GetSingleLineMessage_HasNoLineBreak()
+    {
+        var diagnostic = GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
+            null,
+            ("TempProject.csproj", 1, "It reported the following errors: error NU1101.", "Probable cause.", "msbuild.binlog") );
+
+        var exception = new DiagnosticException(
+            "The build of 'TempProject.csproj' exited with code 1.",
+            ImmutableArray.Create( diagnostic ),
+            false );
+
+        Assert.Contains( "\n", exception.Message );
+        Assert.DoesNotContain( "\r", exception.GetSingleLineMessage() );
+        Assert.DoesNotContain( "\n", exception.GetSingleLineMessage() );
+        Assert.Contains( GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.Id, exception.GetSingleLineMessage() );
+    }
+
     private sealed class ProjectOptionsStub : DefaultProjectOptions
     {
         public ProjectOptionsStub( string? projectPath )

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeExceptionHandlerTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeExceptionHandlerTests.cs
@@ -9,6 +9,8 @@ using Metalama.Testing.UnitTesting;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Globalization;
 using System.IO;
 using Xunit;
 
@@ -79,6 +81,60 @@ public sealed class CompileTimeExceptionHandlerTests : UnitTestClass
         Assert.Single( diagnostics );
         var report = Assert.Single( testContext.ReportedTelemetryExceptions );
         Assert.Equal( TelemetryRouting.Tooling, report.Routing );
+    }
+
+    /// <summary>
+    /// A <see cref="DiagnosticException"/> carries a failure that has already been analyzed and attributed to the user or
+    /// to the build environment, therefore its diagnostics must be reported as such, with neither a crash report nor
+    /// telemetry. See #1744.
+    /// </summary>
+    [Theory]
+    [InlineData( false )]
+    [InlineData( true )]
+    public void ReportException_DiagnosticException_ReportsItsDiagnosticsAndNoTelemetry( bool wrapInAggregateException )
+    {
+        using var testContext = this.CreateTestContext();
+
+        var serviceProvider = testContext.ServiceProvider.Underlying.WithService(
+            new ProjectOptionsStub( Path.Combine( Path.GetTempPath(), "repo", "proj.csproj" ) ),
+            allowOverride: true );
+
+        var handler = new CompileTimeExceptionHandler( serviceProvider );
+        var diagnostics = new List<Diagnostic>();
+
+        var reportedDiagnostic = GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
+            null,
+            ("TempProject.csproj", 1, "It reported the following errors: error NU1101.", "Probable cause.", "msbuild.binlog") );
+
+        Exception exception = new DiagnosticException( "The nested build failed.", ImmutableArray.Create( reportedDiagnostic ), false );
+
+        if ( wrapInAggregateException )
+        {
+            exception = new AggregateException( exception );
+        }
+
+        handler.ReportException( exception, diagnostics.Add, canIgnoreException: false, out var isHandled );
+
+        Assert.True( isHandled );
+        var diagnostic = Assert.Single( diagnostics );
+        Assert.Equal( GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.Id, diagnostic.Id );
+        Assert.Empty( testContext.ReportedTelemetryExceptions );
+    }
+
+    /// <summary>
+    /// Verifies that the message of the reported diagnostic contains no line break, which a Roslyn diagnostic cannot carry.
+    /// </summary>
+    [Fact]
+    public void ReferenceAssemblyBuildFailed_MessageHasNoLineBreak()
+    {
+        var diagnostic = GeneralDiagnosticDescriptors.ReferenceAssemblyBuildFailed.CreateRoslynDiagnostic(
+            null,
+            ("TempProject.csproj", 1, "It reported the following errors: error NU1101.", "Probable cause.", "msbuild.binlog") );
+
+        var message = diagnostic.GetMessage( CultureInfo.InvariantCulture );
+
+        Assert.DoesNotContain( "\r", message );
+        Assert.DoesNotContain( "\n", message );
     }
 
     private sealed class ProjectOptionsStub : DefaultProjectOptions

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeTargetFrameworksTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/CompileTimeTargetFrameworksTests.cs
@@ -1,0 +1,58 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CompileTime;
+using System.Linq;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime;
+
+/// <summary>
+/// Tests the parsing of the <c>MetalamaCompileTimeTargetFrameworks</c> MSBuild property.
+/// </summary>
+/// <remarks>
+/// The property reaches the compiler through the generated analyzer configuration file, in which a semicolon starts a
+/// comment, so the build normalizes it to the comma-separated form that every other list-valued option uses. Both
+/// separators must be accepted, because a value set directly through <c>IProjectOptions</c>, as in tests, does not go
+/// through that file. See issue #1789.
+/// </remarks>
+public sealed class CompileTimeTargetFrameworksTests
+{
+    [Theory]
+    [InlineData( "netstandard2.0;net8.0;net48" )]
+    [InlineData( "netstandard2.0,net8.0,net48" )]
+    [InlineData( "netstandard2.0; net8.0; net48" )]
+    [InlineData( " netstandard2.0 , net8.0 , net48 " )]
+    public void BothSeparatorsAreAccepted( string value )
+    {
+        var targetFrameworks = CompileTimeAssemblyLocator.ParseTargetFrameworks( value );
+
+        Assert.Equal( new[] { "netstandard2.0", "net8.0", "net48" }, targetFrameworks.ToArray() );
+    }
+
+    [Theory]
+    [InlineData( "netstandard2.0" )]
+    [InlineData( "netstandard2.0;" )]
+    [InlineData( ";netstandard2.0;;" )]
+    public void EmptyEntriesAreDropped( string value )
+    {
+        var targetFrameworks = CompileTimeAssemblyLocator.ParseTargetFrameworks( value );
+
+        Assert.Equal( new[] { "netstandard2.0" }, targetFrameworks.ToArray() );
+    }
+
+    /// <summary>
+    /// Verifies the condition of issue #1789: before the fix, a semicolon-separated value was truncated to its first
+    /// entry, which then failed the requirement of a .NET 6.0 or later target framework and crashed with LAMA0001.
+    /// </summary>
+    [Fact]
+    public void SemicolonSeparatedValueKeepsEveryTargetFramework()
+    {
+        var targetFrameworks = CompileTimeAssemblyLocator.ParseTargetFrameworks( "netstandard2.0;net8.0;net48" );
+
+        Assert.Contains( "netstandard2.0", targetFrameworks );
+        Assert.Contains( "net8.0", targetFrameworks );
+        Assert.Contains( "net48", targetFrameworks );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/ReferenceAssemblyBuildFailureClassifierTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/ReferenceAssemblyBuildFailureClassifierTests.cs
@@ -26,16 +26,33 @@ public sealed class ReferenceAssemblyBuildFailureClassifierTests
     private static string GetProbableCause( ImmutableArray<string> output )
         => ReferenceAssemblyBuildFailureClassifier.GetProbableCause( output, _projectDirectory, null );
 
-    [Fact]
-    public void ProbableCause_FeedRequiresCredentials()
+    /// <summary>
+    /// NuGet reports the rejected request without a message identifier, so the HTTP status code is the only invariant
+    /// signal. It is recognized in a localized output, where every word around it differs.
+    /// </summary>
+    [Theory]
+    [InlineData( "TempProject.csproj(5): error :   Response status code does not indicate success: 401 (Unauthorized)." )]
+    [InlineData( "TempProject.csproj(5): erreur :   Le code d'état de la réponse n'indique pas une réussite : 401 (Unauthorized)." )]
+    public void ProbableCause_FeedRequiresCredentials( string statusLine )
     {
         var output = ImmutableArray.Create(
             "MSBuild version 17.8.43+f0cbb1397 for .NET",
-            "  Determining projects to restore...",
             "TempProject.csproj(5): error : Unable to load the service index for source https://feed.example.com/v3/index.json.",
-            "TempProject.csproj(5): error :   Response status code does not indicate success: 401 (Unauthorized)." );
+            statusLine );
 
-        Assert.Contains( "credentials", GetProbableCause( output ) );
+        Assert.Contains( "HTTP authentication error", GetProbableCause( output ) );
+    }
+
+    /// <summary>
+    /// The status code is recognized only in an output that also contains a URL, and only as a whole number, so that a
+    /// package version or a build number that ends in 401 does not produce a message about credentials.
+    /// </summary>
+    [Theory]
+    [InlineData( "TempProject.csproj(5): error : Restore failed for https://feed.example.com after 1.0.401 seconds." )]
+    [InlineData( "TempProject.csproj(5): error : Package Some.Package 3.401.0 could not be installed." )]
+    public void ProbableCause_NumberResemblingAStatusCodeIsNotAnAuthenticationFailure( string line )
+    {
+        Assert.Contains( "not a defect of Metalama", GetProbableCause( ImmutableArray.Create( line ) ) );
     }
 
     [Fact]
@@ -56,18 +73,18 @@ public sealed class ReferenceAssemblyBuildFailureClassifierTests
         Assert.Contains( "packageSourceMapping", GetProbableCause( output ) );
     }
 
-    [Fact]
-    public void ProbableCause_SdkPinnedByGlobalJsonIsNotInstalled()
+    /// <summary>
+    /// The .NET host fails before MSBuild is loaded, so the output carries no message identifier and the file name
+    /// <c>global.json</c> is the only invariant signal. The prose around it differs in a localized toolchain.
+    /// </summary>
+    [Theory]
+    [InlineData( "      A compatible .NET SDK was not found.", "Requested SDK version: 9.0.311" )]
+    [InlineData( "      Aucun SDK .NET compatible n'a été trouvé.", "Version du SDK demandée : 9.0.311" )]
+    public void ProbableCause_SdkPinnedByGlobalJsonIsNotInstalled( string notFoundLine, string requestedVersionLine )
     {
-        var output = ImmutableArray.Create(
-            "The command could not be loaded, possibly because:",
-            "  * You intended to execute a .NET SDK command:",
-            "      A compatible .NET SDK was not found.",
-            "",
-            "Requested SDK version: 9.0.311",
-            "global.json file: C:\\src\\global.json" );
+        var output = ImmutableArray.Create( notFoundLine, requestedVersionLine, "global.json file: C:\\src\\global.json" );
 
-        Assert.Contains( "global.json", GetProbableCause( output ) );
+        Assert.Contains( "This build resolved a global.json file", GetProbableCause( output ) );
     }
 
     /// <summary>
@@ -95,13 +112,19 @@ public sealed class ReferenceAssemblyBuildFailureClassifierTests
         Assert.Contains( "MetalamaCompileTimeTargetFrameworks", GetProbableCause( output ) );
     }
 
+    /// <summary>
+    /// The .NET SDK reports an MSBuild that is too old for it without any message identifier, and the sentence that
+    /// carries the two versions is localized, so the condition carries no invariant signal and is deliberately left
+    /// unclassified. The quoted output still shows the user what happened. See #1744.
+    /// </summary>
     [Fact]
-    public void ProbableCause_MSBuildTooOldForSdk()
+    public void ProbableCause_MSBuildTooOldForSdkIsLeftUnclassified()
     {
         var output = ImmutableArray.Create(
             "Version 10.0.201 of the .NET SDK requires at least version 18.0.0 of MSBuild. The current available version of MSBuild is 17.14.23.42201." );
 
-        Assert.Contains( "older than the version required by the .NET SDK", GetProbableCause( output ) );
+        Assert.Contains( "not a defect of Metalama", GetProbableCause( output ) );
+        Assert.Contains( "requires at least version 18.0.0 of MSBuild", ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output ) );
     }
 
     [Fact]
@@ -131,6 +154,25 @@ public sealed class ReferenceAssemblyBuildFailureClassifierTests
         var output = ImmutableArray.Create( "TempProject.csproj(5): erreur NU1101: Impossible de trouver le package Microsoft.CodeAnalysis.CSharp." );
 
         Assert.Contains( "NU1101", ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output ) );
+    }
+
+    /// <summary>
+    /// An output that carries no message identifier cannot be filtered down to its error lines without depending on the
+    /// language of the toolchain, so the last lines are quoted instead. They are where a failing build explains itself,
+    /// and the user reads them in the language of their own toolchain.
+    /// </summary>
+    [Fact]
+    public void ReportedErrors_LocalizedOutputWithoutMessageIdentifierFallsBackToTheLastLines()
+    {
+        var output = ImmutableArray.Create(
+            "Version de MSBuild 17.8.43+f0cbb1397 pour .NET",
+            "  Determination des projets a restaurer...",
+            "TempProject.csproj(5): erreur :   Le code d'etat de la reponse n'indique pas une reussite : 401 (Unauthorized)." );
+
+        var errors = ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output );
+
+        Assert.Contains( "Its last output lines were the following:", errors );
+        Assert.Contains( "401 (Unauthorized)", errors );
     }
 
     [Fact]

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/ReferenceAssemblyBuildFailureClassifierTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/ReferenceAssemblyBuildFailureClassifierTests.cs
@@ -1,0 +1,204 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CompileTime;
+using System.Collections.Immutable;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime;
+
+/// <summary>
+/// Tests <see cref="ReferenceAssemblyBuildFailureClassifier"/>, which turns the console output of the failed nested
+/// reference-assembly build into the text of a diagnostic.
+/// </summary>
+/// <remarks>
+/// The outputs used here are modelled on the ones reported in issues #1744, #1745, #1746 and #1747.
+/// </remarks>
+public sealed class ReferenceAssemblyBuildFailureClassifierTests
+{
+    private const string _projectDirectory = @"C:\Temp\Metalama\AssemblyLocator\abcdef";
+
+    /// <summary>
+    /// Calls <see cref="ReferenceAssemblyBuildFailureClassifier.GetProbableCause"/> for a build in which Metalama pinned
+    /// no .NET SDK version, which is the ordinary case.
+    /// </summary>
+    private static string GetProbableCause( ImmutableArray<string> output )
+        => ReferenceAssemblyBuildFailureClassifier.GetProbableCause( output, _projectDirectory, null );
+
+    [Fact]
+    public void ProbableCause_FeedRequiresCredentials()
+    {
+        var output = ImmutableArray.Create(
+            "MSBuild version 17.8.43+f0cbb1397 for .NET",
+            "  Determining projects to restore...",
+            "TempProject.csproj(5): error : Unable to load the service index for source https://feed.example.com/v3/index.json.",
+            "TempProject.csproj(5): error :   Response status code does not indicate success: 401 (Unauthorized)." );
+
+        Assert.Contains( "credentials", GetProbableCause( output ) );
+    }
+
+    [Fact]
+    public void ProbableCause_InsecureFeed()
+    {
+        var output = ImmutableArray.Create( "TempProject.csproj(5): error NU1302: The source 'http://feed' uses an insecure connection." );
+
+        Assert.Contains( "allowInsecureConnections", GetProbableCause( output ) );
+    }
+
+    [Fact]
+    public void ProbableCause_PackageNotFoundOnMappedSource()
+    {
+        var output = ImmutableArray.Create(
+            "TempProject.csproj(5): error NU1101: Unable to find package Microsoft.CodeAnalysis.CSharp.",
+            "TempProject.csproj(5): error NU1101: No packages exist with this id in source(s): InternalFeed" );
+
+        Assert.Contains( "packageSourceMapping", GetProbableCause( output ) );
+    }
+
+    [Fact]
+    public void ProbableCause_SdkPinnedByGlobalJsonIsNotInstalled()
+    {
+        var output = ImmutableArray.Create(
+            "The command could not be loaded, possibly because:",
+            "  * You intended to execute a .NET SDK command:",
+            "      A compatible .NET SDK was not found.",
+            "",
+            "Requested SDK version: 9.0.311",
+            "global.json file: C:\\src\\global.json" );
+
+        Assert.Contains( "global.json", GetProbableCause( output ) );
+    }
+
+    /// <summary>
+    /// Metalama writes its own global.json beside the reference-assembly project to pin the .NET SDK to the version that
+    /// builds the project. When that is the file at fault, the user must not be sent looking at their own global.json.
+    /// </summary>
+    [Fact]
+    public void ProbableCause_SdkPinnedByMetalamaIsNotInstalled()
+    {
+        var output = ImmutableArray.Create(
+            "      A compatible .NET SDK was not found.",
+            "Requested SDK version: 9.0.311",
+            $"global.json file: {_projectDirectory}\\global.json" );
+
+        var probableCause = ReferenceAssemblyBuildFailureClassifier.GetProbableCause( output, _projectDirectory, "9.0.311" );
+
+        Assert.Contains( "Metalama requested the .NET SDK version '9.0.311'", probableCause );
+    }
+
+    [Fact]
+    public void ProbableCause_SdkTooOldForTargetFramework()
+    {
+        var output = ImmutableArray.Create( "TempProject.csproj(1,1): error NETSDK1045: The current .NET SDK does not support targeting .NET 8.0." );
+
+        Assert.Contains( "MetalamaCompileTimeTargetFrameworks", GetProbableCause( output ) );
+    }
+
+    [Fact]
+    public void ProbableCause_MSBuildTooOldForSdk()
+    {
+        var output = ImmutableArray.Create(
+            "Version 10.0.201 of the .NET SDK requires at least version 18.0.0 of MSBuild. The current available version of MSBuild is 17.14.23.42201." );
+
+        Assert.Contains( "older than the version required by the .NET SDK", GetProbableCause( output ) );
+    }
+
+    [Fact]
+    public void ProbableCause_TaskCrashedWithAccessViolation()
+    {
+        var output = ImmutableArray.Create(
+            "TempProject.csproj(1,1): error MSB6006: \"csc.exe\" exited with code -1073741819 [C:\\temp\\TempProject.csproj::TargetFramework=netstandard2.0]" );
+
+        Assert.Contains( "access violation", GetProbableCause( output ) );
+    }
+
+    [Fact]
+    public void ProbableCause_UnrecognizedOutputFallsBackToTheGenericSentence()
+    {
+        var output = ImmutableArray.Create( "Build FAILED." );
+
+        Assert.Contains( "not a defect of Metalama", GetProbableCause( output ) );
+    }
+
+    /// <summary>
+    /// Verifies that the message identifier is recognized even when MSBuild localizes the prose that surrounds it, which
+    /// is the case for a substantial share of the affected users.
+    /// </summary>
+    [Fact]
+    public void ReportedErrors_LocalizedOutputIsRecognizedByItsMessageIdentifier()
+    {
+        var output = ImmutableArray.Create( "TempProject.csproj(5): erreur NU1101: Impossible de trouver le package Microsoft.CodeAnalysis.CSharp." );
+
+        Assert.Contains( "NU1101", ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output ) );
+    }
+
+    [Fact]
+    public void ReportedErrors_NonErrorLinesAreExcluded()
+    {
+        var output = ImmutableArray.Create(
+            "MSBuild version 17.8.43+f0cbb1397 for .NET",
+            "  Determining projects to restore...",
+            "TempProject.csproj(5): error NU1101: Unable to find package Microsoft.CodeAnalysis.CSharp.",
+            "Build FAILED." );
+
+        var errors = ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output );
+
+        Assert.Contains( "NU1101", errors );
+        Assert.DoesNotContain( "Determining projects", errors );
+        Assert.DoesNotContain( "Build FAILED", errors );
+    }
+
+    /// <summary>
+    /// A multi-targeted build reports the same error once per target framework, and MSBuild appends the name of the
+    /// target framework to each occurrence. Quoting all of them would fill the diagnostic without adding information.
+    /// </summary>
+    [Fact]
+    public void ReportedErrors_ErrorsRepeatedPerTargetFrameworkAreQuotedOnce()
+    {
+        var output = ImmutableArray.Create(
+            "csc : error MSB6006: \"csc.exe\" exited with code -1073741819 [C:\\temp\\TempProject.csproj::TargetFramework=netstandard2.0]",
+            "csc : error MSB6006: \"csc.exe\" exited with code -1073741819 [C:\\temp\\TempProject.csproj::TargetFramework=net8.0]",
+            "csc : error MSB6006: \"csc.exe\" exited with code -1073741819 [C:\\temp\\TempProject.csproj::TargetFramework=net48]" );
+
+        var errors = ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output );
+
+        Assert.Equal( "It reported the following errors: " + output[0], errors );
+    }
+
+    /// <summary>
+    /// Verifies that the text of the diagnostic never contains a line break, which a Roslyn diagnostic cannot carry.
+    /// </summary>
+    [Fact]
+    public void ReportedErrors_TextHasNoLineBreak()
+    {
+        var output = ImmutableArray.Create(
+            "TempProject.csproj(5): error NU1101: Unable to find package\r\nMicrosoft.CodeAnalysis.CSharp.",
+            "TempProject.csproj(5): error NU1102: Unable to find package\nMicrosoft.CodeAnalysis." );
+
+        var errors = ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output );
+
+        Assert.DoesNotContain( "\r", errors );
+        Assert.DoesNotContain( "\n", errors );
+    }
+
+    /// <summary>
+    /// When the child process fails before MSBuild can report a diagnostic, as when the .NET host cannot satisfy a
+    /// global.json, there is no error line to quote and the last output lines are the informative ones.
+    /// </summary>
+    [Fact]
+    public void ReportedErrors_WithoutErrorLineTheLastOutputLinesAreQuoted()
+    {
+        var output = ImmutableArray.Create( "A compatible .NET SDK was not found.", "", "Requested SDK version: 9.0.311" );
+
+        var errors = ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( output );
+
+        Assert.Contains( "Requested SDK version: 9.0.311", errors );
+    }
+
+    [Fact]
+    public void ReportedErrors_EmptyOutput()
+    {
+        Assert.Equal( "It did not produce any output.", ReferenceAssemblyBuildFailureClassifier.GetReportedErrors( ImmutableArray<string>.Empty ) );
+    }
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/Aspect.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/Aspect.cs
@@ -1,0 +1,17 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+namespace Issue1744;
+
+/// <summary>
+/// An aspect, whose only purpose is to make the compile-time pipeline initialize, which is what runs the nested
+/// reference-assembly build that this scenario makes fail.
+/// </summary>
+public class Aspect : TypeAspect
+{
+    [Introduce]
+    public string GetMessage() => "ok";
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/Aspect.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/Aspect.cs
@@ -13,5 +13,5 @@ namespace Issue1744;
 public class Aspect : TypeAspect
 {
     [Introduce]
-    public string GetMessage() => "ok";
+    public static string GetMessage() => "ok";
 }

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/AssemblyLocatorHooks/Metalama.AssemblyLocator.Build.targets
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/AssemblyLocatorHooks/Metalama.AssemblyLocator.Build.targets
@@ -1,0 +1,17 @@
+<Project>
+
+    <!--
+        Imported into the temporary project whose build resolves the compile-time reference assemblies, through the
+        MetalamaAssemblyLocatorHooksDirectory property. It fails that build on purpose, which is what this scenario
+        exists to observe.
+
+        The failure has to be one that the build cannot recover from and that leaves no result behind: the assembly
+        locator caches the list of reference assemblies, so a provocation that lets the build complete would populate
+        the cache and every later run would silently assert nothing. Failing before the WriteAssembliesList target
+        keeps the cache empty for good.
+    -->
+    <Target Name="_FailReferenceAssemblyBuildOnPurpose" BeforeTargets="Build">
+        <Error Text="The reference-assembly build is failed on purpose by the Issue1744 test scenario." />
+    </Target>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/Issue1744.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/Issue1744.csproj
@@ -4,15 +4,19 @@
         <OutputType>Exe</OutputType>
         <TargetFramework>net8.0</TargetFramework>
         <Nullable>enable</Nullable>
+        <!-- The shared compiler server outlives a build and can serve a compile-time assembly locator that a
+             previous compilation created successfully, which would keep this scenario from reaching the failure
+             it exists to observe. Each compilation must therefore start from a fresh compiler process. -->
+        <UseSharedCompilation>false</UseSharedCompilation>
     </PropertyGroup>
 
     <PropertyGroup>
-        <!-- Makes the nested reference-assembly build fail, deterministically and without network access: no process
-             can start and complete within one millisecond, so the assembly locator kills it and reports a timeout.
-             The salt keeps this scenario on a cache directory of its own; the cache is never populated, because the
-             build never completes, so every run exercises the failure. See README.md. -->
-        <MetalamaReferenceAssemblyRestoreTimeout>1</MetalamaReferenceAssemblyRestoreTimeout>
-        <MetalamaAssemblyLocatorSalt>Issue1744</MetalamaAssemblyLocatorSalt>
+        <!-- Makes the nested reference-assembly build fail, deterministically and without network access: the hooks
+             directory below is imported into the temporary project and raises an error before anything is produced.
+             The salt keeps this scenario on a cache directory of its own, which the failing build never populates, so
+             every run exercises the failure rather than reading a cached result. See README.md. -->
+        <MetalamaAssemblyLocatorHooksDirectory>$(MSBuildThisFileDirectory)AssemblyLocatorHooks</MetalamaAssemblyLocatorHooksDirectory>
+        <MetalamaAssemblyLocatorSalt>Issue1744.HooksFailure</MetalamaAssemblyLocatorSalt>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/Issue1744.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/Issue1744.csproj
@@ -1,0 +1,22 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- Makes the nested reference-assembly build fail, deterministically and without network access: no process
+             can start and complete within one millisecond, so the assembly locator kills it and reports a timeout.
+             The salt keeps this scenario on a cache directory of its own; the cache is never populated, because the
+             build never completes, so every run exercises the failure. See README.md. -->
+        <MetalamaReferenceAssemblyRestoreTimeout>1</MetalamaReferenceAssemblyRestoreTimeout>
+        <MetalamaAssemblyLocatorSalt>Issue1744</MetalamaAssemblyLocatorSalt>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Metalama.Framework" />
+    </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/Program.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/Program.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Issue1744;
+
+[Aspect]
+internal static class Program
+{
+    private static void Main() => System.Console.WriteLine( "ok" );
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/README.md
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/README.md
@@ -1,34 +1,44 @@
 # Issue1744
 
-Asserts that a failure of the nested reference-assembly build is reported as an actionable diagnostic, and not as
-`LAMA0001` "unexpected exception occurred in Metalama" with a crash report and a telemetry report. See issues #1744,
-#1745, #1746 and #1747.
+Asserts that a failure of the nested reference-assembly build is reported as `LAMA0082`, an actionable diagnostic
+quoting what the failing build said, and not as `LAMA0001` "unexpected exception occurred in Metalama" with a crash
+report and a telemetry report. See issues #1744, #1745, #1746 and #1747.
 
 ## How the failure is provoked
 
-`MetalamaReferenceAssemblyRestoreTimeout` is set to one millisecond. No process can start and complete in that time,
-so `DotNetTool` kills the nested build and reports a timeout, which the assembly locator turns into `LAMA0083`.
+`MetalamaAssemblyLocatorHooksDirectory` points at `AssemblyLocatorHooks`, whose
+`Metalama.AssemblyLocator.Build.targets` is imported into the temporary project that resolves the compile-time
+reference assemblies and raises an error before that project produces anything.
 
 This provocation was chosen because it is deterministic and needs no network access, unlike the conditions actually
 reported in the issues (a NuGet feed that requires credentials, a `global.json` that pins an absent .NET SDK, a task
 of the nested build crashing). The code path under test is shared with all of them: `DotNetTool` throws
-`ProcessFailedException`, `CompileTimeAssemblyLocator` turns it into a `DiagnosticException`, and
+`ProcessFailedException`, `CompileTimeAssemblyLocator` classifies the output and throws a `DiagnosticException`, and
 `CompileTimeExceptionHandler` reports the diagnostics it carries instead of writing a crash report.
 
-`MetalamaAssemblyLocatorSalt` gives the scenario a cache directory of its own. The cache is never populated, because
-the nested build never completes, so every run exercises the failure rather than reading a previous result.
+Two settings make the scenario repeatable, and both are necessary:
 
-The sibling condition, a nested build that completes with a non-zero exit code, is reported as `LAMA0082`. Its
-classification of the child output is covered by `ReferenceAssemblyBuildFailureClassifierTests`, and the architecture
-mismatch that causes it in the field is reproduced by the
-`docker/win-x64/ReferenceAssemblyArchitectureMismatch` scenario.
+- `MetalamaAssemblyLocatorSalt` gives the scenario a cache directory of its own. The failing build never writes the
+  list of reference assemblies, so that directory is never populated and every run reaches the failure instead of
+  reading a previous result.
+- `UseSharedCompilation` is `false`. The compiler server outlives a build and can serve an assembly locator that a
+  previous compilation created successfully, in which case this scenario would build cleanly and assert nothing.
+
+An earlier version of this scenario provoked the failure with a one-millisecond
+`MetalamaReferenceAssemblyRestoreTimeout`. That does not work: killing the `dotnet` process does not stop the MSBuild
+worker processes it started, which finish the build and populate the cache, so the scenario passed once and silently
+stopped asserting afterwards.
 
 ## Why the build is expected to fail
 
-The compile-time reference assemblies cannot be resolved, so the compilation genuinely cannot proceed: `LAMA0083` is
+The compile-time reference assemblies cannot be resolved, so the compilation genuinely cannot proceed: `LAMA0082` is
 an error and the build fails, hence `IgnoreExitCode`. What this scenario asserts is the *shape* of the failure:
 
-- `LAMA0083` is reported, and its message names `MetalamaReferenceAssemblyRestoreTimeout`, the property that raises
-  the budget, as well as the path of the binary log of the nested build.
+- `LAMA0082` is reported, and it quotes what the nested build said rather than discarding it.
 - `LAMA0001` is **not** reported: the condition belongs to the environment and must not be presented as a defect of
   Metalama, nor produce a crash report or a telemetry report.
+
+The sibling condition, a nested build that exceeds its time budget, is reported as `LAMA0083`. The classification of
+the child output is covered by `ReferenceAssemblyBuildFailureClassifierTests`, and the architecture mismatch that
+causes these failures in the field is reproduced by the
+`docker/win-x64/ReferenceAssemblyArchitectureMismatch` scenario.

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/README.md
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/README.md
@@ -1,0 +1,34 @@
+# Issue1744
+
+Asserts that a failure of the nested reference-assembly build is reported as an actionable diagnostic, and not as
+`LAMA0001` "unexpected exception occurred in Metalama" with a crash report and a telemetry report. See issues #1744,
+#1745, #1746 and #1747.
+
+## How the failure is provoked
+
+`MetalamaReferenceAssemblyRestoreTimeout` is set to one millisecond. No process can start and complete in that time,
+so `DotNetTool` kills the nested build and reports a timeout, which the assembly locator turns into `LAMA0083`.
+
+This provocation was chosen because it is deterministic and needs no network access, unlike the conditions actually
+reported in the issues (a NuGet feed that requires credentials, a `global.json` that pins an absent .NET SDK, a task
+of the nested build crashing). The code path under test is shared with all of them: `DotNetTool` throws
+`ProcessFailedException`, `CompileTimeAssemblyLocator` turns it into a `DiagnosticException`, and
+`CompileTimeExceptionHandler` reports the diagnostics it carries instead of writing a crash report.
+
+`MetalamaAssemblyLocatorSalt` gives the scenario a cache directory of its own. The cache is never populated, because
+the nested build never completes, so every run exercises the failure rather than reading a previous result.
+
+The sibling condition, a nested build that completes with a non-zero exit code, is reported as `LAMA0082`. Its
+classification of the child output is covered by `ReferenceAssemblyBuildFailureClassifierTests`, and the architecture
+mismatch that causes it in the field is reproduced by the
+`docker/win-x64/ReferenceAssemblyArchitectureMismatch` scenario.
+
+## Why the build is expected to fail
+
+The compile-time reference assemblies cannot be resolved, so the compilation genuinely cannot proceed: `LAMA0083` is
+an error and the build fails, hence `IgnoreExitCode`. What this scenario asserts is the *shape* of the failure:
+
+- `LAMA0083` is reported, and its message names `MetalamaReferenceAssemblyRestoreTimeout`, the property that raises
+  the budget, as well as the path of the binary log of the nested build.
+- `LAMA0001` is **not** reported: the condition belongs to the environment and must not be presented as a defect of
+  Metalama, nor produce a crash report or a telemetry report.

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/test.json
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/test.json
@@ -1,6 +1,6 @@
 {
     "BuildOnly": true,
     "IgnoreExitCode": true,
-    "ExpectedDiagnosticsRegexes": [ "LAMA0083", "MetalamaReferenceAssemblyRestoreTimeout" ],
+    "ExpectedDiagnosticsRegexes": [ "LAMA0082", "failed on purpose" ],
     "ForbiddenDiagnosticsRegexes": [ "LAMA0001" ]
 }

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/test.json
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/test.json
@@ -1,0 +1,6 @@
+{
+    "BuildOnly": true,
+    "IgnoreExitCode": true,
+    "ExpectedDiagnosticsRegexes": [ "LAMA0083", "MetalamaReferenceAssemblyRestoreTimeout" ],
+    "ForbiddenDiagnosticsRegexes": [ "LAMA0001" ]
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1789/Aspect.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1789/Aspect.cs
@@ -4,11 +4,11 @@
 
 using Metalama.Framework.Aspects;
 
-namespace Issue1744;
+namespace Issue1789;
 
 /// <summary>
-/// An aspect, whose only purpose is to make the compile-time pipeline initialize, which is what runs the nested
-/// reference-assembly build that this scenario makes fail.
+/// An aspect, whose only purpose is to make the compile-time pipeline initialize, which is what parses the
+/// target frameworks that this scenario sets.
 /// </summary>
 public class Aspect : TypeAspect
 {

--- a/Metalama.Framework/src/tests/Standalone/Issue1789/Issue1789.csproj
+++ b/Metalama.Framework/src/tests/Standalone/Issue1789/Issue1789.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <!-- The documented, semicolon-separated form of the property. It is set to the same target frameworks as the
+             default, so that this scenario asserts that the value is read in full rather than changing what is built.
+             See README.md. -->
+        <MetalamaCompileTimeTargetFrameworks>netstandard2.0;net8.0;net48</MetalamaCompileTimeTargetFrameworks>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Metalama.Framework" />
+    </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/Standalone/Issue1789/Program.cs
+++ b/Metalama.Framework/src/tests/Standalone/Issue1789/Program.cs
@@ -1,0 +1,11 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+namespace Issue1789;
+
+[Aspect]
+internal static class Program
+{
+    private static void Main() => System.Console.WriteLine( "ok" );
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1789/README.md
+++ b/Metalama.Framework/src/tests/Standalone/Issue1789/README.md
@@ -1,0 +1,18 @@
+# Issue1789
+
+Asserts that `MetalamaCompileTimeTargetFrameworks` is read in full when it is written in the documented,
+semicolon-separated form. See issue #1789.
+
+The property reaches the compiler through the generated analyzer configuration file, in which a semicolon starts a
+comment. Everything after the first semicolon was therefore dropped, `netstandard2.0;net8.0;net48` was read as
+`netstandard2.0` alone, and the assembly locator then failed its own requirement of a .NET 6.0 or later target
+framework and threw, which surfaced as `LAMA0001` and invited a crash report for what is a configuration value.
+
+The build now normalizes the separator to a comma, as it already did for every other list-valued option, and the
+engine accepts either separator, so that a value set directly through `IProjectOptions` (as in unit tests) keeps
+working.
+
+There is no `test.json`: the assertion is that the scenario builds and runs cleanly, which it could not do before the
+fix. The value is deliberately the same set of target frameworks as the default, so that the scenario asserts that the
+value is parsed in full without changing what is actually built. The parsing itself is covered by
+`CompileTimeTargetFrameworksTests`, and an invalid value is now reported as `LAMA0084` rather than as a crash.

--- a/Metalama.Framework/src/tests/docker/win-x64/ReferenceAssemblyArchitectureMismatch/Dockerfile
+++ b/Metalama.Framework/src/tests/docker/win-x64/ReferenceAssemblyArchitectureMismatch/Dockerfile
@@ -1,0 +1,37 @@
+# escape=`
+
+# Reproduces the cause behind issue #1745: the nested reference-assembly build runs on a .NET installation of a
+# different architecture than the one that built the project, so the .NET SDK version that Metalama pins in the
+# global.json it writes is not among the ones installed there.
+#
+# The two installations carry deliberately different .NET SDK versions, which is the ordinary situation: the 32-bit
+# SDK is installed by some Visual Studio workloads and is rarely kept in step with the 64-bit one. A 32-bit host such
+# as the MSBuild.exe of Visual Studio builds the project with the 64-bit SDK but expands %ProgramFiles% to
+# 'C:\Program Files (x86)', which is how the 32-bit installation used to be selected. The selection itself is covered
+# by PlatformInfoArchitectureTests in Metalama.Backstage.Tests; this scenario covers the build failure that follows.
+
+FROM mcr.microsoft.com/windows/servercore:ltsc2025
+
+SHELL ["powershell", "-Command", "$ErrorActionPreference = 'Stop'; $ProgressPreference = 'SilentlyContinue';"]
+
+# The version installed as the 64-bit SDK, i.e. the one that would have built the project, and which Metalama pins.
+ARG SDK_X64=10.0.302
+
+# The version installed as the 32-bit SDK. It must differ from SDK_X64, and must not be one that SDK_X64 could roll
+# forward to, otherwise the scenario would pass vacuously.
+ARG SDK_X86=8.0.423
+
+RUN Invoke-WebRequest -Uri https://dot.net/v1/dotnet-install.ps1 -OutFile dotnet-install.ps1; `
+    & .\dotnet-install.ps1 -Version $env:SDK_X64 -Architecture x64 -InstallDir 'C:\Program Files\dotnet'; `
+    & .\dotnet-install.ps1 -Version $env:SDK_X86 -Architecture x86 -InstallDir 'C:\Program Files (x86)\dotnet'; `
+    Remove-Item -Force dotnet-install.ps1
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT=1
+ENV DOTNET_NOLOGO=1
+ENV SDK_X64=$SDK_X64
+ENV SDK_X86=$SDK_X86
+
+WORKDIR C:/app
+COPY test.ps1 C:/app/test.ps1
+
+ENTRYPOINT ["C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe", "-NoProfile", "-File", "C:\\app\\test.ps1"]

--- a/Metalama.Framework/src/tests/docker/win-x64/ReferenceAssemblyArchitectureMismatch/test.ps1
+++ b/Metalama.Framework/src/tests/docker/win-x64/ReferenceAssemblyArchitectureMismatch/test.ps1
@@ -1,0 +1,158 @@
+$ErrorActionPreference = 'Stop'
+
+$x64Dotnet = 'C:\Program Files\dotnet\dotnet.exe'
+$x86Dotnet = 'C:\Program Files (x86)\dotnet\dotnet.exe'
+$sdkX64 = $env:SDK_X64
+$failures = 0
+
+function Write-Section($text) { Write-Host ''; Write-Host "===== $text =====" }
+
+# Runs a native command and returns its combined output as one string. PowerShell turns the standard error of a
+# native command into ErrorRecord objects, which would terminate the script under $ErrorActionPreference = 'Stop'
+# and would not render as text, so the preference is relaxed and the records are converted back to their text.
+function Invoke-NativeCommand {
+    param([string]$Executable, [string[]]$Arguments)
+
+    $previousPreference = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
+
+    try {
+        $lines = & $Executable @Arguments 2>&1 | ForEach-Object {
+            if ($_ -is [System.Management.Automation.ErrorRecord]) { $_.Exception.Message } else { $_ }
+        }
+
+        return [PSCustomObject]@{ Output = ($lines -join [Environment]::NewLine); ExitCode = $LASTEXITCODE }
+    }
+    finally {
+        $ErrorActionPreference = $previousPreference
+    }
+}
+
+Write-Section 'Precondition: two installations with different SDK sets'
+Write-Host "x64 ($x64Dotnet):"
+& $x64Dotnet --list-sdks
+Write-Host "x86 ($x86Dotnet):"
+& $x86Dotnet --list-sdks
+
+$x86Sdks = (& $x86Dotnet --list-sdks | Out-String)
+
+if ($x86Sdks -match [regex]::Escape($sdkX64)) {
+    Write-Host "INCONCLUSIVE: the x86 installation also carries $sdkX64, so the scenario would pass vacuously."
+    exit 1
+}
+
+Write-Section 'Arrange: the files that CompileTimeAssemblyLocator writes into its cache directory'
+
+# GlobalJsonHelper.WriteCurrentVersion pins NETCoreSdkVersion, i.e. the version of the .NET SDK that
+# is building the project. That project is built by the x64 SDK here, as it is in a 32-bit MSBuild.exe
+# host, which resolves the .NET SDK from the 64-bit installation.
+$cacheDirectory = 'C:\app\AssemblyLocator'
+New-Item -ItemType Directory -Path $cacheDirectory -Force | Out-Null
+Set-Location $cacheDirectory
+
+@"
+{
+  "sdk": {
+    "version": "$sdkX64",
+    "rollForward": "disable"
+  }
+}
+"@ | Set-Content -Path 'global.json' -Encoding utf8
+
+# A NuGet configuration with no source at all, so that the control build never reaches the network. The
+# container has IP connectivity but no name resolution, and a restore that tries nuget.org would merely
+# stall until it times out.
+@'
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <clear />
+  </packageSources>
+</configuration>
+'@ | Set-Content -Path 'nuget.config' -Encoding utf8
+
+# This is the project that CompileTimeAssemblyLocator writes, with two deviations that keep the container
+# free of network access and that play no part in the failure, because the .NET SDK is resolved before any
+# restore would run: its PackageReference on Microsoft.CodeAnalysis.CSharp is omitted, and it targets the
+# framework of the 64-bit SDK itself, whose reference pack that SDK carries, rather than
+# 'netstandard2.0;net8.0;net48', whose reference packs would have to be downloaded.
+@"
+<Project>
+  <PropertyGroup>
+    <ImportDirectoryPackagesProps>false</ImportDirectoryPackagesProps>
+    <ImportDirectoryBuildProps>false</ImportDirectoryBuildProps>
+    <ImportDirectoryBuildTargets>false</ImportDirectoryBuildTargets>
+  </PropertyGroup>
+  <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
+  <PropertyGroup>
+    <TargetFrameworks>net$($sdkX64.Split('.')[0]).0</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+    <RestoreIgnoreFailedSources>true</RestoreIgnoreFailedSources>
+  </PropertyGroup>
+  <Target Name="WriteAssembliesList" AfterTargets="Build" Condition="'`$(TargetFramework)'!=''">
+    <WriteLinesToFile File="assemblies-`$(TargetFramework).txt" Overwrite="true" Lines="@(ReferencePathWithRefAssemblies)" />
+  </Target>
+  <Import Project="Sdk.targets" Sdk="Microsoft.NET.Sdk" />
+</Project>
+"@ | Set-Content -Path 'TempProject.csproj' -Encoding utf8
+
+'System.Console.WriteLine("Hello, world.");' | Set-Content -Path 'Program.cs' -Encoding utf8
+
+Write-Section "Act 1 (the defect): the nested build runs on the x86 host, as PlatformInfo selects it in a 32-bit process"
+$x86Result = Invoke-NativeCommand $x86Dotnet @('build', '-bl:msbuild.binlog')
+$x86Output = $x86Result.Output
+$x86ExitCode = $x86Result.ExitCode
+Write-Host $x86Output
+Write-Host "exit code: $x86ExitCode"
+
+if ($x86ExitCode -eq 0) {
+    Write-Host 'FAIL: the build on the x86 host succeeded, so the defect was not reproduced.'
+    $failures++
+}
+else {
+    # These are the two lines that identify the condition in the crash reports of #1745.
+    if ($x86Output -notmatch [regex]::Escape("Requested SDK version: $sdkX64")) {
+        Write-Host "FAIL: the output does not request the pinned SDK version $sdkX64."
+        $failures++
+    }
+
+    if ($x86Output -notmatch 'global\.json file:') {
+        Write-Host 'FAIL: the output does not name a global.json file.'
+        $failures++
+    }
+    else {
+        # The global.json at fault is the one Metalama wrote, not one belonging to the user.
+        if ($x86Output -notmatch [regex]::Escape($cacheDirectory)) {
+            Write-Host "FAIL: the global.json named is not the one in the cache directory $cacheDirectory."
+            $failures++
+        }
+        else {
+            Write-Host "OK: reproduced, and the global.json at fault is Metalama's own, in $cacheDirectory."
+        }
+    }
+}
+
+Write-Section 'Act 2 (the control): the same directory built on the x64 host, which carries the pinned SDK'
+$x64Result = Invoke-NativeCommand $x64Dotnet @('build', '-bl:msbuild-x64.binlog')
+$x64Output = $x64Result.Output
+$x64ExitCode = $x64Result.ExitCode
+Write-Host $x64Output
+Write-Host "exit code: $x64ExitCode"
+
+if ($x64ExitCode -ne 0) {
+    Write-Host 'INCONCLUSIVE: the control build failed as well, so the failure is not attributable to the architecture.'
+    $failures++
+}
+else {
+    Write-Host 'OK: the identical build succeeds on the x64 host. The only difference is which host was selected.'
+}
+
+Write-Section 'Result'
+
+if ($failures -eq 0) {
+    Write-Host 'REPRODUCED: the nested reference-assembly build fails only because it ran on the installation of the other architecture.'
+    exit 0
+}
+
+Write-Host "NOT REPRODUCED: $failures check(s) failed."
+exit 1


### PR DESCRIPTION
Fixes #1744.
Fixes #1745.
Fixes #1746.
Fixes #1747.
Fixes #1788.
Fixes #1789.

## Problem

`CompileTimeAssemblyLocator` runs a nested `dotnet build` (or `MSBuild.exe`) on an internal `TempProject.csproj` to
resolve the compile-time reference assemblies. When that build fails, `DotNetTool.Execute` threw an
`InvalidOperationException` with the whole console transcript pasted into the message, or an
`AssertionFailedException` on timeout. Both surfaced as `LAMA0001 Unexpected exception occurred in Metalama`, wrote a
crash report and sent a CEIP report.

Practically every one of those failures belongs to the environment, and the child process had already explained it in
well-formed MSBuild diagnostics:

| Cause | Issue | Reporting installations |
|---|---|---|
| `global.json` pins a .NET SDK that is not installed | #1745 | 198 |
| `packageSourceMapping` pins `Microsoft.CodeAnalysis.*` to a feed that lacks it (`NU1101`) | #1747 | 252 |
| A task of the nested build crashes with `0xC0000005` (`MSB6006`) | #1746 | 150 |
| Feed returns 401, insecure feed (`NU1302`), SDK or MSBuild too old | #1744 | 51 |

None of these is a defect of Metalama. The defect is that Metalama reported them as one.

## Change

Two parts: a root cause is fixed, and the failures that remain are reported as diagnostics instead of crashes.

### Part 1: the wrong .NET installation was selected in a 32-bit host

`PlatformInfo` looked for the .NET installation under `%ProgramFiles%`, which a 32-bit process reads as
`C:\Program Files (x86)`:

```
32-bit process: ProgramFiles=C:\Program Files (x86) ; ProgramW6432=C:\Program Files
64-bit process: ProgramFiles=C:\Program Files       ; ProgramW6432=C:\Program Files
```

The project itself is built by the .NET SDK of the native architecture, and `GlobalJsonHelper` pins that version
in the `global.json` it writes beside the reference-assembly project, with `rollForward: disable`. So in a 32-bit
host such as the `MSBuild.exe` of Visual Studio, the nested build ran on an installation that did not have the
pinned version, and failed before MSBuild was even loaded. This is #1745: the `global.json` named in those crash
reports is Metalama's own, and the non-empty `Installed SDKs` list is the *other* architecture's.

`%ProgramW6432%` denotes the native directory in a process of either architecture, and is now searched first.
`%ProgramFiles%` is still searched afterwards, so a machine whose only .NET installation is the 32-bit one keeps
working. In a 64-bit process the two are identical and nothing changes.

### Part 2: two configuration defects that also surfaced as LAMA0001

Both were found while writing the tests for part 3, and both are the same class of problem: a value the user controls,
failing as a crash.

- **#1789.** `MetalamaCompileTimeTargetFrameworks` lost everything after the first semicolon. The property reaches the
  compiler through the generated analyzer configuration file, in which `;` starts a comment, so `netstandard2.0;net8.0;net48`
  was read as `netstandard2.0` alone. The truncated value then failed the locator's own requirement of a .NET 6.0 or
  later target framework and threw, surfacing as `LAMA0001`. The property was therefore unusable in its documented
  form, and no single value could work either. `Metalama.Framework.targets` now normalizes the separator to a comma,
  next to the properties that already did so under the comment "We don't use ';' because it means a comment in
  .editorconfig"; the engine accepts either separator, so a value set directly through `IProjectOptions` keeps working;
  and an invalid value is now reported as **LAMA0084** rather than thrown.
- **#1788.** The assembly-locator targets hook was imported through a doubled-brace interpolation, so the path was the
  literal `{hooksDirectory}/Metalama.AssemblyLocator.Build.targets` and the hook had never been imported, while
  `_WarnOfImports` reported that it had. Fixed to single braces, as in the two neighbouring strings.

### Part 3: the nested build failure becomes a diagnostic, not a crash

- `ProcessFailedException` (new) replaces the ad-hoc exceptions thrown by `DotNetTool` and `MSBuildTool`. It carries
  the exit code (or the timeout), the working directory and the output lines as data rather than as prose, so the
  caller can analyze the failure.
- `ReferenceAssemblyBuildFailureClassifier` (new) turns that output into two sentences: the errors that the child
  reported, and the probable cause with the action that resolves it. Everything is folded onto a single line, since a
  Roslyn diagnostic cannot contain line breaks.

  **No rule depends on the wording of a message.** The child process writes in the language of the toolchain, and a
  substantial share of the affected reports come from a localized one (#1746 notes this explicitly), so the classifier
  recognizes only signals that are invariant across languages:

  | Signal | Used for |
  |---|---|
  | Message identifiers `NU1302`, `NU1101`, `NU1301`, `NETSDK1045`, `MSB6006` | The NuGet and .NET SDK conditions |
  | The exit code `-1073741819` (`0xC0000005`), together with `MSB6006` | The task that crashes |
  | The HTTP status codes `401` and `403`, in an output that contains a URL | The feed that requires credentials |
  | The file name `global.json` | The .NET SDK that the host cannot resolve |

  The rules are ordered by decreasing confidence, so a message identifier wins over the circumstantial signals. A
  condition for which no invariant signal exists is deliberately left unclassified and falls back to the generic
  explanation: less precise, but never wrong. The "MSBuild is older than the .NET SDK requires" case of #1744 is in
  that category, because the .NET SDK reports it with no identifier and a localized sentence.

  For the same reason, the quoted error lines are selected by message identifier alone. When the output carries none,
  as when the .NET host fails before MSBuild is loaded, the last output lines are quoted instead, verbatim and in the
  user's own language.
- Two new diagnostics: **LAMA0082** (the build failed) and **LAMA0083** (the build timed out, naming
  `MetalamaReferenceAssemblyRestoreTimeout`). Both name the `.binlog` of the nested build, which #1740 and #1746 both
  ask for and which was previously written and then never mentioned.
- `CompileTimeAssemblyLocator` catches `ProcessFailedException`, writes the complete child output to the Metalama log
  (the diagnostic can only quote a few lines of it) and throws a `DiagnosticException`.
- `CompileTimeExceptionHandler` and `DesignTimeExceptionHandler` now recognize `DiagnosticException`: they report the
  diagnostics it carries and write neither a crash report nor telemetry. This is a general improvement, not one
  specific to the assembly locator: any `DiagnosticException` that escapes the pipeline was already an analyzed,
  user-attributable failure.

`DiagnosticException` had to be made public (its constructors stay internal) so that `Metalama.Framework.DesignTime`,
which has no `InternalsVisibleTo` to the engine, can recognize it.

The `global.json` case is worded from the file that is actually at fault: Metalama writes its own `global.json` beside
the reference-assembly project to pin the .NET SDK version of the outer build, so the message distinguishes that case
from the user's own `global.json` and does not send the user looking at the wrong file.

### Example

Before:

```
CSC : error LAMA0001: Unexpected exception occurred in Metalama: Error calling `"dotnet" build -bl:msbuild_3d01.binlog`
in `C:\Users\...\AppData\Local\Temp\Metalama\AssemblyLocator\a1b2` returned 1. Process output:

MSBuild version 17.8.43+f0cbb1397 for .NET
  Determining projects to restore...
[... 40 lines of transcript ...]
Exception details are in 'C:\Users\...\crashreports\exception-....txt'. Please report this issue at
https://www.postsharp.net/support and attach this file to the ticket.
```

After:

```
CSC : error LAMA0082: Metalama could not build the internal project that resolves the compile-time reference
assemblies, therefore the compilation cannot continue. The build of 'C:\...\TempProject.csproj' exited with code 1.
It reported the following errors: TempProject.csproj(5): error NU1101: Unable to find package
Microsoft.CodeAnalysis.CSharp. A package that is required to resolve the compile-time reference assemblies was not
found on the configured NuGet sources. When nuget.config maps the Microsoft.CodeAnalysis.* pattern to a private feed
through packageSourceMapping, this build is restricted to that feed, therefore these packages must be mapped to a
source that provides them, such as nuget.org. The binary log of that build is 'C:\...\msbuild_3d01.binlog'.
```

## Reproduction

The architecture mismatch is reproduced at two levels.

- **`PlatformInfoArchitectureTests`** covers the selection itself: a 32-bit process with both installations present
  must resolve the native one, must still fall back to the 32-bit one when there is no native install, must skip a
  native install that has no .NET SDK, and must be unchanged in a 64-bit process.
- **A Windows container** reproduces the resulting build failure end to end, with a 64-bit SDK 10.0.302 and a 32-bit
  SDK 8.0.423 installed side by side. It writes the files that `CompileTimeAssemblyLocator` writes, runs the nested
  build on the 32-bit host, and asserts the failure; then it builds the same directory on the 64-bit host as a
  control, which succeeds. The output of the failing half matches the crash reports of #1745 exactly:

  ```
  Requested SDK version: 10.0.302
  global.json file: C:pp\AssemblyLocator\global.json

  Installed SDKs:
  8.0.423 [C:\Program Files (x86)\dotnet\sdk]
  ```

  The container scenario is in this pull request, as
  `Metalama.Framework/src/tests/docker/win-x64/ReferenceAssemblyArchitectureMismatch`, following the conventions of
  the existing scenarios there (a `Dockerfile` and a `test.ps1`, run by `DockerTests.ps1`). It downloads the two .NET
  SDKs itself, so the build context is two files, and the run needs no network access.

## Deliberately out of scope

- **The environmental causes themselves.** They are not fixed and this pull request does not try to.
- **`-nodeReuse:false` on the nested build**, the suspected root cause of #1740. That is a behavior change rather than
  a diagnostics one, so #1740 stays open for it. #1740 also asked for the binlog path in the timeout message, which is
  done here (LAMA0083).
- **Surfacing the diagnostic in the IDE.** At design time the exception is swallowed by `TheDiagnosticAnalyzer`, so the
  user saw nothing before this change and sees nothing after it, minus the crash report. #1758 tracks surfacing it.
- **Relaxing `rollForward: disable`** in the `global.json` that `GlobalJsonHelper` writes. It is what turns a mere
  version drift into a hard failure: with the pinned 9.0.311 absent, `disable` fails whereas `latestPatch` resolves
  9.0.316 and `latestMajor` resolves 10.0.302. It would fix the cases where the installation is right but the version
  drifted, which the architecture fix does not cover, and it is a separate behavioral decision.
- **Choosing the installation that carries the pinned .NET SDK version**, rather than any installation that has some
  .NET SDK. It would make the selection exact instead of heuristic, at the cost of a new member on `IPlatformInfo`.

## Tests

- `ReferenceAssemblyBuildFailureClassifierTests` (new, 20 cases): one per classified cause, each of the ambiguous ones
  also run against a localized output; the deduplication of an error repeated per target framework; the absence of line
  breaks; that a version such as `1.0.401` is not mistaken for an HTTP status code; and every fallback, including the
  unclassifiable MSBuild-version case.
- `CompileTimeExceptionHandlerTests`: a `DiagnosticException`, bare and wrapped in an `AggregateException`, is reported
  as its own diagnostics with no telemetry; and the rendered LAMA0082 message contains no line break.
- `PlatformInfoArchitectureTests` (new, 4 cases): the selection in a 32-bit process, its fallbacks, and the absence of
  any change in a 64-bit process.
- `Standalone/Issue1744` (new): a real build asserting that the failure is reported as `LAMA0082`, that the diagnostic
  quotes what the failing nested build said, and that `LAMA0001` is **not** reported. The failure is provoked through
  the assembly-locator hooks directory, which needs no network and, unlike a timeout, never populates the locator
  cache. Verified deterministic over three consecutive clean runs; see the scenario's `README.md` for why it also
  pins a locator salt and disables the shared compiler.
- `DesignTimeStandalone/Issue1744` (new): the same provocation through the design-time host simulator, asserting that
  the analysis does not crash, does not report `LAMA0001` and does not escape into `AD0001`. See the caveat below.
- `docker/win-x64/ReferenceAssemblyArchitectureMismatch` (new): the container described under Reproduction.
- `CompileTimeTargetFrameworksTests` (new, 8 cases) and `Standalone/Issue1789` (new) for #1789. The scenario has no
  `test.json`: the assertion is that it builds and runs, which it could not do before the fix.
### A caveat on the design-time scenario

It could not be validated locally: the design-time host simulator fails with `SIM0001` ("cannot load analyzers ...
UnableToCreateAnalyzer") against the locally-built package. This is **not** specific to the new scenario. The existing
`DesignTimeStandalone/Issue1749` fails identically once it is restored against the same local build, and the very same
assemblies work in the real compiler, since the standalone scenario above exercises the whole pipeline and reports
`LAMA0083` as expected. The failure therefore lies in the simulator or in the local packaging, not in this branch, and
the new scenario is submitted for CI to validate in the proper pipeline. Worth a look independently of this pull
request.

- The full `Metalama.Framework.Tests.UnitTests` suite passes. The `Metalama.Backstage.Tests` suite passes on both
  target frameworks except `UsageSessionFactoryTests.SessionReportedToMatomoAsync` and `LicenseAuditTests.LicenseIsAudited`,
  which fail identically on `develop/2026.1` without these changes. `Build.ps1 build` succeeds.

— Claude for @gfraiteur
