### PR TITLE
Disable MSBuild node reuse in the nested reference-assembly build (#1740)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeAssemblyLocator.cs
@@ -543,6 +543,37 @@ internal sealed class CompileTimeAssemblyLocator
         return true;
     }
 
+    /// <summary>
+    /// Gets the command line of the nested reference-assembly build when it is run through <c>dotnet build</c>.
+    /// </summary>
+    /// <remarks>
+    /// See <see cref="GetMSBuildToolArguments"/> for the reason why node reuse and multi-node builds are switched off.
+    /// </remarks>
+    internal static string GetDotNetToolArguments( string binaryLogFileName ) => $"build -nodeReuse:false -m:1 -bl:{binaryLogFileName}";
+
+    /// <summary>
+    /// Gets the command line of the nested reference-assembly build when it is run through <c>MSBuild.exe</c>, which is
+    /// the case for old-style .NET Framework projects, for which the .NET SDK version is unknown.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This build is started from inside the compiler, which itself runs inside a task of the outer build. With its
+    /// default settings, MSBuild would build with as many worker nodes as there are processors and leave those nodes
+    /// alive for about fifteen minutes so that a later build can reuse them. Requesting worker nodes from within a
+    /// build whose own nodes are all occupied, waiting for the compiler that started this build, is a re-entrancy
+    /// hazard: whether a node can be acquired depends on how many of them happen to be free at that instant, which is
+    /// what made the failure reported in issue #1740 intermittent and unrelated to any axis of the build matrix.
+    /// </para>
+    /// <para>
+    /// A single-project build gains nothing from either parallelism or node reuse, so both are switched off. The
+    /// nested build then runs entirely in the process that Metalama starts, which has the further benefit that
+    /// terminating that process when it exceeds its time budget genuinely terminates the build, instead of leaving
+    /// worker processes behind to finish it.
+    /// </para>
+    /// </remarks>
+    internal static string GetMSBuildToolArguments( string projectFilePath, string binaryLogFileName )
+        => $"\"{projectFilePath}\" /t:Restore;Build /nodeReuse:false /m:1 /bl:{binaryLogFileName}";
+
     private bool TryGetReferenceAssembliesManifest(
         string targetFrameworks,
         string additionalPackageReferences,
@@ -691,19 +722,16 @@ internal sealed class CompileTimeAssemblyLocator
                 if ( string.IsNullOrEmpty( this._sdkVersion ) && !string.IsNullOrEmpty( this._msBuildBinPath ) )
                 {
                     var msBuildTool = new MSBuildTool( this._msBuildBinPath );
-                    var arguments = $"\"{projectFilePath}\" /t:Restore;Build /bl:{binaryLogFileName}";
 
-                    msBuildTool.Execute( arguments, this._cacheDirectory, this._restoreTimeout );
+                    msBuildTool.Execute( GetMSBuildToolArguments( projectFilePath, binaryLogFileName ), this._cacheDirectory, this._restoreTimeout );
                 }
                 else
                 {
                     // Remove configuration environment variable to avoid having different output directory than Debug.
                     // Build scripts may rely on env var to set the configuration in MSBuild.
                     // Case insensitive comparison needed because MSBuild is case insensitive.
-                    var arguments = $"build -bl:{binaryLogFileName}";
-
                     this._dotNetTool.Execute(
-                        arguments,
+                        GetDotNetToolArguments( binaryLogFileName ),
                         this._cacheDirectory,
                         this._restoreTimeout,
                         envVar => !StringComparer.OrdinalIgnoreCase.Equals( envVar.Key, "configuration" ) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
@@ -71,15 +71,17 @@ public sealed class DotNetTool
             }
         }
 
-        // Every process started through this class is a short-lived build that runs inside another build, so it must
-        // never take part in MSBuild node reuse: acquiring a worker node from within a build whose own nodes are
-        // occupied waiting for us is a re-entrancy hazard. The command line of the nested build disables node reuse as
-        // well; this variable covers any further MSBuild that the child may start on its own. It is set after the
-        // filter, because it is a requirement of the child process and not a variable inherited from this one. See
-        // issue #1740.
+        // MSBuild node reuse keeps worker processes alive for about fifteen minutes so that a later build can reuse
+        // them, which none of the short-lived commands started through this class has anything to gain from. For the
+        // reference-assembly build it is a re-entrancy hazard as well, because that build runs inside the compiler,
+        // hence inside a task of a build whose own nodes are occupied waiting for it. The command line of that build
+        // disables node reuse too; this variable covers any further MSBuild that the child may start on its own. It is
+        // set after the filter, because it is a requirement of the child process and not a variable inherited from
+        // this one. See issue #1740.
         startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
 
-        var process = new Process() { StartInfo = startInfo };
+        // ReSharper disable once UsingStatementResourceInitialization
+        using var process = new Process() { StartInfo = startInfo };
 
         var lines = new List<string>();
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/DotNetTool.cs
@@ -71,6 +71,14 @@ public sealed class DotNetTool
             }
         }
 
