### PR TITLE
Resolve the fabric type against the run-time identity (#1759)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.cs
@@ -53,10 +53,11 @@ internal abstract partial class FabricDriver : IComparable<FabricDriver>
         Fabric fabric,
         Compilation runTimeCompilation )
     {
-        var originalPath = fabric.GetType().GetCustomAttribute<OriginalPathAttribute>().AssertNotNull().Path;
+        var fabricType = fabric.GetType();
+        var originalPath = fabricType.GetCustomAttribute<OriginalPathAttribute>().AssertNotNull().Path;
 
         // Get the original symbol for the fabric. If it has been moved, we have a custom attribute.
-        var originalId = fabric.GetType().GetCustomAttribute<OriginalIdAttribute>()?.Id;
+        var originalId = fabricType.GetCustomAttribute<OriginalIdAttribute>()?.Id;
 
         INamedTypeSymbol symbol;
 
@@ -66,9 +67,16 @@ internal abstract partial class FabricDriver : IComparable<FabricDriver>
         }
         else
         {
-            symbol = (INamedTypeSymbol) runTimeCompilation.GetCompilationContext()
+            // The fabric is instantiated from the compile-time projection of the project that declares it, so the
+            // assembly of its CLR type is the compile-time assembly 'ml!<name>_<hash>'. That assembly is built in
+            // memory and is never a reference of a compilation, so passing its name to the ReflectionMapper makes the
+            // recovery that resolves a type against the referenced assemblies unreachable, and makes the resulting
+            // message name an assembly whose absence is certain and irrelevant. The run-time identity of the
+            // compile-time project is the identity that the run-time compilation can actually contain, therefore it is
+            // the one to resolve against. See https://github.com/metalama/Metalama/issues/1759.
+            symbol = runTimeCompilation.GetCompilationContext()
                 .ReflectionMapper
-                .GetTypeSymbol( fabric.GetType() );
+                .GetNamedTypeSymbolByMetadataName( fabricType.FullName.AssertNotNull(), new AssemblyName( compileTimeProject.RunTimeIdentity.Name ) );
         }
 
         return new CreationData( fabric, fabricManager, compileTimeProject, symbol, originalPath, runTimeCompilation );

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/Consumer/Consumer.csproj
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/Consumer/Consumer.csproj
@@ -1,0 +1,23 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <NoWarn>$(NoWarn);MSB3243;MSB3277</NoWarn>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Metalama.Framework" />
+    </ItemGroup>
+
+    <ItemGroup>
+        <!--
+            Both fabric libraries are referenced, so both of them contribute a compile-time project to the closure of
+            this project and both of them export a type named SharedFabrics.SharedProjectFabric.
+        -->
+        <ProjectReference Include="..\FabricsA\FabricsA.csproj" />
+        <ProjectReference Include="..\FabricsB\FabricsB.csproj" />
+    </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/Consumer/Program.cs
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/Consumer/Program.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+
+namespace Consumer;
+
+/// <summary>
+/// The consumer of the two fabric libraries.
+/// </summary>
+/// <remarks>
+/// It names no type of either library. The transitive fabrics of both libraries are discovered through the compile-time
+/// closure of this project, which Metalama walks whether or not the consumer uses any type of them.
+/// </remarks>
+internal static class Program
+{
+    private static void Main() => System.Console.WriteLine( "ok" );
+}
+
+/// <summary>
+/// An aspect of the consumer itself, so that the consumer runs a pipeline of its own.
+/// </summary>
+public class OwnAspect : TypeAspect
+{
+    /// <summary>
+    /// An introduced member, so that the aspect has an effect.
+    /// </summary>
+    [Introduce( WhenExists = OverrideStrategy.New )]
+    public string GetOwnMessage() => "own";
+}
+
+/// <summary>
+/// The target of <see cref="OwnAspect"/>.
+/// </summary>
+[OwnAspect]
+public partial class Target { }

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsA/FabricsA.csproj
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsA/FabricsA.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <!-- A different assembly name than FabricsB, so that the two assemblies bind to two distinct assembly
+             symbols in the consumer and both of them supply the shared fabric type. -->
+        <AssemblyName>FabricsA</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Metalama.Framework" />
+    </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsA/SharedProjectFabric.cs
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsA/SharedProjectFabric.cs
@@ -1,0 +1,27 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Fabrics;
+
+namespace SharedFabrics;
+
+/// <summary>
+/// A transitive project fabric that has the same full name as the one declared by <c>FabricsB</c>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The fabric amends nothing. The defect occurs while the driver of the fabric is created, which happens before any
+/// fabric is executed, so the body of <see cref="AmendProject"/> is irrelevant to the reproduction.
+/// </para>
+/// <para>
+/// The type declaration survives in the run-time assembly, because <c>RunTimeAssemblyRewriter</c> replaces the bodies
+/// of compile-time members by a throw statement and keeps their declarations. Both <c>FabricsA</c> and <c>FabricsB</c>
+/// therefore export a type of this full name, which is what makes the name ambiguous in the consumer.
+/// </para>
+/// </remarks>
+public class SharedProjectFabric : TransitiveProjectFabric
+{
+    /// <inheritdoc />
+    public override void AmendProject( IProjectAmender amender ) { }
+}

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsB/FabricsB.csproj
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsB/FabricsB.csproj
@@ -1,0 +1,15 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <TargetFramework>net8.0</TargetFramework>
+        <Nullable>enable</Nullable>
+        <!-- A different assembly name than FabricsA, so that the two assemblies bind to two distinct assembly
+             symbols in the consumer and both of them supply the shared fabric type. -->
+        <AssemblyName>FabricsB</AssemblyName>
+    </PropertyGroup>
+
+    <ItemGroup>
+        <PackageReference Include="Metalama.Framework" />
+    </ItemGroup>
+
+</Project>

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsB/SharedProjectFabric.cs
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/FabricsB/SharedProjectFabric.cs
@@ -1,0 +1,20 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Fabrics;
+
+namespace SharedFabrics;
+
+/// <summary>
+/// A transitive project fabric that has the same full name as the one declared by <c>FabricsA</c>.
+/// </summary>
+/// <remarks>
+/// The two declarations are deliberately identical. Two independently published libraries that happen to declare a
+/// fabric of the same namespace and name produce exactly this situation in a project that references both.
+/// </remarks>
+public class SharedProjectFabric : TransitiveProjectFabric
+{
+    /// <inheritdoc />
+    public override void AmendProject( IProjectAmender amender ) { }
+}

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/Issue1759.sln
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/Issue1759.sln
@@ -1,0 +1,41 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FabricsA", "FabricsA\FabricsA.csproj", "{7B1E5A20-0001-4D6C-8C31-000000000001}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "FabricsB", "FabricsB\FabricsB.csproj", "{7B1E5A20-0002-4D6C-8C31-000000000002}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Consumer", "Consumer\Consumer.csproj", "{7B1E5A20-0003-4D6C-8C31-000000000003}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		LamaDebug|Any CPU = LamaDebug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7B1E5A20-0001-4D6C-8C31-000000000001}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B1E5A20-0001-4D6C-8C31-000000000001}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B1E5A20-0001-4D6C-8C31-000000000001}.LamaDebug|Any CPU.ActiveCfg = LamaDebug|Any CPU
+		{7B1E5A20-0001-4D6C-8C31-000000000001}.LamaDebug|Any CPU.Build.0 = LamaDebug|Any CPU
+		{7B1E5A20-0001-4D6C-8C31-000000000001}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B1E5A20-0001-4D6C-8C31-000000000001}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B1E5A20-0002-4D6C-8C31-000000000002}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B1E5A20-0002-4D6C-8C31-000000000002}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B1E5A20-0002-4D6C-8C31-000000000002}.LamaDebug|Any CPU.ActiveCfg = LamaDebug|Any CPU
+		{7B1E5A20-0002-4D6C-8C31-000000000002}.LamaDebug|Any CPU.Build.0 = LamaDebug|Any CPU
+		{7B1E5A20-0002-4D6C-8C31-000000000002}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B1E5A20-0002-4D6C-8C31-000000000002}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7B1E5A20-0003-4D6C-8C31-000000000003}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7B1E5A20-0003-4D6C-8C31-000000000003}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7B1E5A20-0003-4D6C-8C31-000000000003}.LamaDebug|Any CPU.ActiveCfg = LamaDebug|Any CPU
+		{7B1E5A20-0003-4D6C-8C31-000000000003}.LamaDebug|Any CPU.Build.0 = LamaDebug|Any CPU
+		{7B1E5A20-0003-4D6C-8C31-000000000003}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7B1E5A20-0003-4D6C-8C31-000000000003}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {7B1E5A20-9999-4D6C-8C31-000000000099}
+	EndGlobalSection
+EndGlobal

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/README.md
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/README.md
@@ -1,0 +1,109 @@
+# Issue 1759 at design time: a fabric whose type name is ambiguous in the consumer
+
+**Red.** This scenario reproduces [#1759](https://github.com/metalama/Metalama/issues/1759) on `develop/2026.1` at
+`23d57ba747`. It fails, and it is expected to fail until the defect is fixed.
+
+## What it reproduces
+
+The design-time pipeline fails to initialize, and the failure escapes as an unhandled exception rather than a
+diagnostic:
+
+```
+System.InvalidOperationException: The type 'SharedFabrics.SharedProjectFabric' cannot be used at run-time,
+because the assembly 'ml!FabricsA_9065f04512aa6559' is not referenced in project 'Consumer'.
+   at Metalama.Framework.Engine.CodeModel.Helpers.ReflectionMapper.GetNamedTypeSymbolByMetadataName(...)
+   at Metalama.Framework.Engine.CodeModel.Helpers.ReflectionMapper.GetNamedTypeSymbol(...)
+   at Metalama.Framework.Engine.CodeModel.Helpers.ReflectionMapper.GetTypeSymbolCore(...)
+   at System.Collections.Concurrent.ConcurrentDictionary`2.GetOrAdd(...)
+   at Metalama.Framework.Engine.Fabrics.FabricDriver.GetCreationData(...)
+   at Metalama.Framework.Engine.Fabrics.ProjectFabricDriver.Create(...)
+   at Metalama.Framework.Engine.Fabrics.FabricManager.CreateDrivers(...)
+   at Metalama.Framework.Engine.Fabrics.FabricManager.ExecuteFabrics(...)
+   at Metalama.Framework.Engine.Pipeline.AspectPipeline.TryInitialize(...)
+```
+
+The stack matches the reported signatures frame for frame down to `AspectPipeline.TryInitialize`. Both entry points
+named in the issue are reached, `AnalysisProcessProjectSourceGenerator.ComputeAsync` and
+`TheDiagnosticAnalyzer.AnalyzeSemanticModel`, as well as a third one the issue does not mention,
+`TheDiagnosticSuppressor.ReportSuppressions`. The consumer therefore loses every design-time feature, and no diagnostic
+explains why.
+
+## The configuration
+
+| Project | Contains | References |
+|---|---|---|
+| `FabricsA` | `SharedFabrics.SharedProjectFabric`, a `TransitiveProjectFabric` | |
+| `FabricsB` | a type declaration of the same full name | |
+| `Consumer` | an aspect of its own, so that it runs a pipeline | `FabricsA` and `FabricsB` |
+
+The two libraries have different assembly names, so the consumer binds two distinct assembly symbols and each of them
+exports a type named `SharedFabrics.SharedProjectFabric`. Two independently published libraries that happen to declare
+a fabric of the same namespace and name produce this configuration in any project that references both.
+
+## Why the type cannot be resolved
+
+`FabricDriver.GetCreationData` resolves the fabric type into the run-time compilation through
+`ReflectionMapper.GetNamedTypeSymbolByMetadataName`, which proceeds in two steps:
+
+1. `Compilation.GetTypeByMetadataName( metadataName )`, which searches the compilation and all of its references and
+   returns `null` when the name is found in more than one assembly.
+2. Only when the first step returned `null`, a lookup of the assembly name among the referenced assemblies, which
+   throws the exception above when that assembly is absent.
+
+Both libraries export the fabric type, so step 1 is ambiguous and returns `null`. Step 2 then looks for the assembly
+that declares the fabric instance, which is the compile-time assembly `ml!FabricsA_<hash>`, because the fabric was
+instantiated from the compile-time projection. A compile-time assembly is built in memory and can never be a metadata
+reference of a compilation, so that lookup necessarily finds nothing and the exception is raised.
+
+## The message is misleading, and that matters
+
+`Consumer` references `FabricsA` through an ordinary project reference. The assertion made by the message, that the
+assembly is not referenced, is false. The message is a tautology: it names an assembly whose absence is structurally
+certain, and it discards the only fact of interest, which is the reason the first step failed.
+
+Two consequences follow, and both are worth weighing before choosing a fix:
+
+- The recovery path immediately below the throw site, which resolves a type against the highest version when several
+  versions of an assembly are present, is unreachable for any type that comes from a transformed compile-time project,
+  because the assembly name it is given always begins with `ml!`. Passing the run-time identity of the compile-time
+  project instead of the identity of the compile-time assembly would both revive that recovery and make the message
+  truthful.
+- A guard that tests whether the compilation references the run-time assembly of the fabric does not cover this
+  scenario, because that assembly is referenced. The scenario is therefore a test of whether a candidate fix addresses
+  the reported condition or only a condition that resembles it.
+
+## The control
+
+Removing the reference to `FabricsB` from `Consumer`, and changing nothing else, makes the solution build and analyze
+cleanly. The transitive fabric of `FabricsA` is discovered and applied as expected. The second library, and only the
+second library, is what turns a working configuration into a crash.
+
+## Not limited to design time
+
+A plain `dotnet build` of this solution fails with the same exception, reported as `LAMA0001`. The scenario lives here
+rather than under `Standalone/` because the reported occurrences are all design-time, where the cost to the user is
+much higher: a batch build stops with an error the user can act upon, whereas the IDE silently loses all Metalama
+features for the project. A `Standalone/` twin would be justified if the two sites ever diverge, as they did for
+[#1749](https://github.com/metalama/Metalama/issues/1749).
+
+## How the outcome is asserted
+
+`test.json` sets `ErrorRegexes` and deliberately sets no `ForbiddenDiagnosticsRegexes`. The three assertion modes of
+`TestableSolution.EvaluateOutput` are mutually exclusive, in the order "assert on diagnostics", "report a non-zero exit
+code", "match `ErrorRegexes` against the whole output". Declaring a diagnostics assertion would therefore suppress the
+exit-code check, and the scenario would be reported as successful while crashing, because the simulator does not
+surface this exception as a diagnostic in the canonical MSBuild format. The exception is written to the output as a
+`# Metalama ERROR` trace line and the simulator reports the failure through its exit code.
+
+The current outcome is thus a failure by exit code. Once the defect is fixed, the exit code becomes zero and
+`ErrorRegexes` takes over, so that a fix which merely swallows the exception while still logging it does not pass.
+
+## Running it by hand
+
+```powershell
+dotnet <repo>\Metalama.Framework\src\tests\Metalama.DesignTime.HostSimulator\bin\Debug\net9.0\Metalama.DesignTime.HostSimulator.dll Issue1759.sln --timeout 300
+```
+
+Use the **net9.0** build, as `eng/src/DesignTimeSolution.cs` does. Add `--trace "*"` to obtain the trace of Metalama
+itself. The host simulator is a test project, so `Build.ps1 build` does not build it; build it with `dotnet build`
+first.

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/README.md
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/README.md
@@ -1,7 +1,7 @@
 # Issue 1759 at design time: a fabric whose type name is ambiguous in the consumer
 
-**Red.** This scenario reproduces [#1759](https://github.com/metalama/Metalama/issues/1759) on `develop/2026.1` at
-`23d57ba747`. It fails, and it is expected to fail until the defect is fixed.
+**Status: Fixed.** This scenario reproduces [#1759](https://github.com/metalama/Metalama/issues/1759) on `develop/2026.1` at
+`23d57ba747`. It failed before the fix and is expected to pass once the defect is fixed.
 
 ## What it reproduces
 

--- a/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/test.json
+++ b/Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759/test.json
@@ -1,0 +1,4 @@
+{
+    "BuildOnly": true,
+    "ErrorRegexes": [ "cannot be used at run-time, because the assembly" ]
+}


### PR DESCRIPTION
Fixes #1759. Supersedes #1787, which is being closed.

## Summary

- The exception reported in #1759 does not mean what it says. `ReflectionMapper.GetNamedTypeSymbolByMetadataName` first calls `Compilation.GetTypeByMetadataName`, which searches the compilation and all of its references and returns `null` when the name is found in **more than one** assembly. Only then does it look the assembly name up among the references and throw. For a fabric, that assembly name is the compile-time assembly `ml!<name>_<hash>`, which is built in memory and can never be a reference of a compilation, so the lookup necessarily finds nothing and the throw is unconditional. The message therefore names an assembly whose absence is structurally certain, and discards the only fact of interest, which is why the first step failed.

- The real condition is an **ambiguous type name**. `Consumer` in the new scenario references the declaring assembly through an ordinary project reference, and the crash still occurs, because a second referenced assembly exports a type of the same full name.

- The fix passes `compileTimeProject.RunTimeIdentity` as the assembly hint instead of the identity of the compile-time assembly. That identity is one the run-time compilation can actually contain, so the existing recovery in `ReflectionMapper`, which resolves the type against the referenced assemblies and prefers the highest version, becomes reachable and resolves the fabric from the assembly that really declares it. When the assembly is genuinely absent, the message now names that assembly and is actionable.

- The change is confined to `FabricDriver.GetCreationData`. `ReflectionMapper` is unchanged, so no other call site is affected.

## Tests

`Metalama.Framework/src/tests/DesignTimeStandalone/Issue1759` is a new design-time standalone scenario. `FabricsA` declares a `TransitiveProjectFabric`, `FabricsB` declares a type of the same full name, and `Consumer` references both.

- Before the fix, the host simulator fails with the reported exception, and the stack matches the reported signatures frame for frame down to `AspectPipeline.TryInitialize`. Both entry points named in the issue are reached, `AnalysisProcessProjectSourceGenerator.ComputeAsync` and `TheDiagnosticAnalyzer.AnalyzeSemanticModel`, as well as a third one the issue does not mention, `TheDiagnosticSuppressor.ReportSuppressions`.
- After the fix, the scenario passes, and so does a plain `dotnet build` of the same solution, which fails with `LAMA0001` without the fix.
- Control: removing only the reference to `FabricsB`, and changing nothing else, makes the solution build and analyze cleanly, with or without the fix. The commit that adds the scenario precedes the commit that fixes the defect, so the reproduction can be verified in isolation.

`test.json` asserts through `ErrorRegexes` and deliberately declares no `ForbiddenDiagnosticsRegexes`. The three assertion modes of `TestableSolution.EvaluateOutput` are mutually exclusive, so declaring a diagnostics assertion would suppress the exit-code check, and the scenario would be reported as successful while crashing: this exception does not reach the output as a diagnostic in the canonical MSBuild format. The scenario README documents this, along with the reasoning above.

## Why not #1787

[#1787](https://github.com/metalama/Metalama/pull/1787) attributes the failure to a compile-time closure that contains an assembly the run-time compilation does not reference, and guards on `CompilationContext.ContainsOrReferencesAssembly`. In the scenario above that guard returns `true`, because the assembly **is** referenced, so `ReflectionMapper` still throws and the reported condition is not fixed. Its unit test reaches the exception only by substituting a `TestAssemblyLocator`; in the product, `IAssemblyLocator` is constructed from `compilation.References` (`ServiceProviderFactory`), so the closure cannot contain an assembly the compilation does not reference, and a locator failure is already reported as `CannotFindCompileTimeAssembly` rather than thrown.

Two things from #1787 remain worth doing, and are deliberately out of scope here:

- Reporting a diagnostic instead of letting an unresolved fabric abort pipeline initialization. That is a separate decision about behavior, and it is no longer urgent once the resolution itself is correct.
- Its `LAMA0082` collides with the identifier taken by the branch of #1744. Whichever merges second must renumber.

## Verification

- `Build.ps1 build`: successful, no compiler warnings (only the pre-existing `NU1902` and `NU1903` audit warnings).
- `Metalama.Framework.Tests.UnitTests` (net8.0): 2184 passed, 0 failed.
- `Metalama.Framework.Tests.AspectTests` (net8.0): 2271 passed, 0 failed.
- All five existing design-time standalone scenarios (`Issue1749`, `Issue1749.FrameworkVersions`, `Issue1749.SameAssemblyIdentity`, `Issue1749.SameProjectKey`, `Issue1749.UpstreamReuse`) pass.

## Issues Fixed

- #1759 - Design-time pipeline crashes in `FabricDriver.GetCreationData`.

— Claude for @gfraiteur