+        // Every process started through this class is a short-lived build that runs inside another build, so it must
+        // never take part in MSBuild node reuse: acquiring a worker node from within a build whose own nodes are
+        // occupied waiting for us is a re-entrancy hazard. The command line of the nested build disables node reuse as
+        // well; this variable covers any further MSBuild that the child may start on its own. It is set after the
+        // filter, because it is a requirement of the child process and not a variable inherited from this one. See
+        // issue #1740.
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
         var process = new Process() { StartInfo = startInfo };
 
         var lines = new List<string>();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
@@ -70,12 +70,13 @@ public sealed class MSBuildTool
             }
         }
 
-        // Every process started through this class is a short-lived build that runs inside another build, so it must
-        // never take part in MSBuild node reuse: acquiring a worker node from within a build whose own nodes are
-        // occupied waiting for us is a re-entrancy hazard. The command line of the nested build disables node reuse as
-        // well; this variable covers any further MSBuild that the child may start on its own. It is set after the
-        // filter, because it is a requirement of the child process and not a variable inherited from this one. See
-        // issue #1740.
+        // MSBuild node reuse keeps worker processes alive for about fifteen minutes so that a later build can reuse
+        // them, which the short-lived builds started through this class have nothing to gain from. It is a re-entrancy
+        // hazard as well, because the reference-assembly build runs inside the compiler, hence inside a task of a
+        // build whose own nodes are occupied waiting for it. The command line of that build disables node reuse too;
+        // this variable covers any further MSBuild that the child may start on its own. It is set after the filter,
+        // because it is a requirement of the child process and not a variable inherited from this one. See issue
+        // #1740.
         startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
 
         // ReSharper disable once UsingStatementResourceInitialization

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/MSBuildTool.cs
@@ -70,6 +70,14 @@ public sealed class MSBuildTool
             }
         }
 
+        // Every process started through this class is a short-lived build that runs inside another build, so it must
+        // never take part in MSBuild node reuse: acquiring a worker node from within a build whose own nodes are
+        // occupied waiting for us is a re-entrancy hazard. The command line of the nested build disables node reuse as
+        // well; this variable covers any further MSBuild that the child may start on its own. It is set after the
+        // filter, because it is a requirement of the child process and not a variable inherited from this one. See
+        // issue #1740.
+        startInfo.Environment["MSBUILDDISABLENODEREUSE"] = "1";
+
         // ReSharper disable once UsingStatementResourceInitialization
         using var process = new Process { StartInfo = startInfo };
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/ReferenceAssemblyBuildArgumentsTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/ReferenceAssemblyBuildArgumentsTests.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CompileTime;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime;
+
+/// <summary>
+/// Tests the command line of the nested build that resolves the compile-time reference assemblies.
+/// </summary>
+/// <remarks>
+/// That build runs inside the compiler, which itself runs inside a task of the outer build, so it must not compete for
+/// MSBuild worker nodes with the build that is waiting for it. Both switches that prevent this are asserted here,
+/// because removing either of them reintroduces a deadlock that only manifests as an intermittent timeout on a loaded
+/// machine, and therefore would not be caught by any other test. See issue #1740.
+/// </remarks>
+public sealed class ReferenceAssemblyBuildArgumentsTests
+{
+    [Fact]
+    public void DotNetToolBuildRunsInASingleNonReusableNode()
+    {
+        var arguments = CompileTimeAssemblyLocator.GetDotNetToolArguments( "msbuild_1234.binlog" );
+
+        Assert.Equal( "build -nodeReuse:false -m:1 -bl:msbuild_1234.binlog", arguments );
+    }
+
+    [Fact]
+    public void MSBuildToolBuildRunsInASingleNonReusableNode()
+    {
+        var arguments = CompileTimeAssemblyLocator.GetMSBuildToolArguments( @"C:\cache\TempProject.csproj", "msbuild_1234.binlog" );
+
+        Assert.Equal( @"""C:\cache\TempProject.csproj"" /t:Restore;Build /nodeReuse:false /m:1 /bl:msbuild_1234.binlog", arguments );
+    }
+}

--- a/Metalama.Framework/src/tests/Standalone/Issue1744/README.md
+++ b/Metalama.Framework/src/tests/Standalone/Issue1744/README.md
@@ -25,9 +25,10 @@ Two settings make the scenario repeatable, and both are necessary:
   previous compilation created successfully, in which case this scenario would build cleanly and assert nothing.
 
 An earlier version of this scenario provoked the failure with a one-millisecond
-`MetalamaReferenceAssemblyRestoreTimeout`. That does not work: killing the `dotnet` process does not stop the MSBuild
-worker processes it started, which finish the build and populate the cache, so the scenario passed once and silently
-stopped asserting afterwards.
+`MetalamaReferenceAssemblyRestoreTimeout`. That did not work: killing the `dotnet` process did not stop the MSBuild
+worker processes it had started, which finished the build and populated the cache, so the scenario passed once and
+silently stopped asserting afterwards. The nested build no longer starts worker processes since issue #1740, but the
+provocation used here is still preferred, because it does not depend on timing.
 
 ## Why the build is expected to fail
 


### PR DESCRIPTION
## Summary

- The nested build that resolves the compile-time reference assemblies now runs with `-nodeReuse:false -m:1` (`/nodeReuse:false /m:1` on the `MSBuild.exe` path). That build is started from inside the compiler, which itself runs inside a task of the outer build, so with MSBuild's default settings it requests worker nodes from a build whose own nodes are occupied waiting for it. Whether a node happens to be free is timing-dependent, which is what made the reported failure intermittent and unrelated to any axis of the build matrix.
- `DotNetTool` and `MSBuildTool` set `MSBUILDDISABLENODEREUSE=1` in the child environment, which covers any further MSBuild that the child may start on its own.
- With a single in-process node, the nested build no longer leaves worker processes behind, so terminating the child process when it exceeds its time budget genuinely terminates the build.
- New unit test `ReferenceAssemblyBuildArgumentsTests` covers both command lines.

The diagnostic half of #1740 (`LAMA0083` instead of `LAMA0001`, naming `MetalamaReferenceAssemblyRestoreTimeout` and the binary log path) was already implemented under #1744 and #1746.

## Trade-off

`-m:1` serializes the inner builds of the three compile-time target frameworks. Each of them compiles a single trivial source file, and the restore, which is the expensive part, happens once for the whole project, so the cost is negligible against a 120 s budget.

## Verification

Building `Standalone/Issue1789` with a fresh `MetalamaAssemblyLocatorSalt` forces the nested build to run. Its binary log records the forwarded command line `... -nodeReuse:false -m:1 -bl:...` and the `MSBUILDDISABLENODEREUSE` environment variable, so the switches survive the .NET CLI argument forwarding.

## Issues Fixed

- Fixes #1740 - Intermittent LAMA0001: nested reference-assembly build times out after 120 s.

&mdash; Claude for @gfraiteur
