### PR TITLE
Do not assume a syntax tree path is unique in a compilation (#1742)

### DIFF
--- a/Metalama.Framework/src/Metalama.Extensions.HtmlWriter/HtmlCodeWriter.cs
+++ b/Metalama.Framework/src/Metalama.Extensions.HtmlWriter/HtmlCodeWriter.cs
@@ -616,12 +616,12 @@ internal sealed class HtmlCodeWriter : IHtmlCodeWriter
 
         FileDiffInfo? GetDiffInfoForPath( string path, bool isOld )
         {
-            if ( !inputCompilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out var oldTree ) )
+            if ( !inputCompilation.TryGetSyntaxTreeByPath( path, out var oldTree ) )
             {
                 return null;
             }
 
-            if ( !outputCompilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out var newTree ) )
+            if ( !outputCompilation.TryGetSyntaxTreeByPath( path, out var newTree ) )
             {
                 return null;
             }
@@ -631,7 +631,7 @@ internal sealed class HtmlCodeWriter : IHtmlCodeWriter
 
         SyntaxTreeKind GetOutputSyntaxTreeKind( string path )
         {
-            if ( inputCompilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out _ ) )
+            if ( inputCompilation.TryGetSyntaxTreeByPath( path, out _ ) )
             {
                 return SyntaxTreeKind.Transformed;
             }

--- a/Metalama.Framework/src/Metalama.Extensions.HtmlWriter/HtmlCodeWriter.cs
+++ b/Metalama.Framework/src/Metalama.Extensions.HtmlWriter/HtmlCodeWriter.cs
@@ -616,12 +616,12 @@ internal sealed class HtmlCodeWriter : IHtmlCodeWriter
 
         FileDiffInfo? GetDiffInfoForPath( string path, bool isOld )
         {
-            if ( !inputCompilation.SyntaxTrees.TryGetValue( path, out var oldTree ) )
+            if ( !inputCompilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out var oldTree ) )
             {
                 return null;
             }
 
-            if ( !outputCompilation.SyntaxTrees.TryGetValue( path, out var newTree ) )
+            if ( !outputCompilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out var newTree ) )
             {
                 return null;
             }
@@ -631,7 +631,7 @@ internal sealed class HtmlCodeWriter : IHtmlCodeWriter
 
         SyntaxTreeKind GetOutputSyntaxTreeKind( string path )
         {
-            if ( inputCompilation.SyntaxTrees.ContainsKey( path ) )
+            if ( inputCompilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out _ ) )
             {
                 return SyntaxTreeKind.Transformed;
             }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/CodeLens/CodeLensServiceImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/CodeLens/CodeLensServiceImpl.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
@@ -117,7 +118,7 @@ internal sealed class CodeLensServiceImpl : PreviewPipelineBasedService, ICodeLe
         }
 
         // If we have a plain method, display the number of target aspects.
-        if ( !codePointData.PipelineResult.SyntaxTreeResults.TryGetValue( codePointData.FilePath, out var syntaxTreeResult ) )
+        if ( !codePointData.PipelineResult.SyntaxTreeResults.TryGetValue( DocumentKey.FromPath( codePointData.FilePath ), out var syntaxTreeResult ) )
         {
             this._logger.Trace?.Log( $"Cannot return code lens info for symbol '{symbolId}' in '{projectKey}' because there is no result for this symbol." );
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/DesignTimeDiagnosticDescriptors.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/DesignTimeDiagnosticDescriptors.cs
@@ -55,6 +55,25 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                     "A Metalama user hidden message.",
                     _category );
 
+        /// <summary>
+        /// Reported when several syntax trees of the compilation have one path, which the project system can produce
+        /// out of a valid project and which Metalama resolves by analyzing one of them. See issue #1742.
+        /// </summary>
+        /// <remarks>
+        /// Design-time only. The command-line compiler deduplicates its source files itself, reporting <c>CS2002</c>, so
+        /// the build is unaffected and this warning is the only notice the user receives.
+        /// </remarks>
+        internal static readonly DiagnosticDefinition<string>
+            DuplicateSyntaxTreePath
+                = new(
+                    "LAMA0307",
+                    Warning,
+                    "Several source files of this project have the path '{0}'. Metalama analyzes only one of them, so a declaration "
+                    + "of the others is not seen by aspects. Verify that the file is not included several times by the project file, "
+                    + "for instance by a Compile item that repeats a glob, by Link metadata, or by a shared project.",
+                    "Several source files of the project have the same path.",
+                    _category );
+
         internal static readonly DiagnosticDefinition<(string Id, ISymbol Symbol)>
             UnregisteredSuppression
                 = new(

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/TheDiagnosticAnalyzer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/TheDiagnosticAnalyzer.cs
@@ -403,7 +403,7 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
 
             var syntaxTree = context.SemanticModel.SyntaxTree;
 
-            if ( compilation.GetIndexedSyntaxTrees().TryGetValue( syntaxTreeFilePath, out var indexedSyntaxTree )
+            if ( compilation.GetIndexedSyntaxTrees().TryGetValue( syntaxTree.GetDocumentKey(), out var indexedSyntaxTree )
                  && indexedSyntaxTree == syntaxTree
                  && duplicates.Any( t => string.Equals( t.FilePath, syntaxTreeFilePath, StringComparison.Ordinal ) ) )
             {
@@ -432,7 +432,7 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
 
                 // Find the new syntax tree in the compilation.
 
-                if ( !compilation.GetIndexedSyntaxTrees().TryGetValue( reportSourceTree.FilePath, out var newSyntaxTree ) )
+                if ( !compilation.GetIndexedSyntaxTrees().TryGetValue( reportSourceTree.GetDocumentKey(), out var newSyntaxTree ) )
                 {
                     mappedLocation = Location.Create( reportSourceTree.FilePath, location.SourceSpan, location.GetLineSpan().Span );
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/TheDiagnosticAnalyzer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/TheDiagnosticAnalyzer.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using JetBrains.Annotations;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Compiler;
@@ -10,6 +9,7 @@ using Metalama.Framework.DesignTime.Pipeline;
 using Metalama.Framework.DesignTime.Services;
 using Metalama.Framework.DesignTime.Utilities;
 using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Options;
 using Metalama.Framework.Engine.Services;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/TheDiagnosticAnalyzer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticAnalysis/TheDiagnosticAnalyzer.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using JetBrains.Annotations;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Compiler;
@@ -107,6 +108,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                     return;
                 }
 
+                ReportDuplicateSyntaxTreePath( context, compilation, syntaxTreeFilePath );
+
                 // Execute the pipeline.
                 var cancellationToken = context.CancellationToken.IgnoreIfDebugging().ToTestable();
 
@@ -166,8 +169,8 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 }
                 else
                 {
-                    diagnostics = pipelineResult.Value.GetDiagnosticsOnSyntaxTree( syntaxTreeFilePath ).Concat( filteredPipelineDiagnostics );
-                    suppressions = pipelineResult.Value.GetSuppressionsOnSyntaxTree( syntaxTreeFilePath );
+                    diagnostics = pipelineResult.Value.GetDiagnosticsOnSyntaxTree( DocumentKey.FromPath( syntaxTreeFilePath ) ).Concat( filteredPipelineDiagnostics );
+                    suppressions = pipelineResult.Value.GetSuppressionsOnSyntaxTree( DocumentKey.FromPath( syntaxTreeFilePath ) );
                 }
 
                 // Execute the analyses that are not performed in the design-time pipeline.
@@ -177,7 +180,7 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                     context.SemanticModel,
                     ReportDiagnostic,
                     null,
-                    pipeline.MustReportPausedPipelineAsErrors && pipeline.IsCompileTimeSyntaxTreeOutdated( context.SemanticModel.SyntaxTree.FilePath ),
+                    pipeline.MustReportPausedPipelineAsErrors && pipeline.IsCompileTimeSyntaxTreeOutdated( context.SemanticModel.SyntaxTree.GetDocumentKey() ),
                     true,
                     cancellationToken );
 
@@ -370,6 +373,44 @@ namespace Metalama.Framework.DesignTime.DiagnosticAnalysis
                 {
                     reportDiagnostic( designTimeDiagnostic );
                 }
+            }
+        }
+
+        /// <summary>
+        /// Reports <see cref="DesignTimeDiagnosticDescriptors.DuplicateSyntaxTreePath"/> when several syntax trees of
+        /// the compilation share the path of the tree being analyzed.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// Reported here rather than from the pipeline because this is the only design-time surface that reaches the
+        /// user's editor with a location, and because the condition is a property of the compilation the IDE built and
+        /// not of anything the pipeline did. The pipeline never sees it: the compilation it analyzes has already been
+        /// normalized. See issue #1742.
+        /// </para>
+        /// <para>
+        /// Reported once, on the tree that keeps the path, so that the two analyzer invocations Roslyn makes for the two
+        /// trees do not produce two warnings on one file.
+        /// </para>
+        /// </remarks>
+        private static void ReportDuplicateSyntaxTreePath( ISemanticModelAnalysisContext context, Compilation compilation, string syntaxTreeFilePath )
+        {
+            var duplicates = compilation.GetDuplicatePathSyntaxTrees();
+
+            if ( duplicates.IsEmpty )
+            {
+                return;
+            }
+
+            var syntaxTree = context.SemanticModel.SyntaxTree;
+
+            if ( compilation.GetIndexedSyntaxTrees().TryGetValue( syntaxTreeFilePath, out var indexedSyntaxTree )
+                 && indexedSyntaxTree == syntaxTree
+                 && duplicates.Any( t => string.Equals( t.FilePath, syntaxTreeFilePath, StringComparison.Ordinal ) ) )
+            {
+                context.ReportDiagnostic(
+                    DesignTimeDiagnosticDescriptors.DuplicateSyntaxTreePath.CreateRoslynDiagnostic(
+                        Location.Create( syntaxTree, default ),
+                        syntaxTreeFilePath ) );
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticSuppressing/TheDiagnosticSuppressor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/DiagnosticSuppressing/TheDiagnosticSuppressor.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using JetBrains.Annotations;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Compiler;
@@ -163,7 +164,7 @@ namespace Metalama.Framework.DesignTime.DiagnosticSuppressing
                 {
                     var syntaxTree = diagnosticGroup.Key;
 
-                    var pipelineSuppressions = pipelineResult.Value.GetSuppressionsOnSyntaxTree( syntaxTree.FilePath );
+                    var pipelineSuppressions = pipelineResult.Value.GetSuppressionsOnSyntaxTree( syntaxTree.GetDocumentKey() );
 
                     var supportedPipelineSuppressions = pipelineSuppressions
                         .Where( s => supportedSuppressionDescriptors.ContainsKey( s.Suppression.Definition.SuppressedDiagnosticId ) )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/CompilationPipelineResult.Invalidator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/CompilationPipelineResult.Invalidator.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Utilities.Diagnostics;
 using System.Collections.Immutable;
 
@@ -12,8 +13,8 @@ public sealed partial class DesignTimeAspectPipelineResult
     internal sealed class Invalidator
     {
         private readonly DesignTimeAspectPipelineResult _parent;
-        private readonly ImmutableDictionary<string, SyntaxTreePipelineResult>.Builder _syntaxTreeBuilders;
-        private readonly ImmutableDictionary<string, SyntaxTreePipelineResult>.Builder _invalidSyntaxTreeBuilders;
+        private readonly ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult>.Builder _syntaxTreeBuilders;
+        private readonly ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult>.Builder _invalidSyntaxTreeBuilders;
 
         public Invalidator( DesignTimeAspectPipelineResult parent )
         {
@@ -23,7 +24,7 @@ public sealed partial class DesignTimeAspectPipelineResult
             this._invalidSyntaxTreeBuilders = parent._invalidSyntaxTreeResults.ToBuilder();
         }
 
-        public void InvalidateSyntaxTree( string path )
+        public void InvalidateSyntaxTree( DocumentKey path )
         {
             Logger.DesignTime.Trace?.Log( $"DesignTimeSyntaxTreeResultCache.InvalidateCache({path}): removed from cache." );
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/BaseDependencyCollector.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/BaseDependencyCollector.cs
@@ -20,9 +20,9 @@ internal class BaseDependencyCollector
     /// </summary>
     public PartialCompilation PartialCompilation { get; }
 
-    private readonly ConcurrentDictionary<string, DependencyCollectorByDependentSyntaxTree> _dependenciesByDependentFilePath = new();
+    private readonly ConcurrentDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTree> _dependenciesByDependentFilePath = new();
 
-    public IReadOnlyDictionary<string, DependencyCollectorByDependentSyntaxTree> DependenciesByDependentFilePath => this._dependenciesByDependentFilePath;
+    public IReadOnlyDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTree> DependenciesByDependentFilePath => this._dependenciesByDependentFilePath;
 
     public BaseDependencyCollector( IProjectVersion projectVersion, PartialCompilation? partialCompilation = null )
     {
@@ -64,7 +64,7 @@ internal class BaseDependencyCollector
         }
     }
 
-    public void AddPartialTypeDependency( string dependentFilePath, ProjectKey masterProjectKey, TypeDependencyKey masterPartialType )
+    public void AddPartialTypeDependency( DocumentKey dependentFilePath, ProjectKey masterProjectKey, TypeDependencyKey masterPartialType )
     {
 #if DEBUG
         if ( this.IsReadOnly )
@@ -78,7 +78,7 @@ internal class BaseDependencyCollector
         dependencies.AddPartialTypeDependency( masterProjectKey, masterPartialType );
     }
 
-    public void AddSyntaxTreeDependency( string dependentFilePath, ProjectKey masterProjectKey, string masterFilePath, ulong masterHash )
+    public void AddSyntaxTreeDependency( DocumentKey dependentFilePath, ProjectKey masterProjectKey, DocumentKey masterFilePath, ulong masterHash )
     {
 #if DEBUG
         if ( this.IsReadOnly )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/BaseDependencyCollector.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/BaseDependencyCollector.cs
@@ -20,9 +20,9 @@ internal class BaseDependencyCollector
     /// </summary>
     public PartialCompilation PartialCompilation { get; }
 
-    private readonly ConcurrentDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTree> _dependenciesByDependentFilePath = new();
+    private readonly ConcurrentDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTree> _dependenciesByDependentDocumentKey = new();
 
-    public IReadOnlyDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTree> DependenciesByDependentFilePath => this._dependenciesByDependentFilePath;
+    public IReadOnlyDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTree> DependenciesByDependentDocumentKey => this._dependenciesByDependentDocumentKey;
 
     public BaseDependencyCollector( IProjectVersion projectVersion, PartialCompilation? partialCompilation = null )
     {
@@ -35,13 +35,13 @@ internal class BaseDependencyCollector
     /// </summary>
     public IEnumerable<SyntaxTreeDependency> EnumerateSyntaxTreeDependencies()
     {
-        foreach ( var dependenciesByDependentSyntaxTree in this._dependenciesByDependentFilePath )
+        foreach ( var dependenciesByDependentSyntaxTree in this._dependenciesByDependentDocumentKey )
         {
             foreach ( var dependenciesInCompilation in dependenciesByDependentSyntaxTree.Value.DependenciesByMasterProject )
             {
-                foreach ( var masterFilePath in dependenciesInCompilation.Value.MasterFilePathsAndHashes.Keys )
+                foreach ( var masterDocumentKey in dependenciesInCompilation.Value.MasterDocumentKeysAndHashes.Keys )
                 {
-                    yield return new SyntaxTreeDependency( masterFilePath, dependenciesInCompilation.Value.DependentFilePath );
+                    yield return new SyntaxTreeDependency( masterDocumentKey, dependenciesInCompilation.Value.DependentDocumentKey );
                 }
             }
         }
@@ -52,19 +52,19 @@ internal class BaseDependencyCollector
     /// </summary>
     public IEnumerable<PartialTypeDependency> EnumeratePartialTypeDependencies()
     {
-        foreach ( var dependenciesByDependentSyntaxTree in this._dependenciesByDependentFilePath )
+        foreach ( var dependenciesByDependentSyntaxTree in this._dependenciesByDependentDocumentKey )
         {
             foreach ( var dependenciesInCompilation in dependenciesByDependentSyntaxTree.Value.DependenciesByMasterProject )
             {
                 foreach ( var masterType in dependenciesInCompilation.Value.MasterPartialTypes )
                 {
-                    yield return new PartialTypeDependency( masterType, dependenciesInCompilation.Value.DependentFilePath );
+                    yield return new PartialTypeDependency( masterType, dependenciesInCompilation.Value.DependentDocumentKey );
                 }
             }
         }
     }
 
-    public void AddPartialTypeDependency( DocumentKey dependentFilePath, ProjectKey masterProjectKey, TypeDependencyKey masterPartialType )
+    public void AddPartialTypeDependency( DocumentKey dependentDocumentKey, ProjectKey masterProjectKey, TypeDependencyKey masterPartialType )
     {
 #if DEBUG
         if ( this.IsReadOnly )
@@ -73,12 +73,12 @@ internal class BaseDependencyCollector
         }
 #endif
 
-        var dependencies = this._dependenciesByDependentFilePath.GetOrAdd( dependentFilePath, x => new DependencyCollectorByDependentSyntaxTree( x ) );
+        var dependencies = this._dependenciesByDependentDocumentKey.GetOrAdd( dependentDocumentKey, x => new DependencyCollectorByDependentSyntaxTree( x ) );
 
         dependencies.AddPartialTypeDependency( masterProjectKey, masterPartialType );
     }
 
-    public void AddSyntaxTreeDependency( DocumentKey dependentFilePath, ProjectKey masterProjectKey, DocumentKey masterFilePath, ulong masterHash )
+    public void AddSyntaxTreeDependency( DocumentKey dependentDocumentKey, ProjectKey masterProjectKey, DocumentKey masterDocumentKey, ulong masterHash )
     {
 #if DEBUG
         if ( this.IsReadOnly )
@@ -87,9 +87,9 @@ internal class BaseDependencyCollector
         }
 #endif
 
-        var dependencies = this._dependenciesByDependentFilePath.GetOrAdd( dependentFilePath, x => new DependencyCollectorByDependentSyntaxTree( x ) );
+        var dependencies = this._dependenciesByDependentDocumentKey.GetOrAdd( dependentDocumentKey, x => new DependencyCollectorByDependentSyntaxTree( x ) );
 
-        dependencies.AddSyntaxTreeDependency( masterProjectKey, masterFilePath, masterHash );
+        dependencies.AddSyntaxTreeDependency( masterProjectKey, masterDocumentKey, masterHash );
     }
 
 #if DEBUG
@@ -99,7 +99,7 @@ internal class BaseDependencyCollector
     {
         this.IsReadOnly = true;
 
-        foreach ( var child in this._dependenciesByDependentFilePath.Values )
+        foreach ( var child in this._dependenciesByDependentDocumentKey.Values )
         {
             child.Freeze();
         }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollector.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollector.cs
@@ -73,9 +73,9 @@ internal sealed class DependencyCollector : BaseDependencyCollector, IDependency
                     if ( dependentTree != masterSyntaxReference.SyntaxTree )
                     {
                         this.AddSyntaxTreeDependency(
-                            dependentTree.FilePath,
+                            dependentTree.GetDocumentKey(),
                             this.ProjectVersion.ProjectKey,
-                            masterSyntaxReference.SyntaxTree.FilePath,
+                            masterSyntaxReference.SyntaxTree.GetDocumentKey(),
                             0 );
                     }
                 }
@@ -83,7 +83,7 @@ internal sealed class DependencyCollector : BaseDependencyCollector, IDependency
                 if ( masterIsPartial )
                 {
                     this.AddPartialTypeDependency(
-                        dependentTree.FilePath,
+                        dependentTree.GetDocumentKey(),
                         this.ProjectVersion.ProjectKey,
                         new TypeDependencyKey( masterSymbol, this._storeTypeName ) );
                 }
@@ -102,14 +102,14 @@ internal sealed class DependencyCollector : BaseDependencyCollector, IDependency
 
                 foreach ( var masterSyntaxReference in masterSymbol.DeclaringSyntaxReferences )
                 {
-                    if ( referencedCompilationVersion.TryGetSyntaxTreeVersion( masterSyntaxReference.SyntaxTree.FilePath, out var masterSyntaxTreeVersion ) )
+                    if ( referencedCompilationVersion.TryGetSyntaxTreeVersion( masterSyntaxReference.SyntaxTree.GetDocumentKey(), out var masterSyntaxTreeVersion ) )
                     {
                         foreach ( var dependentSyntaxReference in dependentTrees )
                         {
                             this.AddSyntaxTreeDependency(
-                                dependentSyntaxReference.FilePath,
+                                dependentSyntaxReference.GetDocumentKey(),
                                 referencedCompilationVersion.ProjectKey,
-                                masterSyntaxReference.SyntaxTree.FilePath,
+                                masterSyntaxReference.SyntaxTree.GetDocumentKey(),
                                 masterSyntaxTreeVersion.DeclarationHash );
                         }
                     }
@@ -124,7 +124,7 @@ internal sealed class DependencyCollector : BaseDependencyCollector, IDependency
                         foreach ( var dependentSyntaxReference in dependentTrees )
                         {
                             this.AddPartialTypeDependency(
-                                dependentSyntaxReference.FilePath,
+                                dependentSyntaxReference.GetDocumentKey(),
                                 referencedCompilationVersion.ProjectKey,
                                 new TypeDependencyKey( masterSymbol, this._storeTypeName ) );
                         }
@@ -215,9 +215,9 @@ internal sealed class DependencyCollector : BaseDependencyCollector, IDependency
         if ( dependentTree != masterTree )
         {
             this.AddSyntaxTreeDependency(
-                dependentTree.FilePath,
+                dependentTree.GetDocumentKey(),
                 this.ProjectVersion.ProjectKey,
-                masterTree.FilePath,
+                masterTree.GetDocumentKey(),
                 0 );
         }
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTree.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTree.cs
@@ -15,17 +15,17 @@ internal sealed class DependencyCollectorByDependentSyntaxTree
 {
     private readonly ConcurrentDictionary<ProjectKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> _dependenciesByMasterProject = new();
 
-    public DocumentKey DependentFilePath { get; }
+    public DocumentKey DependentDocumentKey { get; }
 
     public IReadOnlyDictionary<ProjectKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> DependenciesByMasterProject
         => this._dependenciesByMasterProject;
 
-    public DependencyCollectorByDependentSyntaxTree( DocumentKey dependentFilePath )
+    public DependencyCollectorByDependentSyntaxTree( DocumentKey dependentDocumentKey )
     {
-        this.DependentFilePath = dependentFilePath;
+        this.DependentDocumentKey = dependentDocumentKey;
     }
 
-    public void AddSyntaxTreeDependency( ProjectKey masterCompilation, DocumentKey masterFilePath, ulong masterHash )
+    public void AddSyntaxTreeDependency( ProjectKey masterCompilation, DocumentKey masterDocumentKey, ulong masterHash )
     {
 #if DEBUG
         if ( this._isReadOnly )
@@ -37,9 +37,9 @@ internal sealed class DependencyCollectorByDependentSyntaxTree
         var compilationCollector = this._dependenciesByMasterProject.GetOrAdd(
             masterCompilation,
             static ( _, path ) => new DependencyCollectorByDependentSyntaxTreeAndMasterProject( path ),
-            this.DependentFilePath );
+            this.DependentDocumentKey );
 
-        compilationCollector.AddSyntaxTreeDependency( masterFilePath, masterHash );
+        compilationCollector.AddSyntaxTreeDependency( masterDocumentKey, masterHash );
     }
 
     public void AddPartialTypeDependency( ProjectKey masterProject, TypeDependencyKey masterPartialType )
@@ -54,7 +54,7 @@ internal sealed class DependencyCollectorByDependentSyntaxTree
         var compilationCollector = this._dependenciesByMasterProject.GetOrAdd(
             masterProject,
             static ( _, path ) => new DependencyCollectorByDependentSyntaxTreeAndMasterProject( path ),
-            this.DependentFilePath );
+            this.DependentDocumentKey );
 
         compilationCollector.AddPartialTypeDependency( masterPartialType );
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTree.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTree.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
 using System.Collections.Concurrent;
 
@@ -14,17 +15,17 @@ internal sealed class DependencyCollectorByDependentSyntaxTree
 {
     private readonly ConcurrentDictionary<ProjectKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> _dependenciesByMasterProject = new();
 
-    public string DependentFilePath { get; }
+    public DocumentKey DependentFilePath { get; }
 
     public IReadOnlyDictionary<ProjectKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> DependenciesByMasterProject
         => this._dependenciesByMasterProject;
 
-    public DependencyCollectorByDependentSyntaxTree( string dependentFilePath )
+    public DependencyCollectorByDependentSyntaxTree( DocumentKey dependentFilePath )
     {
         this.DependentFilePath = dependentFilePath;
     }
 
-    public void AddSyntaxTreeDependency( ProjectKey masterCompilation, string masterFilePath, ulong masterHash )
+    public void AddSyntaxTreeDependency( ProjectKey masterCompilation, DocumentKey masterFilePath, ulong masterHash )
     {
 #if DEBUG
         if ( this._isReadOnly )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTree.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTree.cs
@@ -2,8 +2,8 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.Engine.CodeModel;
 using System.Collections.Concurrent;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTreeAndMasterProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTreeAndMasterProject.cs
@@ -2,8 +2,8 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.CodeModel;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTreeAndMasterProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTreeAndMasterProject.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
@@ -11,24 +12,24 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// </summary>
 internal sealed class DependencyCollectorByDependentSyntaxTreeAndMasterProject
 {
-    private readonly Dictionary<string, ulong> _masterFilePathsAndHashes = new( StringComparer.Ordinal );
+    private readonly Dictionary<DocumentKey, ulong> _masterFilePathsAndHashes = new();
     private readonly HashSet<TypeDependencyKey> _masterPartialTypes = new();
     private int _hashCode;
 
-    public string DependentFilePath { get; }
+    public DocumentKey DependentFilePath { get; }
 
-    public IReadOnlyDictionary<string, ulong> MasterFilePathsAndHashes => this._masterFilePathsAndHashes;
+    public IReadOnlyDictionary<DocumentKey, ulong> MasterFilePathsAndHashes => this._masterFilePathsAndHashes;
 
     public IReadOnlyCollection<TypeDependencyKey> MasterPartialTypes => this._masterPartialTypes;
 
     public bool Contains( TypeDependencyKey type ) => this._masterPartialTypes.Contains( type );
 
-    public DependencyCollectorByDependentSyntaxTreeAndMasterProject( string dependentFilePath )
+    public DependencyCollectorByDependentSyntaxTreeAndMasterProject( DocumentKey dependentFilePath )
     {
         this.DependentFilePath = dependentFilePath;
     }
 
-    public void AddSyntaxTreeDependency( string masterFilePath, ulong masterHash )
+    public void AddSyntaxTreeDependency( DocumentKey masterFilePath, ulong masterHash )
     {
 #if DEBUG
         if ( this._isReadOnly )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTreeAndMasterProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyCollectorByDependentSyntaxTreeAndMasterProject.cs
@@ -12,24 +12,24 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// </summary>
 internal sealed class DependencyCollectorByDependentSyntaxTreeAndMasterProject
 {
-    private readonly Dictionary<DocumentKey, ulong> _masterFilePathsAndHashes = new();
+    private readonly Dictionary<DocumentKey, ulong> _masterDocumentKeysAndHashes = new();
     private readonly HashSet<TypeDependencyKey> _masterPartialTypes = new();
     private int _hashCode;
 
-    public DocumentKey DependentFilePath { get; }
+    public DocumentKey DependentDocumentKey { get; }
 
-    public IReadOnlyDictionary<DocumentKey, ulong> MasterFilePathsAndHashes => this._masterFilePathsAndHashes;
+    public IReadOnlyDictionary<DocumentKey, ulong> MasterDocumentKeysAndHashes => this._masterDocumentKeysAndHashes;
 
     public IReadOnlyCollection<TypeDependencyKey> MasterPartialTypes => this._masterPartialTypes;
 
     public bool Contains( TypeDependencyKey type ) => this._masterPartialTypes.Contains( type );
 
-    public DependencyCollectorByDependentSyntaxTreeAndMasterProject( DocumentKey dependentFilePath )
+    public DependencyCollectorByDependentSyntaxTreeAndMasterProject( DocumentKey dependentDocumentKey )
     {
-        this.DependentFilePath = dependentFilePath;
+        this.DependentDocumentKey = dependentDocumentKey;
     }
 
-    public void AddSyntaxTreeDependency( DocumentKey masterFilePath, ulong masterHash )
+    public void AddSyntaxTreeDependency( DocumentKey masterDocumentKey, ulong masterHash )
     {
 #if DEBUG
         if ( this._isReadOnly )
@@ -37,16 +37,16 @@ internal sealed class DependencyCollectorByDependentSyntaxTreeAndMasterProject
             throw new InvalidOperationException();
         }
 #endif
-        lock ( this._masterFilePathsAndHashes )
+        lock ( this._masterDocumentKeysAndHashes )
         {
-            if ( !this._masterFilePathsAndHashes.TryGetValue( masterFilePath, out var existingHash ) )
+            if ( !this._masterDocumentKeysAndHashes.TryGetValue( masterDocumentKey, out var existingHash ) )
             {
-                this._masterFilePathsAndHashes.Add( masterFilePath, masterHash );
-                this._hashCode ^= HashCode.Combine( masterFilePath, masterHash );
+                this._masterDocumentKeysAndHashes.Add( masterDocumentKey, masterHash );
+                this._hashCode ^= HashCode.Combine( masterDocumentKey, masterHash );
             }
             else if ( existingHash != masterHash )
             {
-                throw new AssertionFailedException( $"Hashes '{existingHash}' and '{masterHash}' do not match for '{masterFilePath}'." );
+                throw new AssertionFailedException( $"Hashes '{existingHash}' and '{masterHash}' do not match for '{masterDocumentKey}'." );
             }
         }
     }
@@ -86,15 +86,15 @@ internal sealed class DependencyCollectorByDependentSyntaxTreeAndMasterProject
         }
 
         if ( this._hashCode != other._hashCode
-             || this._masterFilePathsAndHashes.Count != other._masterFilePathsAndHashes.Count
+             || this._masterDocumentKeysAndHashes.Count != other._masterDocumentKeysAndHashes.Count
              || this._masterPartialTypes.Count != other._masterPartialTypes.Count )
         {
             return false;
         }
 
-        foreach ( var dependency in this._masterFilePathsAndHashes )
+        foreach ( var dependency in this._masterDocumentKeysAndHashes )
         {
-            if ( !other._masterFilePathsAndHashes.TryGetValue( dependency.Key, out var otherHash ) || otherHash != dependency.Value )
+            if ( !other._masterDocumentKeysAndHashes.TryGetValue( dependency.Key, out var otherHash ) || otherHash != dependency.Value )
             {
                 return false;
             }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.Builder.cs
@@ -2,8 +2,8 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.Engine.CodeModel;
 using System.Collections.Immutable;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.Builder.cs
@@ -68,7 +68,7 @@ internal readonly partial struct DependencyGraph
 
         public void UpdateDependencies(
             ProjectKey projectKey,
-            DocumentKey dependentFilePath,
+            DocumentKey dependentDocumentKey,
             DependencyCollectorByDependentSyntaxTreeAndMasterProject dependencies )
         {
             if ( !this.GetDependenciesByCompilation().TryGetValue( projectKey, out var currentDependenciesOfCompilation ) )
@@ -77,7 +77,7 @@ internal readonly partial struct DependencyGraph
             }
 
             if ( currentDependenciesOfCompilation.TryUpdateDependencies(
-                    dependentFilePath,
+                    dependentDocumentKey,
                     dependencies,
                     out var newDependenciesOfCompilation ) )
             {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.Builder.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
 using System.Collections.Immutable;
 
@@ -27,7 +28,7 @@ internal readonly partial struct DependencyGraph
             => (IReadOnlyDictionary<ProjectKey, DependencyGraphByDependentProject>?) this._dependenciesByCompilationBuilder
                ?? this._dependencyGraph.DependenciesByMasterProject;
 
-        public void RemoveDependentSyntaxTree( string path )
+        public void RemoveDependentSyntaxTree( DocumentKey path )
         {
             List<DependencyGraphByDependentProject>? modifiedDependencies = null;
 
@@ -67,7 +68,7 @@ internal readonly partial struct DependencyGraph
 
         public void UpdateDependencies(
             ProjectKey projectKey,
-            string dependentFilePath,
+            DocumentKey dependentFilePath,
             DependencyCollectorByDependentSyntaxTreeAndMasterProject dependencies )
         {
             if ( !this.GetDependenciesByCompilation().TryGetValue( projectKey, out var currentDependenciesOfCompilation ) )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.cs
@@ -37,23 +37,23 @@ internal readonly partial struct DependencyGraph
         var builder = this.ToBuilder();
 
         // Add or update dependencies.
-        foreach ( var dependenciesByDependentFilePath in dependencyCollector.DependenciesByDependentFilePath )
+        foreach ( var dependenciesByDependentDocumentKey in dependencyCollector.DependenciesByDependentDocumentKey )
         {
-            var dependentFilePath = dependenciesByDependentFilePath.Key;
+            var dependentDocumentKey = dependenciesByDependentDocumentKey.Key;
 
             // ReSharper disable once SuspiciousTypeConversion.Global
 
-            foreach ( var dependenciesByMasterProject in dependenciesByDependentFilePath.Value.DependenciesByMasterProject )
+            foreach ( var dependenciesByMasterProject in dependenciesByDependentDocumentKey.Value.DependenciesByMasterProject )
             {
                 var projectKey = dependenciesByMasterProject.Key;
-                builder.UpdateDependencies( projectKey, dependentFilePath, dependenciesByMasterProject.Value );
+                builder.UpdateDependencies( projectKey, dependentDocumentKey, dependenciesByMasterProject.Value );
             }
         }
 
         // Remove graphs for dependent syntax trees were analyzed but for which no dependency was found.
         foreach ( var syntaxTree in dependencyCollector.PartialCompilation.SyntaxTreeCollection )
         {
-            if ( !dependencyCollector.DependenciesByDependentFilePath.ContainsKey( syntaxTree.GetDocumentKey() ) )
+            if ( !dependencyCollector.DependenciesByDependentDocumentKey.ContainsKey( syntaxTree.GetDocumentKey() ) )
             {
                 // The syntax tree does not have any dependency in any compilation.
                 builder.RemoveDependentSyntaxTree( syntaxTree.GetDocumentKey() );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
 using System.Collections.Immutable;
 
@@ -50,12 +51,12 @@ internal readonly partial struct DependencyGraph
         }
 
         // Remove graphs for dependent syntax trees were analyzed but for which no dependency was found.
-        foreach ( var syntaxTreeEntry in dependencyCollector.PartialCompilation.SyntaxTrees )
+        foreach ( var syntaxTree in dependencyCollector.PartialCompilation.SyntaxTreeCollection )
         {
-            if ( !dependencyCollector.DependenciesByDependentFilePath.ContainsKey( syntaxTreeEntry.Key ) )
+            if ( !dependencyCollector.DependenciesByDependentFilePath.ContainsKey( syntaxTree.GetDocumentKey() ) )
             {
                 // The syntax tree does not have any dependency in any compilation.
-                builder.RemoveDependentSyntaxTree( syntaxTreeEntry.Key );
+                builder.RemoveDependentSyntaxTree( syntaxTree.GetDocumentKey() );
             }
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraph.cs
@@ -2,8 +2,8 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.Engine.CodeModel;
 using System.Collections.Immutable;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByDependentProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByDependentProject.cs
@@ -13,10 +13,10 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// </summary>
 internal readonly struct DependencyGraphByDependentProject
 {
-    private static readonly ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> _emptyDependenciesByMasterFilePath =
+    private static readonly ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> _emptyDependenciesByMasterDocumentKey =
         ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree>.Empty;
 
-    private static readonly ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> _emptyDependenciesByDependentFilePath =
+    private static readonly ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> _emptyDependenciesByDependentDocumentKey =
         ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject>.Empty;
 
     public ProjectKey ProjectKey { get; }
@@ -24,35 +24,35 @@ internal readonly struct DependencyGraphByDependentProject
     /// <summary>
     /// Gets the list of dependencies on syntax trees within the master compilation, indexed by file path.
     /// </summary>
-    public ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> DependenciesByMasterFilePath { get; }
+    public ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> DependenciesByMasterDocumentKey { get; }
 
     public ImmutableDictionary<TypeDependencyKey, DependencyGraphByMasterPartialType> DependenciesByMasterPartialType { get; }
 
-    public bool IsEmpty => this.DependenciesByMasterFilePath.Count == 0 && this.DependenciesByMasterPartialType.Count == 0;
+    public bool IsEmpty => this.DependenciesByMasterDocumentKey.Count == 0 && this.DependenciesByMasterPartialType.Count == 0;
 
-    internal ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> DependenciesByDependentFilePath { get; }
+    internal ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> DependenciesByDependentDocumentKey { get; }
 
     public DependencyGraphByDependentProject( ProjectKey projectKey ) : this(
         projectKey,
-        _emptyDependenciesByMasterFilePath,
+        _emptyDependenciesByMasterDocumentKey,
         ImmutableDictionary<TypeDependencyKey, DependencyGraphByMasterPartialType>.Empty,
-        _emptyDependenciesByDependentFilePath ) { }
+        _emptyDependenciesByDependentDocumentKey ) { }
 
     private DependencyGraphByDependentProject(
         ProjectKey projectKey,
-        ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> dependenciesByMasterFilePath,
+        ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> dependenciesByMasterDocumentKey,
         ImmutableDictionary<TypeDependencyKey, DependencyGraphByMasterPartialType> dependenciesByMasterPartialType,
-        ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> dependenciesByDependentFilePath )
+        ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> dependenciesByDependentDocumentKey )
     {
         this.ProjectKey = projectKey;
-        this.DependenciesByMasterFilePath = dependenciesByMasterFilePath;
+        this.DependenciesByMasterDocumentKey = dependenciesByMasterDocumentKey;
         this.DependenciesByMasterPartialType = dependenciesByMasterPartialType;
-        this.DependenciesByDependentFilePath = dependenciesByDependentFilePath;
+        this.DependenciesByDependentDocumentKey = dependenciesByDependentDocumentKey;
     }
 
-    public bool TryRemoveDependentSyntaxTree( DocumentKey dependentFilePath, out DependencyGraphByDependentProject newDependenciesGraph )
+    public bool TryRemoveDependentSyntaxTree( DocumentKey dependentDocumentKey, out DependencyGraphByDependentProject newDependenciesGraph )
     {
-        if ( !this.DependenciesByDependentFilePath.TryGetValue( dependentFilePath, out var oldDependencies ) )
+        if ( !this.DependenciesByDependentDocumentKey.TryGetValue( dependentDocumentKey, out var oldDependencies ) )
         {
             // There is nothing to do because the dependency was not present.
             newDependenciesGraph = this;
@@ -61,23 +61,23 @@ internal readonly struct DependencyGraphByDependentProject
         }
 
         // Update syntax tree dependencies.
-        var dependenciesByMasterFilePathBuilder = this.DependenciesByMasterFilePath.ToBuilder();
+        var dependenciesByMasterFilePathBuilder = this.DependenciesByMasterDocumentKey.ToBuilder();
 
-        foreach ( var oldMasterFilePathAndHash in oldDependencies.MasterFilePathsAndHashes )
+        foreach ( var oldMasterFilePathAndHash in oldDependencies.MasterDocumentKeysAndHashes )
         {
-            var masterFilePath = oldMasterFilePathAndHash.Key;
+            var masterDocumentKey = oldMasterFilePathAndHash.Key;
 
-            if ( dependenciesByMasterFilePathBuilder.TryGetValue( masterFilePath, out var syntaxTreeDependencies ) )
+            if ( dependenciesByMasterFilePathBuilder.TryGetValue( masterDocumentKey, out var syntaxTreeDependencies ) )
             {
-                var newSyntaxTreeDependencies = syntaxTreeDependencies.RemoveDependency( dependentFilePath );
+                var newSyntaxTreeDependencies = syntaxTreeDependencies.RemoveDependency( dependentDocumentKey );
 
-                if ( newSyntaxTreeDependencies.DependentFilePaths.IsEmpty )
+                if ( newSyntaxTreeDependencies.DependentDocumentKeys.IsEmpty )
                 {
-                    dependenciesByMasterFilePathBuilder.Remove( masterFilePath );
+                    dependenciesByMasterFilePathBuilder.Remove( masterDocumentKey );
                 }
                 else
                 {
-                    dependenciesByMasterFilePathBuilder[masterFilePath] = newSyntaxTreeDependencies;
+                    dependenciesByMasterFilePathBuilder[masterDocumentKey] = newSyntaxTreeDependencies;
                 }
             }
         }
@@ -89,9 +89,9 @@ internal readonly struct DependencyGraphByDependentProject
         {
             if ( dependenciesByMasterPartialTypesBuilder.TryGetValue( type, out var typeDependencies ) )
             {
-                var newTypeDependencies = typeDependencies.RemoveDependency( dependentFilePath );
+                var newTypeDependencies = typeDependencies.RemoveDependency( dependentDocumentKey );
 
-                if ( newTypeDependencies.DependentFilePaths.IsEmpty )
+                if ( newTypeDependencies.DependentDocumentKeys.IsEmpty )
                 {
                     dependenciesByMasterPartialTypesBuilder.Remove( type );
                 }
@@ -106,18 +106,18 @@ internal readonly struct DependencyGraphByDependentProject
             this.ProjectKey,
             dependenciesByMasterFilePathBuilder.ToImmutable(),
             dependenciesByMasterPartialTypesBuilder.ToImmutable(),
-            this.DependenciesByDependentFilePath.Remove( dependentFilePath ) );
+            this.DependenciesByDependentDocumentKey.Remove( dependentDocumentKey ) );
 
         return true;
     }
 
     public bool TryUpdateDependencies(
-        DocumentKey dependentFilePath,
+        DocumentKey dependentDocumentKey,
         DependencyCollectorByDependentSyntaxTreeAndMasterProject dependencies,
         out DependencyGraphByDependentProject newDependenciesGraph )
     {
         // Check if there is any change.
-        if ( this.DependenciesByDependentFilePath.TryGetValue( dependentFilePath, out var oldDependencies )
+        if ( this.DependenciesByDependentDocumentKey.TryGetValue( dependentDocumentKey, out var oldDependencies )
              && dependencies.IsStructurallyEqual( oldDependencies ) )
         {
             newDependenciesGraph = this;
@@ -125,11 +125,11 @@ internal readonly struct DependencyGraphByDependentProject
             return false;
         }
 
-        var dependenciesByMasterFilePathBuilder = this.DependenciesByMasterFilePath.ToBuilder();
+        var dependenciesByMasterFilePathBuilder = this.DependenciesByMasterDocumentKey.ToBuilder();
         var dependenciesByMasterPartialTypeBuilder = this.DependenciesByMasterPartialType.ToBuilder();
 
         // Add syntax tree dependencies.
-        foreach ( var masterFilePathAndHash in dependencies.MasterFilePathsAndHashes )
+        foreach ( var masterFilePathAndHash in dependencies.MasterDocumentKeysAndHashes )
         {
             if ( !dependenciesByMasterFilePathBuilder.TryGetValue( masterFilePathAndHash.Key, out var syntaxTreeDependencies ) )
             {
@@ -140,7 +140,7 @@ internal readonly struct DependencyGraphByDependentProject
                 syntaxTreeDependencies = syntaxTreeDependencies.UpdateDeclarationHash( masterFilePathAndHash.Value );
             }
 
-            dependenciesByMasterFilePathBuilder[masterFilePathAndHash.Key] = syntaxTreeDependencies.AddSyntaxTreeDependency( dependentFilePath );
+            dependenciesByMasterFilePathBuilder[masterFilePathAndHash.Key] = syntaxTreeDependencies.AddSyntaxTreeDependency( dependentDocumentKey );
         }
 
         // Add partial type dependencies.
@@ -151,29 +151,29 @@ internal readonly struct DependencyGraphByDependentProject
                 partialTypeDependencies = new DependencyGraphByMasterPartialType();
             }
 
-            dependenciesByMasterPartialTypeBuilder[masterPartialType] = partialTypeDependencies.AddPartialTypeDependency( dependentFilePath );
+            dependenciesByMasterPartialTypeBuilder[masterPartialType] = partialTypeDependencies.AddPartialTypeDependency( dependentDocumentKey );
         }
 
         if ( oldDependencies != null )
         {
             // Remove syntax tree dependencies.
-            foreach ( var oldMasterFilePathAndHash in oldDependencies.MasterFilePathsAndHashes )
+            foreach ( var oldMasterFilePathAndHash in oldDependencies.MasterDocumentKeysAndHashes )
             {
-                var masterFilePath = oldMasterFilePathAndHash.Key;
+                var masterDocumentKey = oldMasterFilePathAndHash.Key;
 
-                if ( !dependencies.MasterFilePathsAndHashes.ContainsKey( masterFilePath ) )
+                if ( !dependencies.MasterDocumentKeysAndHashes.ContainsKey( masterDocumentKey ) )
                 {
-                    if ( dependenciesByMasterFilePathBuilder.TryGetValue( masterFilePath, out var syntaxTreeDependencies ) )
+                    if ( dependenciesByMasterFilePathBuilder.TryGetValue( masterDocumentKey, out var syntaxTreeDependencies ) )
                     {
-                        var newSyntaxTreeDependencies = syntaxTreeDependencies.RemoveDependency( dependentFilePath );
+                        var newSyntaxTreeDependencies = syntaxTreeDependencies.RemoveDependency( dependentDocumentKey );
 
-                        if ( newSyntaxTreeDependencies.DependentFilePaths.IsEmpty )
+                        if ( newSyntaxTreeDependencies.DependentDocumentKeys.IsEmpty )
                         {
-                            dependenciesByMasterFilePathBuilder.Remove( masterFilePath );
+                            dependenciesByMasterFilePathBuilder.Remove( masterDocumentKey );
                         }
                         else
                         {
-                            dependenciesByMasterFilePathBuilder[masterFilePath] = newSyntaxTreeDependencies;
+                            dependenciesByMasterFilePathBuilder[masterDocumentKey] = newSyntaxTreeDependencies;
                         }
                     }
                 }
@@ -187,9 +187,9 @@ internal readonly struct DependencyGraphByDependentProject
                 {
                     if ( dependenciesByMasterPartialTypeBuilder.TryGetValue( type, out var partialTypeDependencies ) )
                     {
-                        var newPartialTypeDependencies = partialTypeDependencies.RemoveDependency( dependentFilePath );
+                        var newPartialTypeDependencies = partialTypeDependencies.RemoveDependency( dependentDocumentKey );
 
-                        if ( newPartialTypeDependencies.DependentFilePaths.IsEmpty )
+                        if ( newPartialTypeDependencies.DependentDocumentKeys.IsEmpty )
                         {
                             dependenciesByMasterPartialTypeBuilder.Remove( type );
                         }
@@ -206,7 +206,7 @@ internal readonly struct DependencyGraphByDependentProject
             this.ProjectKey,
             dependenciesByMasterFilePathBuilder.ToImmutable(),
             dependenciesByMasterPartialTypeBuilder.ToImmutable(),
-            this.DependenciesByDependentFilePath.SetItem( dependentFilePath, dependencies ) );
+            this.DependenciesByDependentDocumentKey.SetItem( dependentDocumentKey, dependencies ) );
 
         return true;
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByDependentProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByDependentProject.cs
@@ -2,8 +2,8 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.Engine.CodeModel;
 using System.Collections.Immutable;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByDependentProject.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByDependentProject.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Rpc;
 using System.Collections.Immutable;
 
@@ -12,24 +13,24 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// </summary>
 internal readonly struct DependencyGraphByDependentProject
 {
-    private static readonly ImmutableDictionary<string, DependencyGraphByMasterSyntaxTree> _emptyDependenciesByMasterFilePath =
-        ImmutableDictionary<string, DependencyGraphByMasterSyntaxTree>.Empty.WithComparers( StringComparer.Ordinal );
+    private static readonly ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> _emptyDependenciesByMasterFilePath =
+        ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree>.Empty;
 
-    private static readonly ImmutableDictionary<string, DependencyCollectorByDependentSyntaxTreeAndMasterProject> _emptyDependenciesByDependentFilePath =
-        ImmutableDictionary<string, DependencyCollectorByDependentSyntaxTreeAndMasterProject>.Empty.WithComparers( StringComparer.Ordinal );
+    private static readonly ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> _emptyDependenciesByDependentFilePath =
+        ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject>.Empty;
 
     public ProjectKey ProjectKey { get; }
 
     /// <summary>
     /// Gets the list of dependencies on syntax trees within the master compilation, indexed by file path.
     /// </summary>
-    public ImmutableDictionary<string, DependencyGraphByMasterSyntaxTree> DependenciesByMasterFilePath { get; }
+    public ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> DependenciesByMasterFilePath { get; }
 
     public ImmutableDictionary<TypeDependencyKey, DependencyGraphByMasterPartialType> DependenciesByMasterPartialType { get; }
 
     public bool IsEmpty => this.DependenciesByMasterFilePath.Count == 0 && this.DependenciesByMasterPartialType.Count == 0;
 
-    internal ImmutableDictionary<string, DependencyCollectorByDependentSyntaxTreeAndMasterProject> DependenciesByDependentFilePath { get; }
+    internal ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> DependenciesByDependentFilePath { get; }
 
     public DependencyGraphByDependentProject( ProjectKey projectKey ) : this(
         projectKey,
@@ -39,9 +40,9 @@ internal readonly struct DependencyGraphByDependentProject
 
     private DependencyGraphByDependentProject(
         ProjectKey projectKey,
-        ImmutableDictionary<string, DependencyGraphByMasterSyntaxTree> dependenciesByMasterFilePath,
+        ImmutableDictionary<DocumentKey, DependencyGraphByMasterSyntaxTree> dependenciesByMasterFilePath,
         ImmutableDictionary<TypeDependencyKey, DependencyGraphByMasterPartialType> dependenciesByMasterPartialType,
-        ImmutableDictionary<string, DependencyCollectorByDependentSyntaxTreeAndMasterProject> dependenciesByDependentFilePath )
+        ImmutableDictionary<DocumentKey, DependencyCollectorByDependentSyntaxTreeAndMasterProject> dependenciesByDependentFilePath )
     {
         this.ProjectKey = projectKey;
         this.DependenciesByMasterFilePath = dependenciesByMasterFilePath;
@@ -49,7 +50,7 @@ internal readonly struct DependencyGraphByDependentProject
         this.DependenciesByDependentFilePath = dependenciesByDependentFilePath;
     }
 
-    public bool TryRemoveDependentSyntaxTree( string dependentFilePath, out DependencyGraphByDependentProject newDependenciesGraph )
+    public bool TryRemoveDependentSyntaxTree( DocumentKey dependentFilePath, out DependencyGraphByDependentProject newDependenciesGraph )
     {
         if ( !this.DependenciesByDependentFilePath.TryGetValue( dependentFilePath, out var oldDependencies ) )
         {
@@ -111,7 +112,7 @@ internal readonly struct DependencyGraphByDependentProject
     }
 
     public bool TryUpdateDependencies(
-        string dependentFilePath,
+        DocumentKey dependentFilePath,
         DependencyCollectorByDependentSyntaxTreeAndMasterProject dependencies,
         out DependencyGraphByDependentProject newDependenciesGraph )
     {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterPartialType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterPartialType.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using System.Collections.Immutable;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
@@ -11,18 +12,18 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// </summary>
 internal readonly struct DependencyGraphByMasterPartialType
 {
-    private static readonly ImmutableHashSet<string> _emptyDependencies = ImmutableHashSet.Create<string>().WithComparer( StringComparer.Ordinal );
+    private static readonly ImmutableHashSet<DocumentKey> _emptyDependencies = ImmutableHashSet.Create<DocumentKey>();
 
     public DependencyGraphByMasterPartialType() : this( _emptyDependencies ) { }
 
-    public DependencyGraphByMasterPartialType RemoveDependency( string dependentFilePath ) => new( this.DependentFilePaths.Remove( dependentFilePath ) );
+    public DependencyGraphByMasterPartialType RemoveDependency( DocumentKey dependentFilePath ) => new( this.DependentFilePaths.Remove( dependentFilePath ) );
 
-    public ImmutableHashSet<string> DependentFilePaths { get; }
+    public ImmutableHashSet<DocumentKey> DependentFilePaths { get; }
 
-    private DependencyGraphByMasterPartialType( ImmutableHashSet<string> dependentFilePaths )
+    private DependencyGraphByMasterPartialType( ImmutableHashSet<DocumentKey> dependentFilePaths )
     {
         this.DependentFilePaths = dependentFilePaths;
     }
 
-    public DependencyGraphByMasterPartialType AddPartialTypeDependency( string dependentFilePath ) => new( this.DependentFilePaths.Add( dependentFilePath ) );
+    public DependencyGraphByMasterPartialType AddPartialTypeDependency( DocumentKey dependentFilePath ) => new( this.DependentFilePaths.Add( dependentFilePath ) );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterPartialType.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterPartialType.cs
@@ -16,14 +16,14 @@ internal readonly struct DependencyGraphByMasterPartialType
 
     public DependencyGraphByMasterPartialType() : this( _emptyDependencies ) { }
 
-    public DependencyGraphByMasterPartialType RemoveDependency( DocumentKey dependentFilePath ) => new( this.DependentFilePaths.Remove( dependentFilePath ) );
+    public DependencyGraphByMasterPartialType RemoveDependency( DocumentKey dependentDocumentKey ) => new( this.DependentDocumentKeys.Remove( dependentDocumentKey ) );
 
-    public ImmutableHashSet<DocumentKey> DependentFilePaths { get; }
+    public ImmutableHashSet<DocumentKey> DependentDocumentKeys { get; }
 
     private DependencyGraphByMasterPartialType( ImmutableHashSet<DocumentKey> dependentFilePaths )
     {
-        this.DependentFilePaths = dependentFilePaths;
+        this.DependentDocumentKeys = dependentFilePaths;
     }
 
-    public DependencyGraphByMasterPartialType AddPartialTypeDependency( DocumentKey dependentFilePath ) => new( this.DependentFilePaths.Add( dependentFilePath ) );
+    public DependencyGraphByMasterPartialType AddPartialTypeDependency( DocumentKey dependentDocumentKey ) => new( this.DependentDocumentKeys.Add( dependentDocumentKey ) );
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterSyntaxTree.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterSyntaxTree.cs
@@ -22,35 +22,35 @@ internal readonly struct DependencyGraphByMasterSyntaxTree
     /// <summary>
     /// Gets the list of dependent syntax trees, by their file path.
     /// </summary>
-    public ImmutableHashSet<DocumentKey> DependentFilePaths { get; }
+    public ImmutableHashSet<DocumentKey> DependentDocumentKeys { get; }
 
     public DependencyGraphByMasterSyntaxTree( ulong declarationHash ) : this( declarationHash, _emptyDependencies ) { }
 
     private DependencyGraphByMasterSyntaxTree( ulong declarationHash, ImmutableHashSet<DocumentKey> dependentFilePaths )
     {
         this.DeclarationHash = declarationHash;
-        this.DependentFilePaths = dependentFilePaths;
+        this.DependentDocumentKeys = dependentFilePaths;
     }
 
-    public DependencyGraphByMasterSyntaxTree AddSyntaxTreeDependency( DocumentKey dependentFilePath )
+    public DependencyGraphByMasterSyntaxTree AddSyntaxTreeDependency( DocumentKey dependentDocumentKey )
     {
-        if ( this.DependentFilePaths.Contains( dependentFilePath ) )
+        if ( this.DependentDocumentKeys.Contains( dependentDocumentKey ) )
         {
             return this;
         }
         else
         {
-            return new DependencyGraphByMasterSyntaxTree( this.DeclarationHash, this.DependentFilePaths.Add( dependentFilePath ) );
+            return new DependencyGraphByMasterSyntaxTree( this.DeclarationHash, this.DependentDocumentKeys.Add( dependentDocumentKey ) );
         }
     }
 
-    public DependencyGraphByMasterSyntaxTree RemoveDependency( DocumentKey dependentFilePath )
+    public DependencyGraphByMasterSyntaxTree RemoveDependency( DocumentKey dependentDocumentKey )
     {
-        return new DependencyGraphByMasterSyntaxTree( this.DeclarationHash, this.DependentFilePaths.Remove( dependentFilePath ) );
+        return new DependencyGraphByMasterSyntaxTree( this.DeclarationHash, this.DependentDocumentKeys.Remove( dependentDocumentKey ) );
     }
 
     public DependencyGraphByMasterSyntaxTree UpdateDeclarationHash( ulong hash )
     {
-        return new DependencyGraphByMasterSyntaxTree( hash, this.DependentFilePaths );
+        return new DependencyGraphByMasterSyntaxTree( hash, this.DependentDocumentKeys );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterSyntaxTree.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/DependencyGraphByMasterSyntaxTree.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using System.Collections.Immutable;
 
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
@@ -11,7 +12,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// </summary>
 internal readonly struct DependencyGraphByMasterSyntaxTree
 {
-    private static readonly ImmutableHashSet<string> _emptyDependencies = ImmutableHashSet.Create<string>().WithComparer( StringComparer.Ordinal );
+    private static readonly ImmutableHashSet<DocumentKey> _emptyDependencies = ImmutableHashSet.Create<DocumentKey>();
 
     /// <summary>
     /// Gets the hash of of the master syntax tree.
@@ -21,17 +22,17 @@ internal readonly struct DependencyGraphByMasterSyntaxTree
     /// <summary>
     /// Gets the list of dependent syntax trees, by their file path.
     /// </summary>
-    public ImmutableHashSet<string> DependentFilePaths { get; }
+    public ImmutableHashSet<DocumentKey> DependentFilePaths { get; }
 
     public DependencyGraphByMasterSyntaxTree( ulong declarationHash ) : this( declarationHash, _emptyDependencies ) { }
 
-    private DependencyGraphByMasterSyntaxTree( ulong declarationHash, ImmutableHashSet<string> dependentFilePaths )
+    private DependencyGraphByMasterSyntaxTree( ulong declarationHash, ImmutableHashSet<DocumentKey> dependentFilePaths )
     {
         this.DeclarationHash = declarationHash;
         this.DependentFilePaths = dependentFilePaths;
     }
 
-    public DependencyGraphByMasterSyntaxTree AddSyntaxTreeDependency( string dependentFilePath )
+    public DependencyGraphByMasterSyntaxTree AddSyntaxTreeDependency( DocumentKey dependentFilePath )
     {
         if ( this.DependentFilePaths.Contains( dependentFilePath ) )
         {
@@ -43,7 +44,7 @@ internal readonly struct DependencyGraphByMasterSyntaxTree
         }
     }
 
-    public DependencyGraphByMasterSyntaxTree RemoveDependency( string dependentFilePath )
+    public DependencyGraphByMasterSyntaxTree RemoveDependency( DocumentKey dependentFilePath )
     {
         return new DependencyGraphByMasterSyntaxTree( this.DeclarationHash, this.DependentFilePaths.Remove( dependentFilePath ) );
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/PartialTypeDependency.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/PartialTypeDependency.cs
@@ -10,4 +10,4 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// <summary>
 /// Represents a dependency between a master partial type and a dependent syntax tree. Used in tests only.
 /// </summary>
-internal record struct PartialTypeDependency( TypeDependencyKey MasterType, DocumentKey DependentFilePath );
+internal record struct PartialTypeDependency( TypeDependencyKey MasterType, DocumentKey DependentDocumentKey );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/PartialTypeDependency.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/PartialTypeDependency.cs
@@ -2,10 +2,12 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
+
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 
 // ReSharper disable NotAccessedPositionalProperty.Global
 /// <summary>
 /// Represents a dependency between a master partial type and a dependent syntax tree. Used in tests only.
 /// </summary>
-internal record struct PartialTypeDependency( TypeDependencyKey MasterType, string DependentFilePath );
+internal record struct PartialTypeDependency( TypeDependencyKey MasterType, DocumentKey DependentFilePath );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/SyntaxTreeDependency.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/SyntaxTreeDependency.cs
@@ -2,10 +2,12 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
+
 namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 
 // ReSharper disable NotAccessedPositionalProperty.Global
 /// <summary>
 /// Represents a single dependency edge between a master syntax tree and a dependent syntax tree. This object is used for test only.
 /// </summary>
-internal record struct SyntaxTreeDependency( string MasterFilePath, string DependentFilePath );
+internal record struct SyntaxTreeDependency( DocumentKey MasterFilePath, DocumentKey DependentFilePath );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/SyntaxTreeDependency.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/SyntaxTreeDependency.cs
@@ -10,4 +10,4 @@ namespace Metalama.Framework.DesignTime.Pipeline.Dependencies;
 /// <summary>
 /// Represents a single dependency edge between a master syntax tree and a dependent syntax tree. This object is used for test only.
 /// </summary>
-internal record struct SyntaxTreeDependency( DocumentKey MasterFilePath, DocumentKey DependentFilePath );
+internal record struct SyntaxTreeDependency( DocumentKey MasterDocumentKey, DocumentKey DependentDocumentKey );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/TypeDependencyKey.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/TypeDependencyKey.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Microsoft.CodeAnalysis;
 using System.Globalization;
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/TypeDependencyKey.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Dependencies/TypeDependencyKey.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Microsoft.CodeAnalysis;
 using System.Globalization;
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.PipelineState.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.PipelineState.cs
@@ -40,14 +40,14 @@ public sealed partial class DesignTimeAspectPipeline
         public DependencyGraph Dependencies => this._dependencies;
 #pragma warning restore IDE0032
 
-        private static readonly ImmutableDictionary<string, bool> _emptyCompileTimeSyntaxTrees =
-            ImmutableDictionary.Create<string, bool>( StringComparer.Ordinal );
+        private static readonly ImmutableDictionary<DocumentKey, bool> _emptyCompileTimeSyntaxTrees =
+            ImmutableDictionary.Create<DocumentKey, bool>();
 
         // Syntax trees that may have compile time code based on namespaces. When a syntax tree is known to be compile-time but
         // has been invalidated, we set its value to false. It allows to know
         // that this specific tree is outdated, which then allows us to display a warning.
 
-        public ImmutableDictionary<string, bool>? CompileTimeSyntaxTrees { get; }
+        public ImmutableDictionary<DocumentKey, bool>? CompileTimeSyntaxTrees { get; }
 
         public FallibleResultWithDiagnostics<AspectPipelineConfiguration>? Configuration { get; }
 
@@ -94,7 +94,7 @@ public sealed partial class DesignTimeAspectPipeline
 
         private PipelineState(
             PipelineState prototype,
-            ImmutableDictionary<string, bool> compileTimeSyntaxTrees,
+            ImmutableDictionary<DocumentKey, bool> compileTimeSyntaxTrees,
             DesignTimeAspectPipelineStatus status,
             ProjectVersion projectVersion,
             DesignTimeAspectPipelineResult pipelineResult,
@@ -110,7 +110,7 @@ public sealed partial class DesignTimeAspectPipeline
             this._dependencies = dependencies;
         }
 
-        private PipelineState( PipelineState prototype, ImmutableDictionary<string, bool> compileTimeSyntaxTrees )
+        private PipelineState( PipelineState prototype, ImmutableDictionary<DocumentKey, bool> compileTimeSyntaxTrees )
             : this( prototype )
         {
             this.CompileTimeSyntaxTrees = compileTimeSyntaxTrees;
@@ -149,7 +149,7 @@ public sealed partial class DesignTimeAspectPipeline
                     throw new AssertionFailedException( $"Compilation mismatch with '{compilation.Assembly.Identity}'." );
                 }
 
-                var newCompileTimeSyntaxTrees = ImmutableDictionary<string, bool>.Empty;
+                var newCompileTimeSyntaxTrees = ImmutableDictionary<DocumentKey, bool>.Empty;
 
                 foreach ( var syntaxTree in compilation.SyntaxTrees )
                 {
@@ -157,7 +157,7 @@ public sealed partial class DesignTimeAspectPipeline
 
                     if ( CompileTimeCodeFastDetector.HasCompileTimeCode( syntaxTree.GetRoot() ) )
                     {
-                        newCompileTimeSyntaxTrees = newCompileTimeSyntaxTrees.Add( syntaxTree.FilePath, true );
+                        newCompileTimeSyntaxTrees = newCompileTimeSyntaxTrees.Add( syntaxTree.GetDocumentKey(), true );
                         trees.Add( syntaxTree );
                     }
                 }
@@ -170,7 +170,7 @@ public sealed partial class DesignTimeAspectPipeline
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    if ( state.CompileTimeSyntaxTrees.ContainsKey( syntaxTree.FilePath ) )
+                    if ( state.CompileTimeSyntaxTrees.ContainsKey( syntaxTree.GetDocumentKey() ) )
                     {
                         trees.Add( syntaxTree );
                     }
@@ -200,7 +200,7 @@ public sealed partial class DesignTimeAspectPipeline
                 newCompilation,
                 cancellationToken );
 
-            ImmutableDictionary<string, bool> newCompileTimeSyntaxTrees;
+            ImmutableDictionary<DocumentKey, bool> newCompileTimeSyntaxTrees;
             DependencyGraph newDependencyGraph;
             DesignTimeAspectPipelineResult newAspectPipelineResult;
 
@@ -225,7 +225,7 @@ public sealed partial class DesignTimeAspectPipeline
                 }
 
                 var compileTimeSyntaxTreesBuilder = this.CompileTimeSyntaxTrees?.ToBuilder()
-                                                    ?? ImmutableDictionary.CreateBuilder<string, bool>( StringComparer.Ordinal );
+                                                    ?? ImmutableDictionary.CreateBuilder<DocumentKey, bool>();
 
                 foreach ( var changeEntry in newChanges.SyntaxTreeChanges )
                 {
@@ -239,15 +239,15 @@ public sealed partial class DesignTimeAspectPipeline
                                 // When a syntax tree is known to be compile-time but has been invalidated, we don't remove it from the dictionary,
                                 // but we set its value to null. It allows to know that this specific tree is outdated,
                                 // which then allows us to display a warning.
-                                compileTimeSyntaxTreesBuilder[change.FilePath] = false;
+                                compileTimeSyntaxTreesBuilder[change.DocumentKey] = false;
 
                                 // We require an external build because we don't want to invalidate the pipeline configuration at
                                 // each keystroke.
                                 this._pipeline.Logger.Trace?.Log(
-                                    $"Compile-time change detected: {change.FilePath} has changed. Old hash: {change.OldHash}, new hash: {change.NewHash}." );
+                                    $"Compile-time change detected: {change.DocumentKey} has changed. Old hash: {change.OldHash}, new hash: {change.NewHash}." );
 
                                 // Generated files may change during the startup sequence, and it is safe to reset the pipeline in this case.
-                                var requiresRebuild = !change.FilePath.EndsWith( ".g.cs", StringComparison.OrdinalIgnoreCase );
+                                var requiresRebuild = !change.DocumentKey.Path.EndsWith( ".g.cs", StringComparison.OrdinalIgnoreCase );
 
                                 OnCompileTimeChange( this._pipeline.Logger, requiresRebuild );
                             }
@@ -258,15 +258,15 @@ public sealed partial class DesignTimeAspectPipeline
                             // We don't require an external rebuild when a new syntax tree is added because Roslyn does not give us a complete
                             // compilation in the first call in the Visual Studio initializations sequence. Roslyn calls us later with
                             // a complete compilation, but we don't want to bother the user with the need of an external build.
-                            compileTimeSyntaxTreesBuilder[change.FilePath] = true;
-                            this._pipeline.Logger.Trace?.Log( $"Compile-time change detected: {change.FilePath} is a new compile-time syntax tree." );
+                            compileTimeSyntaxTreesBuilder[change.DocumentKey] = true;
+                            this._pipeline.Logger.Trace?.Log( $"Compile-time change detected: {change.DocumentKey} is a new compile-time syntax tree." );
                             OnCompileTimeChange( this._pipeline.Logger, false );
 
                             break;
 
                         case CompileTimeChangeKind.NoLongerCompileTime:
-                            compileTimeSyntaxTreesBuilder.Remove( change.FilePath );
-                            this._pipeline.Logger.Trace?.Log( $"Compile-time change detected: : {change.FilePath} no longer contains compile-time code." );
+                            compileTimeSyntaxTreesBuilder.Remove( change.DocumentKey );
+                            this._pipeline.Logger.Trace?.Log( $"Compile-time change detected: : {change.DocumentKey} no longer contains compile-time code." );
                             OnCompileTimeChange( this._pipeline.Logger, false );
 
                             break;
@@ -560,7 +560,7 @@ public sealed partial class DesignTimeAspectPipeline
             Invariant.Assert( annotations.KeyComparer is IRefEqualityComparer );
 
             var result = new DesignTimePipelineExecutionResult(
-                compilation.SyntaxTrees,
+                compilation.SyntaxTreeCollection,
                 additionalSyntaxTrees,
                 immutableUserDiagnostics,
                 inheritableAspectInstances,

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
@@ -162,7 +162,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
 
         this.Logger.Trace?.Log( $"Processing change notification from dependent project '{data.ProjectKey}'." );
 
-        if ( !data.IsPartialCompilation || data.SyntaxTreePaths.Any( p => dependenciesInThisProject.DependenciesByMasterFilePath.ContainsKey( p ) ) )
+        if ( !data.IsPartialCompilation || data.SyntaxTreePaths.Any( p => dependenciesInThisProject.DependenciesByMasterFilePath.ContainsKey( DocumentKey.FromPath( p ) ) ) )
         {
             this.Logger.Trace?.Log( $"Processing change notification from dependent project '{data.ProjectKey}': the current project may be affected." );
             this._eventHub?.OnProjectDirty( this.ProjectKey );
@@ -346,7 +346,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                 var notification = new CompilationResultChangedEventData(
                     this.ProjectKey,
                     true,
-                    this._currentState.CompileTimeSyntaxTrees.Keys.ToImmutableArray() );
+                    this._currentState.CompileTimeSyntaxTrees.Keys.Select( k => k.Path ).ToImmutableArray() );
 
                 this._eventHub?.PublishCompilationResultChangedNotification( notification );
             }
@@ -920,7 +920,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
                         var notification = new CompilationResultChangedEventData(
                             this.ProjectKey,
                             partialCompilation.IsPartial,
-                            partialCompilation.IsPartial ? partialCompilation.SyntaxTrees.SelectAsImmutableArray( t => t.Key ) : default );
+                            partialCompilation.IsPartial ? partialCompilation.SyntaxTreeCollection.SelectAsImmutableArray( t => t.FilePath ) : default );
 
                         this._eventHub?.PublishCompilationResultChangedNotification( notification );
 
@@ -1018,9 +1018,9 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
     /// tree has changed compared to the cached configuration of this pipeline. This method is used to
     /// determine whether an error must displayed in the editor.  
     /// </summary>
-    internal bool IsCompileTimeSyntaxTreeOutdated( string name )
+    internal bool IsCompileTimeSyntaxTreeOutdated( DocumentKey documentKey )
         => this._currentState.CompileTimeSyntaxTrees is { } compileTimeSyntaxTrees
-           && compileTimeSyntaxTrees.TryGetValue( name, out var isValid )
+           && compileTimeSyntaxTrees.TryGetValue( documentKey, out var isValid )
            && !isValid;
 
     private IReadOnlyList<DesignTimeAspectInstance>? GetAspectInstancesOnSymbol( ISymbol symbol )
@@ -1035,7 +1035,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
 
         var symbolId = symbol.GetSerializableId();
 
-        if ( !this._currentState.PipelineResult.SyntaxTreeResults.TryGetValue( filePath, out var result ) )
+        if ( !this._currentState.PipelineResult.SyntaxTreeResults.TryGetValue( DocumentKey.FromPath( filePath ), out var result ) )
         {
             return null;
         }
@@ -1285,7 +1285,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
             semanticModel,
             reportDiagnostic,
             reportSuppression,
-            this.IsCompileTimeSyntaxTreeOutdated( semanticModel.SyntaxTree.FilePath ),
+            this.IsCompileTimeSyntaxTreeOutdated( semanticModel.SyntaxTree.GetDocumentKey() ),
             true,
             this._applicationExitingToken );
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipeline.cs
@@ -162,7 +162,7 @@ public sealed partial class DesignTimeAspectPipeline : BaseDesignTimeAspectPipel
 
         this.Logger.Trace?.Log( $"Processing change notification from dependent project '{data.ProjectKey}'." );
 
-        if ( !data.IsPartialCompilation || data.SyntaxTreePaths.Any( p => dependenciesInThisProject.DependenciesByMasterFilePath.ContainsKey( DocumentKey.FromPath( p ) ) ) )
+        if ( !data.IsPartialCompilation || data.SyntaxTreePaths.Any( p => dependenciesInThisProject.DependenciesByMasterDocumentKey.ContainsKey( DocumentKey.FromPath( p ) ) ) )
         {
             this.Logger.Trace?.Log( $"Processing change notification from dependent project '{data.ProjectKey}': the current project may be affected." );
             this._eventHub?.OnProjectDirty( this.ProjectKey );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -30,8 +30,8 @@ namespace Metalama.Framework.DesignTime.Pipeline;
 /// </summary>
 public sealed partial class DesignTimeAspectPipelineResult
 {
-    private static readonly ImmutableDictionary<string, SyntaxTreePipelineResult> _emptySyntaxTreeResults =
-        ImmutableDictionary.Create<string, SyntaxTreePipelineResult>( StringComparer.Ordinal );
+    private static readonly ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult> _emptySyntaxTreeResults =
+        ImmutableDictionary.Create<DocumentKey, SyntaxTreePipelineResult>();
 
     private static readonly ImmutableDictionary<string, IntroducedSyntaxTree> _emptyIntroducedSyntaxTrees =
         ImmutableDictionary.Create<string, IntroducedSyntaxTree>( StringComparer.Ordinal );
@@ -59,12 +59,12 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// <summary>
     /// Gets a maps if the syntax tree name to the pipeline result for this syntax tree.
     /// </summary>
-    internal ImmutableDictionary<string, SyntaxTreePipelineResult> SyntaxTreeResults { get; } = _emptySyntaxTreeResults;
+    internal ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult> SyntaxTreeResults { get; } = _emptySyntaxTreeResults;
 
     /// <summary>
     /// List of SyntaxTreeResult that have been invalidated.
     /// </summary>
-    private readonly ImmutableDictionary<string, SyntaxTreePipelineResult> _invalidSyntaxTreeResults = _emptySyntaxTreeResults;
+    private readonly ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult> _invalidSyntaxTreeResults = _emptySyntaxTreeResults;
 
     private readonly ImmutableDictionaryOfHashSet<string, InheritableAspectInstance> _inheritableAspects = _emptyInheritableAspects;
 
@@ -76,8 +76,8 @@ public sealed partial class DesignTimeAspectPipelineResult
 
     private DesignTimeAspectPipelineResult(
         AspectPipelineConfiguration? configuration,
-        ImmutableDictionary<string, SyntaxTreePipelineResult> syntaxTreeResults,
-        ImmutableDictionary<string, SyntaxTreePipelineResult> invalidSyntaxTreeResults,
+        ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult> syntaxTreeResults,
+        ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult> invalidSyntaxTreeResults,
         ImmutableDictionary<string, IntroducedSyntaxTree> introducedSyntaxTrees,
         ImmutableDictionaryOfHashSet<string, InheritableAspectInstance> inheritableAspects,
         DesignTimeAspectPipelineResultExtensionCollection extensions,
@@ -122,7 +122,11 @@ public sealed partial class DesignTimeAspectPipelineResult
     {
         Logger.DesignTime.Trace?.Log( $"CompilationPipelineResult.Update( id = {this._id} )" );
 
-        var (resultsByTree, externalExtensions) = SplitResultsByTree( compilation, pipelineResults );
+        var (lazyResultsByTree, externalExtensions) = SplitResultsByTree( compilation, pipelineResults );
+
+        // Materialized because it is enumerated twice below and the projection allocates a new result on each
+        // enumeration.
+        var resultsByTree = lazyResultsByTree.ToReadOnlyList();
 
         var syntaxTreeResultBuilder = this.SyntaxTreeResults.ToBuilder();
 
@@ -138,23 +142,32 @@ public sealed partial class DesignTimeAspectPipelineResult
             UnindexOldTree( filePath, oldResult );
         }
 
+        // Every old result is un-indexed before any new one is indexed. Interleaving the two, which this loop used to
+        // do, lets the un-indexing of one tree remove an entry that the indexing of another tree has already added,
+        // whenever the two are keyed alike. That happens with the introduced syntax trees, which are keyed by a name
+        // rendered from the target type while the results they belong to are keyed by a source path: when the primary
+        // declaration of a partial type moves from one file to another, both files are in this batch, and processing
+        // the new owner first made the old owner delete the entry the new one had just written. See issue #1742.
         foreach ( var result in resultsByTree )
         {
-            var filePath = result.SyntaxTreePath ?? "";
+            var filePath = result.SyntaxTreePath;
 
-            // Un-index the old tree.
             if ( syntaxTreeResultBuilder.TryGetValue( filePath, out var oldSyntaxTreeResult ) )
             {
                 UnindexOldTree( filePath, oldSyntaxTreeResult );
             }
+        }
 
-            // Index the new tree.
+        foreach ( var result in resultsByTree )
+        {
+            var filePath = result.SyntaxTreePath;
+
             IndexNewTree( filePath, result );
 
             syntaxTreeResultBuilder[filePath] = result;
         }
 
-        void UnindexOldTree( string filePath, SyntaxTreePipelineResult oldSyntaxTreeResult )
+        void UnindexOldTree( DocumentKey filePath, SyntaxTreePipelineResult oldSyntaxTreeResult )
         {
             if ( !oldSyntaxTreeResult.Introductions.IsEmpty )
             {
@@ -220,7 +233,7 @@ public sealed partial class DesignTimeAspectPipelineResult
             aspectInstancesHashCode ^= oldSyntaxTreeResult.AspectInstancesHashCode;
         }
 
-        void IndexNewTree( string filePath, SyntaxTreePipelineResult newSyntaxTreeResult )
+        void IndexNewTree( DocumentKey filePath, SyntaxTreePipelineResult newSyntaxTreeResult )
         {
             if ( !newSyntaxTreeResult.Introductions.IsEmpty )
             {
@@ -231,12 +244,23 @@ public sealed partial class DesignTimeAspectPipelineResult
                     Logger.DesignTime.Trace?.Log(
                         $"CompilationPipelineResult.Update( id = {this._id} ): adding introduced syntax tree '{introducedTree.Name}'." );
 
-                    if ( !introducedSyntaxTreeBuilder.TryAdd( introducedTree.Name, introducedTree ) )
+                    // The last one wins. This index is keyed by the introduced tree name, which
+                    // DesignTimeSyntaxTreeGenerator.GetUniqueFilenameForType renders from the target type and never from
+                    // a path, while the un-indexing pass above is keyed by the source path. The two keys are therefore
+                    // independent, and the pass is not a transaction: when the primary declaration of a partial type
+                    // moves from one file to another, this update un-indexes the new file only and the entry the old
+                    // file left behind is still present. It names a tree of an earlier run, so the new one replaces it,
+                    // and the stale result of the old file is corrected when that file is next analysed. See issue
+                    // #1742.
+                    if ( introducedSyntaxTreeBuilder.TryGetValue( introducedTree.Name, out var existingIntroducedTree )
+                         && existingIntroducedTree.SourceSyntaxTree?.FilePath != introducedTree.SourceSyntaxTree?.FilePath )
                     {
-                        // This can happen when the introduced syntax tree name is not deterministic.
-                        throw new AssertionFailedException(
-                            $"CompilationPipelineResult.Update( id = {this._id} ): Attempting to add duplicate syntax tree '{introducedTree.Name}'." );
+                        Logger.DesignTime.Trace?.Log(
+                            $"CompilationPipelineResult.Update( id = {this._id} ): the introduced syntax tree '{introducedTree.Name}' moves from "
+                            + $"'{existingIntroducedTree.SourceSyntaxTree?.FilePath ?? "(none)"}' to '{introducedTree.SourceSyntaxTree?.FilePath ?? "(none)"}'." );
                     }
+
+                    introducedSyntaxTreeBuilder[introducedTree.Name] = introducedTree;
                 }
             }
 
@@ -319,7 +343,7 @@ public sealed partial class DesignTimeAspectPipelineResult
         return new DesignTimeAspectPipelineResult(
             configuration,
             syntaxTreeResultBuilder.ToImmutable(),
-            ImmutableDictionary<string, SyntaxTreePipelineResult>.Empty,
+            ImmutableDictionary<DocumentKey, SyntaxTreePipelineResult>.Empty,
             introducedTrees,
             inheritableAspects,
             extensions,
@@ -341,7 +365,7 @@ public sealed partial class DesignTimeAspectPipelineResult
 
         var resultBuilders = pipelineResults
             .InputSyntaxTrees
-            .ToDictionary( r => r.Key, syntaxTree => new SyntaxTreePipelineResult.Builder( syntaxTree.Value ) );
+            .ToDictionary( syntaxTree => syntaxTree.FilePath, syntaxTree => new SyntaxTreePipelineResult.Builder( syntaxTree ), StringComparer.Ordinal );
 
         List<IDesignTimePipelineResultExtension>? externalValidators = null;
 
@@ -641,16 +665,12 @@ public sealed partial class DesignTimeAspectPipelineResult
         }
 
         // Add syntax trees with empty output so they get cached too.
-        var inputTreesWithoutOutput = compilation.SyntaxTrees.ToBuilder();
-
-        foreach ( var path in resultBuilders.Keys )
+        foreach ( var syntaxTree in compilation.SyntaxTreeCollection )
         {
-            inputTreesWithoutOutput.Remove( path );
-        }
-
-        foreach ( var empty in inputTreesWithoutOutput )
-        {
-            resultBuilders.Add( empty.Key, new SyntaxTreePipelineResult.Builder( empty.Value ) );
+            if ( !resultBuilders.ContainsKey( syntaxTree.FilePath ) )
+            {
+                resultBuilders.Add( syntaxTree.FilePath, new SyntaxTreePipelineResult.Builder( syntaxTree ) );
+            }
         }
 
         if ( emptySyntaxTreeResult != null )
@@ -663,7 +683,7 @@ public sealed partial class DesignTimeAspectPipelineResult
 
     internal Invalidator ToInvalidator() => new( this );
 
-    internal bool IsSyntaxTreeDirty( SyntaxTree syntaxTree ) => !this.SyntaxTreeResults.ContainsKey( syntaxTree.FilePath );
+    internal bool IsSyntaxTreeDirty( SyntaxTree syntaxTree ) => !this.SyntaxTreeResults.ContainsKey( syntaxTree.GetDocumentKey() );
 
     public IEnumerable<string> InheritableAspectTypes => this._inheritableAspects.Keys;
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -363,9 +363,13 @@ public sealed partial class DesignTimeAspectPipelineResult
     {
         SyntaxTreePipelineResult.Builder? emptySyntaxTreeResult = null;
 
+        // Keyed by DocumentKey, with the default key holding the results that belong to the compilation rather than to
+        // any document. The default key cannot collide with a document, because it wraps a null path while every key of
+        // a document wraps SyntaxTree.FilePath, which Roslyn never returns as null. The empty path, which this method
+        // used as its sentinel, has no such guarantee: a syntax tree may carry it.
         var resultBuilders = pipelineResults
             .InputSyntaxTrees
-            .ToDictionary( syntaxTree => syntaxTree.FilePath, syntaxTree => new SyntaxTreePipelineResult.Builder( syntaxTree ), StringComparer.Ordinal );
+            .ToDictionary( syntaxTree => syntaxTree.GetDocumentKey(), syntaxTree => new SyntaxTreePipelineResult.Builder( syntaxTree ) );
 
         List<IDesignTimePipelineResultExtension>? externalValidators = null;
 
@@ -377,7 +381,7 @@ public sealed partial class DesignTimeAspectPipelineResult
             // GetLineSpan() works even for "external" locations (i.e. not tree-based), which we use for exceptions.
             if ( diagnostic.Location.GetLineSpan().Path is { } filePath )
             {
-                if ( !resultBuilders.TryGetValue( filePath, out builder ) )
+                if ( !resultBuilders.TryGetValue( DocumentKey.FromPath( filePath ), out builder ) )
                 {
                     // This can happen when a CS error is reported in the aspect. These errors can be ignored.
                     continue;
@@ -399,7 +403,7 @@ public sealed partial class DesignTimeAspectPipelineResult
             {
                 if ( !string.IsNullOrEmpty( path ) )
                 {
-                    if ( resultBuilders.TryGetValue( path, out var builder ) )
+                    if ( resultBuilders.TryGetValue( DocumentKey.FromPath( path! ), out var builder ) )
                     {
                         builder.Suppressions ??= ImmutableArray.CreateBuilder<CacheableScopedSuppression>();
                         builder.Suppressions.Add( new CacheableScopedSuppression( suppression ) );
@@ -440,12 +444,12 @@ public sealed partial class DesignTimeAspectPipelineResult
 
             if ( introduction.SourceSyntaxTree is { } syntaxTree )
             {
-                var filePath = syntaxTree.FilePath;
+                var documentKey = syntaxTree.GetDocumentKey();
 
-                if ( !resultBuilders.TryGetValue( filePath, out builder ) )
+                if ( !resultBuilders.TryGetValue( documentKey, out builder ) )
                 {
                     // This happens when the source tree is not dirty, so it's not part of the PartialCompilation.
-                    builder = resultBuilders[filePath] = new SyntaxTreePipelineResult.Builder( syntaxTree );
+                    builder = resultBuilders[documentKey] = new SyntaxTreePipelineResult.Builder( syntaxTree );
                 }
             }
             else
@@ -471,9 +475,9 @@ public sealed partial class DesignTimeAspectPipelineResult
                 continue;
             }
 
-            var filePath = syntaxTree.FilePath;
+            var documentKey = syntaxTree.GetDocumentKey();
 
-            if ( !resultBuilders.TryGetValue( filePath, out var builder ) )
+            if ( !resultBuilders.TryGetValue( documentKey, out var builder ) )
             {
                 // An inheritable aspect instance is not bound to the tree the pipeline ran on, because an aspect can add one to
                 // a declaration it did not itself target, e.g. through RequireAspect or through the transitive instance exported
@@ -483,7 +487,7 @@ public sealed partial class DesignTimeAspectPipelineResult
                 // diagnostics and introductions it holds.
                 Logger.DesignTime.Trace?.Log(
                     $"SplitResultsByTree: skipping the inheritable aspect of type '{inheritableAspectInstance.AspectClass.ShortName}' because its target "
-                    + $"declaration is in syntax tree '{filePath}', which is not a part of the partial compilation." );
+                    + $"declaration is in syntax tree '{documentKey}', which is not a part of the partial compilation." );
 
                 continue;
             }
@@ -497,9 +501,9 @@ public sealed partial class DesignTimeAspectPipelineResult
         {
             var syntaxTree = extension.SyntaxTree;
 
-            if ( syntaxTree == null && !resultBuilders.ContainsKey( string.Empty ) )
+            if ( syntaxTree == null && !resultBuilders.ContainsKey( default ) )
             {
-                resultBuilders.Add( string.Empty, new SyntaxTreePipelineResult.Builder( null ) );
+                resultBuilders.Add( default, new SyntaxTreePipelineResult.Builder( null ) );
             }
 
             var designTimeExtension = extension.ToDesignTime();
@@ -517,9 +521,9 @@ public sealed partial class DesignTimeAspectPipelineResult
                 extension.Granularity,
                 compilation.CompilationContext ); */
 
-                var filePath = syntaxTree?.FilePath ?? string.Empty;
+                var documentKey = syntaxTree?.GetDocumentKey() ?? default;
 
-                if ( resultBuilders.TryGetValue( filePath, out var builder ) )
+                if ( resultBuilders.TryGetValue( documentKey, out var builder ) )
                 {
                     builder.Extensions ??= ImmutableArray.CreateBuilder<IDesignTimePipelineResultExtension>();
                     builder.Extensions.Add( designTimeExtension );
@@ -543,9 +547,9 @@ public sealed partial class DesignTimeAspectPipelineResult
             var syntaxTree = aspectInstance.TargetDeclaration.GetPrimarySyntaxTree( compilationContext );
 
             // No continue here to handle even aspect instances without a syntax tree.
-            if ( syntaxTree == null && !resultBuilders.ContainsKey( string.Empty ) )
+            if ( syntaxTree == null && !resultBuilders.ContainsKey( default ) )
             {
-                resultBuilders.Add( string.Empty, new SyntaxTreePipelineResult.Builder( null ) );
+                resultBuilders.Add( default, new SyntaxTreePipelineResult.Builder( null ) );
             }
 
             var targetDeclarationId = aspectInstance.TargetDeclaration.ToSerializableId();
@@ -569,9 +573,9 @@ public sealed partial class DesignTimeAspectPipelineResult
                 predecessorDeclarationId = predecessorDeclarationSymbol?.GetSerializableId();
             }
 
-            var filePath = syntaxTree?.FilePath ?? string.Empty;
+            var documentKey = syntaxTree?.GetDocumentKey() ?? default;
 
-            if ( resultBuilders.TryGetValue( filePath, out var builder ) )
+            if ( resultBuilders.TryGetValue( documentKey, out var builder ) )
             {
                 builder.AspectInstances ??= ImmutableArray.CreateBuilder<DesignTimeAspectInstance>();
 
@@ -592,9 +596,9 @@ public sealed partial class DesignTimeAspectPipelineResult
         // Split transformations by syntax tree.
         foreach ( var transformation in pipelineResults.Transformations )
         {
-            var filePath = (transformation as ISyntaxTreeTransformationBase)?.TransformedSyntaxTree.FilePath;
+            var documentKey = (transformation as ISyntaxTreeTransformationBase)?.TransformedSyntaxTree.GetDocumentKey();
 
-            if ( filePath == null || !resultBuilders.TryGetValue( filePath, out var builder ) )
+            if ( documentKey == null || !resultBuilders.TryGetValue( documentKey.Value, out var builder ) )
             {
                 builder = emptySyntaxTreeResult ??= new SyntaxTreePipelineResult.Builder( null );
             }
@@ -621,7 +625,7 @@ public sealed partial class DesignTimeAspectPipelineResult
 
             if ( syntaxTreePath != null )
             {
-                builder = resultBuilders[syntaxTreePath];
+                builder = resultBuilders[DocumentKey.FromPath( syntaxTreePath )];
             }
             else
             {
@@ -656,8 +660,7 @@ public sealed partial class DesignTimeAspectPipelineResult
             }
             else
             {
-                var filePath = syntaxTree.FilePath;
-                builder = resultBuilders[filePath];
+                builder = resultBuilders[syntaxTree.GetDocumentKey()];
             }
 
             builder.Annotations ??= ImmutableDictionaryOfArray<SerializableDeclarationId, IAnnotation>.CreateBuilder();
@@ -667,15 +670,15 @@ public sealed partial class DesignTimeAspectPipelineResult
         // Add syntax trees with empty output so they get cached too.
         foreach ( var syntaxTree in compilation.SyntaxTreeCollection )
         {
-            if ( !resultBuilders.ContainsKey( syntaxTree.FilePath ) )
+            if ( !resultBuilders.ContainsKey( syntaxTree.GetDocumentKey() ) )
             {
-                resultBuilders.Add( syntaxTree.FilePath, new SyntaxTreePipelineResult.Builder( syntaxTree ) );
+                resultBuilders.Add( syntaxTree.GetDocumentKey(), new SyntaxTreePipelineResult.Builder( syntaxTree ) );
             }
         }
 
         if ( emptySyntaxTreeResult != null )
         {
-            resultBuilders[""] = emptySyntaxTreeResult;
+            resultBuilders[default] = emptySyntaxTreeResult;
         }
 
         return (resultBuilders.SelectAsReadOnlyCollection( b => b.Value.ToImmutable( compilation.Compilation ) ), externalValidators);

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResultAndState.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResultAndState.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Pipeline.Diff;
 using Metalama.Framework.Engine.Pipeline;
 using Microsoft.CodeAnalysis;
@@ -33,9 +34,9 @@ public sealed class DesignTimeAspectPipelineResultAndState
 
     internal IEnumerable<Diagnostic> GetAllDiagnostics() => this.Result.SyntaxTreeResults.SelectMany( x => x.Value.Diagnostics );
 
-    internal ImmutableArray<CacheableScopedSuppression> GetSuppressionsOnSyntaxTree( string path )
+    internal ImmutableArray<CacheableScopedSuppression> GetSuppressionsOnSyntaxTree( DocumentKey documentKey )
     {
-        if ( this.Result.SyntaxTreeResults.TryGetValue( path, out var syntaxTreeResult ) )
+        if ( this.Result.SyntaxTreeResults.TryGetValue( documentKey, out var syntaxTreeResult ) )
         {
             return syntaxTreeResult.Suppressions;
         }
@@ -45,9 +46,9 @@ public sealed class DesignTimeAspectPipelineResultAndState
         }
     }
 
-    public ImmutableArray<Diagnostic> GetDiagnosticsOnSyntaxTree( string path )
+    public ImmutableArray<Diagnostic> GetDiagnosticsOnSyntaxTree( DocumentKey documentKey )
     {
-        if ( this.Result.SyntaxTreeResults.TryGetValue( path, out var syntaxTreeResult ) )
+        if ( this.Result.SyntaxTreeResults.TryGetValue( documentKey, out var syntaxTreeResult ) )
         {
             return syntaxTreeResult.Diagnostics;
         }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimePipelineExecutionResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimePipelineExecutionResult.cs
@@ -25,7 +25,7 @@ namespace Metalama.Framework.DesignTime.Pipeline
     /// <param name="IntroducedSyntaxTrees">The syntax trees introduced by the pipeline (for source generators).</param>
     /// <param name="Diagnostics">The list of diagnostics and suppressions.</param>
     internal sealed record DesignTimePipelineExecutionResult(
-        ImmutableDictionary<string, SyntaxTree> InputSyntaxTrees,
+        IReadOnlyCollection<SyntaxTree> InputSyntaxTrees,
         IReadOnlyList<IntroducedSyntaxTree> IntroducedSyntaxTrees,
         ImmutableUserDiagnosticList Diagnostics,
         IReadOnlyList<InheritableAspectInstance> InheritableAspects,

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/CompilationChanges.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/CompilationChanges.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.DesignTime.Rpc;
 using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Utilities;
 using Metalama.Framework.Engine.Utilities.Threading;
 using Microsoft.CodeAnalysis;
@@ -18,7 +19,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
     {
         private readonly WeakReference<ProjectVersion>? _oldProjectVersionRef;
 
-        public ImmutableDictionary<string, SyntaxTreeChange> SyntaxTreeChanges { get; }
+        public ImmutableDictionary<DocumentKey, SyntaxTreeChange> SyntaxTreeChanges { get; }
 
         public ProjectVersion? OldProjectVersionDangerous
         {
@@ -72,7 +73,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
         public CompilationChanges(
             ProjectVersion? oldProjectVersion,
             ProjectVersion newProjectVersion,
-            ImmutableDictionary<string, SyntaxTreeChange> syntaxTreeChanges,
+            ImmutableDictionary<DocumentKey, SyntaxTreeChange> syntaxTreeChanges,
             ImmutableDictionary<ProjectKey, ReferencedProjectChange> referencedCompilationChanges,
             ImmutableDictionary<string, ReferenceChangeKind> referencedPortableExecutableChanges,
             bool assemblyIdentityChanged,
@@ -101,7 +102,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
             => new(
                 oldProject,
                 newProject,
-                ImmutableDictionary<string, SyntaxTreeChange>.Empty,
+                ImmutableDictionary<DocumentKey, SyntaxTreeChange>.Empty,
                 ImmutableDictionary<ProjectKey, ReferencedProjectChange>.Empty,
                 ImmutableDictionary<string, ReferenceChangeKind>.Empty,
                 assemblyIdentityChanged: false,
@@ -153,10 +154,11 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
 
             oldProjectVersion.Strategy.Observer?.OnComputeIncrementalChanges();
 
-            var newTrees = ImmutableDictionary.CreateBuilder<string, SyntaxTreeVersion>( StringComparer.Ordinal );
+            var newTrees = ImmutableDictionary.CreateBuilder<DocumentKey, SyntaxTreeVersion>();
             var generatedTrees = new List<SyntaxTree>();
+            List<SyntaxTree>? duplicatePathTrees = null;
 
-            var syntaxTreeChanges = ImmutableDictionary.CreateBuilder<string, SyntaxTreeChange>( StringComparer.Ordinal );
+            var syntaxTreeChanges = ImmutableDictionary.CreateBuilder<DocumentKey, SyntaxTreeChange>();
 
             var hasCompileTimeChange = !referenceChanges.PortableExecutableReferenceChanges.IsEmpty
                                        || referenceChanges.ProjectReferenceChanges.Any( c => c.Value.HasCompileTimeCodeChange );
@@ -184,16 +186,22 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                     continue;
                 }
 
-                // At design time, the collection of syntax trees can contain duplicates,
-                // which may not even have the same text (e.g. one could contain `internal class C`, while the other just `class C`).
-                if ( newTrees.TryGetValue( newSyntaxTree.FilePath, out _ ) )
+                // At design time, the collection of syntax trees can contain duplicates, which may not even have the
+                // same text (e.g. one could contain `internal class C`, while the other just `class C`). The tree is
+                // removed from the compilation to analyse and not merely skipped here, so that the version index and
+                // that compilation continue to describe the same set of documents. See issue #1742 and
+                // ProjectVersion.Create, which resolves the condition the same way on the non-incremental path.
+                if ( newTrees.ContainsKey( newSyntaxTree.GetDocumentKey() ) )
                 {
+                    duplicatePathTrees ??= new List<SyntaxTree>();
+                    duplicatePathTrees.Add( newSyntaxTree );
+
                     continue;
                 }
 
                 SyntaxTreeVersion newSyntaxTreeVersion;
 
-                if ( lastTrees.TryGetValue( newSyntaxTree.FilePath, out var oldSyntaxTreeVersion ) )
+                if ( lastTrees.TryGetValue( newSyntaxTree.GetDocumentKey(), out var oldSyntaxTreeVersion ) )
                 {
                     if ( oldProjectVersion.Strategy.IsDifferent(
                             oldSyntaxTreeVersion,
@@ -206,13 +214,13 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                             newSyntaxTreeVersion.HasCompileTimeCode );
 
                         var change = new SyntaxTreeChange(
-                            newSyntaxTree.FilePath,
+                            newSyntaxTree.GetDocumentKey(),
                             SyntaxTreeChangeKind.Changed,
                             compileTimeChangeKind,
                             oldSyntaxTreeVersion,
                             newSyntaxTreeVersion );
 
-                        syntaxTreeChanges.Add( newSyntaxTree.FilePath, change );
+                        syntaxTreeChanges.Add( newSyntaxTree.GetDocumentKey(), change );
 
                         hasCompileTimeChange |= newSyntaxTreeVersion.HasCompileTimeCode || oldSyntaxTreeVersion.HasCompileTimeCode;
                     }
@@ -225,19 +233,19 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                     compileTimeChangeKind = DiffStrategy.GetCompileTimeChangeKind( false, newSyntaxTreeVersion.HasCompileTimeCode );
 
                     var change = new SyntaxTreeChange(
-                        newSyntaxTree.FilePath,
+                        newSyntaxTree.GetDocumentKey(),
                         SyntaxTreeChangeKind.Added,
                         compileTimeChangeKind,
                         default,
                         newSyntaxTreeVersion );
 
-                    syntaxTreeChanges.Add( newSyntaxTree.FilePath, change );
+                    syntaxTreeChanges.Add( newSyntaxTree.GetDocumentKey(), change );
 
                     hasCompileTimeChange |= newSyntaxTreeVersion.HasCompileTimeCode;
                 }
 
-                newTrees.Add( newSyntaxTree.FilePath, newSyntaxTreeVersion );
-                lastTrees = lastTrees.Remove( newSyntaxTree.FilePath );
+                newTrees.Add( newSyntaxTree.GetDocumentKey(), newSyntaxTreeVersion );
+                lastTrees = lastTrees.Remove( newSyntaxTree.GetDocumentKey() );
             }
 
             // Process old trees.
@@ -256,7 +264,13 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
             // Create the new CompilationVersion.
             var syntaxTreeVersions = newTrees.ToImmutable();
 
-            // We have to analyze a new compilation, however we need to remove generated trees.
+            // We have to analyze a new compilation, however we need to remove the generated trees, and the trees whose
+            // path an earlier tree already holds.
+            if ( duplicatePathTrees != null )
+            {
+                generatedTrees.AddRange( duplicatePathTrees );
+            }
+
             var compilationToAnalyze = newCompilation.RemoveSyntaxTrees( generatedTrees );
 
             var newCompilationVersion = new ProjectVersion(

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersion.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersion.cs
@@ -5,6 +5,7 @@
 using Metalama.Backstage.Diagnostics;
 using Metalama.Framework.DesignTime.Rpc;
 using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
@@ -18,7 +19,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
     {
         public DiffStrategy Strategy { get; }
 
-        public ImmutableDictionary<string, SyntaxTreeVersion> SyntaxTrees { get; }
+        public ImmutableDictionary<DocumentKey, SyntaxTreeVersion> SyntaxTrees { get; }
 
         public ImmutableDictionary<ProjectKey, IProjectVersion> ReferencedProjectVersions { get; }
 
@@ -37,7 +38,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
             ProjectKey projectKey,
             Compilation compilation,
             Compilation compilationToAnalyze,
-            ImmutableDictionary<string, SyntaxTreeVersion> syntaxTrees,
+            ImmutableDictionary<DocumentKey, SyntaxTreeVersion> syntaxTrees,
             ImmutableDictionary<ProjectKey, IProjectVersion> referencedCompilations,
             ImmutableHashSet<string> referencesPortableExecutables )
         {
@@ -64,9 +65,10 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
             referencedCompilations ??= ImmutableDictionary<ProjectKey, IProjectVersion>.Empty;
             referencesPortableExecutables ??= ImmutableHashSet<string>.Empty;
 
-            var syntaxTreesBuilder = ImmutableDictionary.CreateBuilder<string, SyntaxTreeVersion>( StringComparer.Ordinal );
+            var syntaxTreesBuilder = ImmutableDictionary.CreateBuilder<DocumentKey, SyntaxTreeVersion>();
 
             var generatedSyntaxTrees = new List<SyntaxTree>();
+            List<SyntaxTree>? duplicatePathSyntaxTrees = null;
 
             foreach ( var syntaxTree in compilation.SyntaxTrees )
             {
@@ -79,8 +81,15 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                     continue;
                 }
 
-                if ( syntaxTreesBuilder.TryGetValue( syntaxTree.FilePath, out var existingTreeVersion ) )
+                if ( syntaxTreesBuilder.TryGetValue( syntaxTree.GetDocumentKey(), out var existingTreeVersion ) )
                 {
+                    // The tree is removed from the compilation and not merely skipped here. A version index that
+                    // excludes a tree the analysed compilation still contains describes a compilation it does not
+                    // match, and the pipeline would then leave that tree unrewritten while its declarations remain
+                    // visible in the code model. See issue #1742.
+                    duplicatePathSyntaxTrees ??= new List<SyntaxTree>();
+                    duplicatePathSyntaxTrees.Add( syntaxTree );
+
                     logger ??= serviceProvider?.GetLoggerFactory().GetLogger( nameof(ProjectVersion) );
 
                     if ( logger?.Warning is { } warningLogger )
@@ -108,12 +117,13 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
 
                 var syntaxTreeVersion = strategy.GetSyntaxTreeVersion( syntaxTree, compilation );
 
-                syntaxTreesBuilder.Add( syntaxTree.FilePath, syntaxTreeVersion );
+                syntaxTreesBuilder.Add( syntaxTree.GetDocumentKey(), syntaxTreeVersion );
             }
 
             var syntaxTreeVersions = syntaxTreesBuilder.ToImmutable();
 
-            var compilationToAnalyze = generatedSyntaxTrees.Count > 0 ? compilation.RemoveSyntaxTrees( generatedSyntaxTrees ) : compilation;
+            var treesToRemove = Concat( generatedSyntaxTrees, duplicatePathSyntaxTrees );
+            var compilationToAnalyze = treesToRemove.Count > 0 ? compilation.RemoveSyntaxTrees( treesToRemove ) : compilation;
 
             return new ProjectVersion(
                 strategy,
@@ -125,10 +135,33 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                 referencesPortableExecutables );
         }
 
+        /// <summary>
+        /// Concatenates the two lists of syntax trees to remove from the compilation, avoiding an allocation in the
+        /// ordinary case where at most one of them has content.
+        /// </summary>
+        private static IReadOnlyList<SyntaxTree> Concat( List<SyntaxTree> generated, List<SyntaxTree>? duplicatePaths )
+        {
+            if ( duplicatePaths == null )
+            {
+                return generated;
+            }
+
+            if ( generated.Count == 0 )
+            {
+                return duplicatePaths;
+            }
+
+            var all = new List<SyntaxTree>( generated.Count + duplicatePaths.Count );
+            all.AddRange( generated );
+            all.AddRange( duplicatePaths );
+
+            return all;
+        }
+
         public ProjectKey ProjectKey { get; }
 
-        public bool TryGetSyntaxTreeVersion( string path, out SyntaxTreeVersion syntaxTreeVersion )
-            => this.SyntaxTrees.AssertNotNull().TryGetValue( path, out syntaxTreeVersion );
+        public bool TryGetSyntaxTreeVersion( DocumentKey documentKey, out SyntaxTreeVersion syntaxTreeVersion )
+            => this.SyntaxTrees.AssertNotNull().TryGetValue( documentKey, out syntaxTreeVersion );
 
         public override string ToString() => this.Compilation.AssemblyName ?? nameof(ProjectVersion);
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.Implementation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.Implementation.cs
@@ -1,7 +1,8 @@
-﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Framework.Code.Collections;
 using Metalama.Framework.DesignTime.Rpc;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.Implementation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.Implementation.cs
@@ -2,7 +2,6 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Backstage.Diagnostics;
 using Metalama.Framework.Code.Collections;
 using Metalama.Framework.DesignTime.Rpc;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.cs
@@ -131,11 +131,11 @@ internal sealed partial class ProjectVersionProvider : IGlobalService, IDisposab
 
                     if ( syntaxTreeChange.SyntaxTreeChangeKind is SyntaxTreeChangeKind.Changed or SyntaxTreeChangeKind.Removed )
                     {
-                        if ( dependenciesOfCompilation.DependenciesByMasterFilePath.TryGetValue(
+                        if ( dependenciesOfCompilation.DependenciesByMasterDocumentKey.TryGetValue(
                                 syntaxTreeChange.DocumentKey,
                                 out var dependenciesOfSyntaxTree ) )
                         {
-                            foreach ( var dependentSyntaxTree in dependenciesOfSyntaxTree.DependentFilePaths )
+                            foreach ( var dependentSyntaxTree in dependenciesOfSyntaxTree.DependentDocumentKeys )
                             {
                                 invalidateAction( dependentSyntaxTree );
                             }
@@ -149,7 +149,7 @@ internal sealed partial class ProjectVersionProvider : IGlobalService, IDisposab
                                 partialTypeChange.Type,
                                 out var dependenciesOfPartialType ) )
                         {
-                            foreach ( var dependentSyntaxTree in dependenciesOfPartialType.DependentFilePaths )
+                            foreach ( var dependentSyntaxTree in dependenciesOfPartialType.DependentDocumentKeys )
                             {
                                 invalidateAction( dependentSyntaxTree );
                             }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Pipeline.Dependencies;
 using Metalama.Framework.Engine;
 using Metalama.Framework.Engine.Services;
@@ -60,7 +61,7 @@ internal sealed partial class ProjectVersionProvider : IGlobalService, IDisposab
     public async ValueTask<DependencyGraph> ProcessCompilationChangesAsync(
         CompilationChanges changes,
         DependencyGraph dependencyGraph,
-        Action<string> invalidateAction,
+        Action<DocumentKey> invalidateAction,
         bool invalidateOnlyDependencies = false,
         TestableCancellationToken cancellationToken = default )
     {
@@ -105,7 +106,7 @@ internal sealed partial class ProjectVersionProvider : IGlobalService, IDisposab
 
                     if ( syntaxTreeChange.SyntaxTreeChangeKind == SyntaxTreeChangeKind.Removed )
                     {
-                        dependencyGraphBuilder.RemoveDependentSyntaxTree( syntaxTreeChange.FilePath );
+                        dependencyGraphBuilder.RemoveDependentSyntaxTree( syntaxTreeChange.DocumentKey );
                     }
 
                     if ( invalidatedAllTrees )
@@ -120,7 +121,7 @@ internal sealed partial class ProjectVersionProvider : IGlobalService, IDisposab
                         // but editing a file with global attributes should be relatively rare, so that's probably not worth it.
                         foreach ( var tree in currentCompilationChanges.NewProjectVersion.Compilation.SyntaxTrees )
                         {
-                            invalidateAction( tree.FilePath );
+                            invalidateAction( tree.GetDocumentKey() );
                         }
 
                         invalidatedAllTrees = true;
@@ -131,7 +132,7 @@ internal sealed partial class ProjectVersionProvider : IGlobalService, IDisposab
                     if ( syntaxTreeChange.SyntaxTreeChangeKind is SyntaxTreeChangeKind.Changed or SyntaxTreeChangeKind.Removed )
                     {
                         if ( dependenciesOfCompilation.DependenciesByMasterFilePath.TryGetValue(
-                                syntaxTreeChange.FilePath,
+                                syntaxTreeChange.DocumentKey,
                                 out var dependenciesOfSyntaxTree ) )
                         {
                             foreach ( var dependentSyntaxTree in dependenciesOfSyntaxTree.DependentFilePaths )

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/ProjectVersionProvider.cs
@@ -2,9 +2,9 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Pipeline.Dependencies;
 using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities.Threading;
 using Metalama.Framework.Services;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/SyntaxTreeChange.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/Diff/SyntaxTreeChange.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.CodeModel;
 using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
 
@@ -30,7 +31,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
         /// <summary>
         /// Gets the path of the syntax tree.
         /// </summary>
-        public string FilePath { get; }
+        public DocumentKey DocumentKey { get; }
 
         // ReSharper disable once MemberCanBePrivate.Global
 
@@ -82,14 +83,14 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
 
         public static SyntaxTreeChange NonIncremental( in SyntaxTreeVersion syntaxTreeVersion )
             => new(
-                syntaxTreeVersion.SyntaxTree.FilePath,
+                syntaxTreeVersion.SyntaxTree.GetDocumentKey(),
                 SyntaxTreeChangeKind.Added,
                 syntaxTreeVersion.HasCompileTimeCode ? CompileTimeChangeKind.NewlyCompileTime : CompileTimeChangeKind.None,
                 default,
                 syntaxTreeVersion );
 
         public SyntaxTreeChange(
-            string filePath,
+            DocumentKey documentKey,
             SyntaxTreeChangeKind syntaxTreeChangeKind,
             CompileTimeChangeKind compileTimeChangeKind,
             in SyntaxTreeVersion oldSyntaxTreeVersion,
@@ -97,7 +98,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
         {
             this.SyntaxTreeChangeKind = syntaxTreeChangeKind;
             this.CompileTimeChangeKind = compileTimeChangeKind;
-            this.FilePath = filePath;
+            this.DocumentKey = documentKey;
             this.NewSyntaxTreeVersion = newSyntaxTreeVersion;
             this._oldSyntaxTreeVersionData = new SyntaxTreeVersionData( oldSyntaxTreeVersion );
             this._oldSyntaxTreeRef = oldSyntaxTreeVersion.IsDefault ? null : new WeakReference<SyntaxTree>( oldSyntaxTreeVersion.SyntaxTree );
@@ -134,7 +135,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
             }
         }
 
-        public override string ToString() => $"{this.FilePath}, ChangeKind={this.SyntaxTreeChangeKind}, CompileTimeChangeKind={this.CompileTimeChangeKind}";
+        public override string ToString() => $"{this.DocumentKey}, ChangeKind={this.SyntaxTreeChangeKind}, CompileTimeChangeKind={this.CompileTimeChangeKind}";
 
         public SyntaxTreeChange Merge( in SyntaxTreeChange newChange )
         {
@@ -172,7 +173,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
             var oldSyntaxTreeVersion = this.OldSyntaxTreeVersionDangerous;
 
             return new SyntaxTreeChange(
-                this.FilePath,
+                this.DocumentKey,
                 newSyntaxTreeChangeKind,
                 newCompileTimeChangeKind,
                 oldSyntaxTreeVersion,
@@ -185,7 +186,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                && this.NewSyntaxTreeVersion.Equals( other.NewSyntaxTreeVersion )
                && this.SyntaxTreeChangeKind == other.SyntaxTreeChangeKind
                && this.CompileTimeChangeKind == other.CompileTimeChangeKind
-               && this.FilePath == other.FilePath
+               && this.DocumentKey == other.DocumentKey
                && this.PartialTypeChanges.Equals( other.PartialTypeChanges );
 
         public override bool Equals( object? obj ) => obj is SyntaxTreeChange other && this.Equals( other );
@@ -197,7 +198,7 @@ namespace Metalama.Framework.DesignTime.Pipeline.Diff
                 this.NewSyntaxTreeVersion,
                 (int) this.SyntaxTreeChangeKind,
                 (int) this.CompileTimeChangeKind,
-                this.FilePath,
+                this.DocumentKey,
                 this.PartialTypeChanges );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/IProjectVersion.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/IProjectVersion.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.Engine.CodeModel;
 using Microsoft.CodeAnalysis;
 using System.Collections.Immutable;
 
@@ -19,7 +20,7 @@ public interface IProjectVersion
     /// </summary>
     ProjectKey ProjectKey { get; }
 
-    bool TryGetSyntaxTreeVersion( string path, out SyntaxTreeVersion syntaxTreeVersion );
+    bool TryGetSyntaxTreeVersion( DocumentKey documentKey, out SyntaxTreeVersion syntaxTreeVersion );
 
     /// <summary>
     /// Gets the compilation of the current version.

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/PipelineResultBasedAspectRepository.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/PipelineResultBasedAspectRepository.cs
@@ -32,7 +32,7 @@ public sealed class PipelineResultBasedAspectRepository : AspectRepository
             return false;
         }
 
-        if ( !this._result.SyntaxTreeResults.TryGetValue( syntaxTree.FilePath, out var syntaxTreeResult ) )
+        if ( !this._result.SyntaxTreeResults.TryGetValue( syntaxTree.GetDocumentKey(), out var syntaxTreeResult ) )
         {
             return false;
         }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.Builder.cs
@@ -70,7 +70,7 @@ namespace Metalama.Framework.DesignTime.Pipeline
                 }
 
                 return new SyntaxTreePipelineResult(
-                    this._syntaxTree == null ? DocumentKey.Compilation : this._syntaxTree.GetDocumentKey(),
+                    this._syntaxTree?.GetDocumentKey() ?? default,
                     this.Diagnostics?.ToImmutable(),
                     this.Suppressions?.ToImmutable(),
                     this.Introductions?.ToImmutable(),

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.Builder.cs
@@ -2,9 +2,9 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
-using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.Collections;
 using Metalama.Framework.Engine.Extensibility;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.Builder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.Builder.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel.Helpers;
@@ -69,7 +70,7 @@ namespace Metalama.Framework.DesignTime.Pipeline
                 }
 
                 return new SyntaxTreePipelineResult(
-                    this._syntaxTree?.FilePath,
+                    this._syntaxTree == null ? DocumentKey.Compilation : this._syntaxTree.GetDocumentKey(),
                     this.Diagnostics?.ToImmutable(),
                     this.Suppressions?.ToImmutable(),
                     this.Introductions?.ToImmutable(),

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/SyntaxTreePipelineResult.cs
@@ -5,6 +5,7 @@
 using System.IO.Hashing;
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Collections;
 using Metalama.Framework.Engine.Extensibility;
 using Metalama.Framework.Engine.Pipeline;
@@ -24,7 +25,7 @@ namespace Metalama.Framework.DesignTime.Pipeline
         /// Gets the file path of the <see cref="Microsoft.CodeAnalysis.SyntaxTree"/> for which the results was prepared,
         /// or <c>null</c> if this object represents the part of the results that do not pertain to any syntax tree.
         /// </summary>
-        public string? SyntaxTreePath { get; }
+        public DocumentKey SyntaxTreePath { get; }
 
         public ImmutableArray<Diagnostic> Diagnostics { get; }
 
@@ -56,7 +57,7 @@ namespace Metalama.Framework.DesignTime.Pipeline
         public ulong AspectInstancesHashCode { get; }
 
         private SyntaxTreePipelineResult(
-            string? syntaxTreePath,
+            DocumentKey syntaxTreePath,
             ImmutableArray<Diagnostic>? diagnostics,
             ImmutableArray<CacheableScopedSuppression>? suppressions,
             ImmutableArray<IntroducedSyntaxTree>? introductions,

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/PreviewPipelineBasedService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/PreviewPipelineBasedService.cs
@@ -104,7 +104,7 @@ public abstract class PreviewPipelineBasedService
         var dependenciesByDependentFilePath = pipeline.Dependencies.DependenciesByMasterProject.GetValueOrDefault( projectKey ).DependenciesByDependentFilePath;
 
         var syntaxTreeNames = syntaxTreeName.SelectManyRecursiveDistinct(
-            treeName => dependenciesByDependentFilePath?.GetValueOrDefault( treeName )?.MasterFilePathsAndHashes.Keys ?? [],
+            treeName => dependenciesByDependentFilePath?.GetValueOrDefault( DocumentKey.FromPath( treeName ) )?.MasterFilePathsAndHashes.Keys.Select( k => k.Path ) ?? [],
             includeRoot: true );
 
         // Find the syntax trees of the given names.

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/PreviewPipelineBasedService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/PreviewPipelineBasedService.cs
@@ -101,10 +101,10 @@ public abstract class PreviewPipelineBasedService
         }
 
         // Get all syntax trees that the given syntax tree depends on.
-        var dependenciesByDependentFilePath = pipeline.Dependencies.DependenciesByMasterProject.GetValueOrDefault( projectKey ).DependenciesByDependentFilePath;
+        var dependenciesByDependentDocumentKey = pipeline.Dependencies.DependenciesByMasterProject.GetValueOrDefault( projectKey ).DependenciesByDependentDocumentKey;
 
         var syntaxTreeNames = syntaxTreeName.SelectManyRecursiveDistinct(
-            treeName => dependenciesByDependentFilePath?.GetValueOrDefault( DocumentKey.FromPath( treeName ) )?.MasterFilePathsAndHashes.Keys.Select( k => k.Path ) ?? [],
+            treeName => dependenciesByDependentDocumentKey?.GetValueOrDefault( DocumentKey.FromPath( treeName ) )?.MasterDocumentKeysAndHashes.Keys.Select( k => k.Path ) ?? [],
             includeRoot: true );
 
         // Find the syntax trees of the given names.

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/TransformationPreviewServiceImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/TransformationPreviewServiceImpl.cs
@@ -49,7 +49,10 @@ public sealed class TransformationPreviewServiceImpl : PreviewPipelineBasedServi
             return SerializablePreviewTransformationResult.Failure( errorMessages );
         }
 
-        var transformedSyntaxTree = pipelineResult.Value.SyntaxTrees[syntaxTreeName];
+        if ( !pipelineResult.Value.TryGetSyntaxTree( DocumentKey.FromPath( syntaxTreeName ), out var transformedSyntaxTree ) )
+        {
+            return SerializablePreviewTransformationResult.Failure( [$"The transformed compilation does not contain a syntax tree for '{syntaxTreeName}'."] );
+        }
 
         return SerializablePreviewTransformationResult.Success( JsonSerializationHelper.CreateSerializableSyntaxTree( transformedSyntaxTree ), null );
     }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/TransformationPreviewServiceImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Preview/TransformationPreviewServiceImpl.cs
@@ -49,7 +49,7 @@ public sealed class TransformationPreviewServiceImpl : PreviewPipelineBasedServi
             return SerializablePreviewTransformationResult.Failure( errorMessages );
         }
 
-        if ( !pipelineResult.Value.TryGetSyntaxTree( DocumentKey.FromPath( syntaxTreeName ), out var transformedSyntaxTree ) )
+        if ( !pipelineResult.Value.TryGetSyntaxTreeByPath( syntaxTreeName, out var transformedSyntaxTree ) )
         {
             return SerializablePreviewTransformationResult.Failure( [$"The transformed compilation does not contain a syntax tree for '{syntaxTreeName}'."] );
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/CompilationModel.cs
@@ -253,9 +253,9 @@ namespace Metalama.Framework.Engine.CodeModel
             // Discover custom attributes.
             AttributeDiscoveryVisitor attributeDiscoveryVisitor = new( this );
 
-            foreach ( var tree in partialCompilation.SyntaxTrees )
+            foreach ( var tree in partialCompilation.SyntaxTreeCollection )
             {
-                attributeDiscoveryVisitor.Visit( tree.Value );
+                attributeDiscoveryVisitor.Visit( tree );
             }
 
             this._allMemberAttributesByType = attributeDiscoveryVisitor.GetDiscoveredAttributes();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.CompleteImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.CompleteImpl.cs
@@ -11,6 +11,7 @@ using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.CodeModel
 {
@@ -30,8 +31,21 @@ namespace Metalama.Framework.Engine.CodeModel
                 ImmutableArray<ManagedResource> resources )
                 : base( baseCompilation, modifications, resources ) { }
 
+            /// <remarks>
+            /// Materialized only if the obsolete property is actually read, which no code of this repository does any
+            /// more. The index of the compilation is a plain dictionary, because it is built once and never updated, so
+            /// producing an <see cref="ImmutableDictionary{TKey,TValue}"/> from it is a conversion that exists purely to
+            /// satisfy the declared type.
+            /// </remarks>
             [Memo]
-            public override ImmutableDictionary<string, SyntaxTree> SyntaxTrees => this.Compilation.GetIndexedSyntaxTrees();
+            [Obsolete( "Use SyntaxTreeCollection to enumerate the syntax trees, or TryGetSyntaxTree to find one by its DocumentKey." )]
+            public override ImmutableDictionary<string, SyntaxTree> SyntaxTrees
+                => this.Compilation.GetIndexedSyntaxTrees().ToImmutableDictionary( x => x.Key, x => x.Value, StringComparer.Ordinal );
+
+            public override IReadOnlyCollection<SyntaxTree> SyntaxTreeCollection => this.Compilation.GetSyntaxTreeIndex().SyntaxTrees;
+
+            public override bool TryGetSyntaxTree( DocumentKey documentKey, [NotNullWhen( true )] out SyntaxTree? syntaxTree )
+                => this.Compilation.GetIndexedSyntaxTrees().TryGetValue( documentKey.Path, out syntaxTree );
 
             [Memo]
             public override ImmutableHashSet<INamedTypeSymbol> Types => this.Compilation.SourceModule.GetTypes().ToImmutableHashSet();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.CompleteImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.CompleteImpl.cs
@@ -40,12 +40,12 @@ namespace Metalama.Framework.Engine.CodeModel
             [Memo]
             [Obsolete( "Use SyntaxTreeCollection to enumerate the syntax trees, or TryGetSyntaxTree to find one by its DocumentKey." )]
             public override ImmutableDictionary<string, SyntaxTree> SyntaxTrees
-                => this.Compilation.GetIndexedSyntaxTrees().ToImmutableDictionary( x => x.Key, x => x.Value, StringComparer.Ordinal );
+                => this.Compilation.GetIndexedSyntaxTrees().ToImmutableDictionary( x => x.Key.Path, x => x.Value, StringComparer.Ordinal );
 
             public override IReadOnlyCollection<SyntaxTree> SyntaxTreeCollection => this.Compilation.GetSyntaxTreeIndex().SyntaxTrees;
 
             public override bool TryGetSyntaxTree( DocumentKey documentKey, [NotNullWhen( true )] out SyntaxTree? syntaxTree )
-                => this.Compilation.GetIndexedSyntaxTrees().TryGetValue( documentKey.Path, out syntaxTree );
+                => this.Compilation.GetIndexedSyntaxTrees().TryGetValue( documentKey, out syntaxTree );
 
             [Memo]
             public override ImmutableHashSet<INamedTypeSymbol> Types => this.Compilation.SourceModule.GetTypes().ToImmutableHashSet();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.PartialImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.PartialImpl.cs
@@ -4,10 +4,12 @@
 
 using Metalama.Compiler;
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Metalama.Framework.Engine.CodeModel
@@ -33,7 +35,7 @@ namespace Metalama.Framework.Engine.CodeModel
                 : base( compilationContext, derivedTypeIndex, resources )
             {
                 this._types = types;
-                this.SyntaxTrees = syntaxTrees;
+                this.SyntaxTreesByPath = syntaxTrees;
                 this._observedSyntaxTreePaths = observedSyntaxTreePaths;
 
 #if DEBUG
@@ -51,7 +53,7 @@ namespace Metalama.Framework.Engine.CodeModel
                 : base( baseCompilation, modifications, resources )
             {
                 this._types = types;
-                this.SyntaxTrees = syntaxTrees;
+                this.SyntaxTreesByPath = syntaxTrees;
                 this._observedSyntaxTreePaths = observedSyntaxTreePaths;
 
 #if DEBUG
@@ -63,14 +65,34 @@ namespace Metalama.Framework.Engine.CodeModel
 
             private void CheckTrees()
             {
-                if ( this.SyntaxTrees.Any( t => string.IsNullOrEmpty( t.Key ) ) )
+                if ( this.SyntaxTreesByPath.Any( t => string.IsNullOrEmpty( t.Key ) ) )
                 {
                     throw new AssertionFailedException( "A syntax tree has no name." );
                 }
             }
 #endif
 
-            public override ImmutableDictionary<string, SyntaxTree> SyntaxTrees { get; }
+            /// <summary>
+            /// Gets the syntax trees of the subset indexed by path. This is the storage of the class, and the source of
+            /// both <see cref="SyntaxTreeCollection"/> and <see cref="TryGetSyntaxTree"/>. It is an
+            /// <see cref="ImmutableDictionary{TKey,TValue}"/>, unlike the index of a complete compilation, because
+            /// <see cref="Update"/> derives a new subset from it and the structural sharing is what makes that cheap.
+            /// </summary>
+            private ImmutableDictionary<string, SyntaxTree> SyntaxTreesByPath { get; }
+
+            [Obsolete( "Use SyntaxTreeCollection to enumerate the syntax trees, or TryGetSyntaxTree to find one by its DocumentKey." )]
+            public override ImmutableDictionary<string, SyntaxTree> SyntaxTrees => this.SyntaxTreesByPath;
+
+            /// <remarks>
+            /// Materialized under <see cref="MemoAttribute"/> rather than adapted, because the pipeline enumerates this
+            /// collection once per tree and an array is the cheapest thing to walk. One instance exists per
+            /// <see cref="PartialImpl"/>, and instances are created only by <see cref="Update"/>.
+            /// </remarks>
+            [Memo]
+            public override IReadOnlyCollection<SyntaxTree> SyntaxTreeCollection => this.SyntaxTreesByPath.Values.ToImmutableArray();
+
+            public override bool TryGetSyntaxTree( DocumentKey documentKey, [NotNullWhen( true )] out SyntaxTree? syntaxTree )
+                => this.SyntaxTreesByPath.TryGetValue( documentKey.Path, out syntaxTree );
 
             public override ImmutableHashSet<INamedTypeSymbol> Types => this._types ?? throw new NotImplementedException();
 
@@ -90,15 +112,22 @@ namespace Metalama.Framework.Engine.CodeModel
             {
                 Validate( transformations );
 
-                var syntaxTrees = this.SyntaxTrees.ToBuilder();
+                var syntaxTrees = this.SyntaxTreesByPath.ToBuilder();
 
                 if ( transformations != null )
                 {
                     foreach ( var transformation in transformations )
                     {
-                        if ( transformation.OldTree != null && !this.SyntaxTrees.ContainsKey( transformation.FilePath ) )
+                        // Matched by identity and not merely by path: the transformation names the tree it applies to,
+                        // and Compilation.ReplaceSyntaxTree resolves it by identity, so a transformation naming a tree
+                        // that this partial compilation does not hold has to be rejected here. Left to Roslyn it fails
+                        // with a message that names neither the path nor the caller.
+                        if ( transformation.OldTree != null
+                             && (!this.SyntaxTreesByPath.TryGetValue( transformation.FilePath, out var existingTree )
+                                 || existingTree != transformation.OldTree) )
                         {
-                            throw new KeyNotFoundException();
+                            throw new KeyNotFoundException(
+                                $"The partial compilation does not contain the syntax tree '{transformation.FilePath}' that the transformation replaces." );
                         }
 
                         switch ( transformation.Kind )

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.PartialImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.PartialImpl.cs
@@ -27,7 +27,7 @@ namespace Metalama.Framework.Engine.CodeModel
 
             public PartialImpl(
                 CompilationContext compilationContext,
-                ImmutableDictionary<string, SyntaxTree> syntaxTrees,
+                ImmutableDictionary<DocumentKey, SyntaxTree> syntaxTrees,
                 ImmutableHashSet<string>? observedSyntaxTreePaths,
                 ImmutableHashSet<INamedTypeSymbol>? types,
                 Lazy<DerivedTypeIndex> derivedTypeIndex,
@@ -35,7 +35,7 @@ namespace Metalama.Framework.Engine.CodeModel
                 : base( compilationContext, derivedTypeIndex, resources )
             {
                 this._types = types;
-                this.SyntaxTreesByPath = syntaxTrees;
+                this.SyntaxTreesByDocumentKey = syntaxTrees;
                 this._observedSyntaxTreePaths = observedSyntaxTreePaths;
 
 #if DEBUG
@@ -44,7 +44,7 @@ namespace Metalama.Framework.Engine.CodeModel
             }
 
             private PartialImpl(
-                ImmutableDictionary<string, SyntaxTree> syntaxTrees,
+                ImmutableDictionary<DocumentKey, SyntaxTree> syntaxTrees,
                 ImmutableHashSet<string>? observedSyntaxTreePaths,
                 ImmutableHashSet<INamedTypeSymbol>? types,
                 PartialCompilation baseCompilation,
@@ -53,7 +53,7 @@ namespace Metalama.Framework.Engine.CodeModel
                 : base( baseCompilation, modifications, resources )
             {
                 this._types = types;
-                this.SyntaxTreesByPath = syntaxTrees;
+                this.SyntaxTreesByDocumentKey = syntaxTrees;
                 this._observedSyntaxTreePaths = observedSyntaxTreePaths;
 
 #if DEBUG
@@ -65,7 +65,7 @@ namespace Metalama.Framework.Engine.CodeModel
 
             private void CheckTrees()
             {
-                if ( this.SyntaxTreesByPath.Any( t => string.IsNullOrEmpty( t.Key ) ) )
+                if ( this.SyntaxTreesByDocumentKey.Any( t => string.IsNullOrEmpty( t.Key.Path ) ) )
                 {
                     throw new AssertionFailedException( "A syntax tree has no name." );
                 }
@@ -78,10 +78,11 @@ namespace Metalama.Framework.Engine.CodeModel
             /// <see cref="ImmutableDictionary{TKey,TValue}"/>, unlike the index of a complete compilation, because
             /// <see cref="Update"/> derives a new subset from it and the structural sharing is what makes that cheap.
             /// </summary>
-            private ImmutableDictionary<string, SyntaxTree> SyntaxTreesByPath { get; }
+            private ImmutableDictionary<DocumentKey, SyntaxTree> SyntaxTreesByDocumentKey { get; }
 
             [Obsolete( "Use SyntaxTreeCollection to enumerate the syntax trees, or TryGetSyntaxTree to find one by its DocumentKey." )]
-            public override ImmutableDictionary<string, SyntaxTree> SyntaxTrees => this.SyntaxTreesByPath;
+            public override ImmutableDictionary<string, SyntaxTree> SyntaxTrees
+                => this.SyntaxTreesByDocumentKey.ToImmutableDictionary( x => x.Key.Path, x => x.Value, StringComparer.Ordinal );
 
             /// <remarks>
             /// Materialized under <see cref="MemoAttribute"/> rather than adapted, because the pipeline enumerates this
@@ -89,10 +90,10 @@ namespace Metalama.Framework.Engine.CodeModel
             /// <see cref="PartialImpl"/>, and instances are created only by <see cref="Update"/>.
             /// </remarks>
             [Memo]
-            public override IReadOnlyCollection<SyntaxTree> SyntaxTreeCollection => this.SyntaxTreesByPath.Values.ToImmutableArray();
+            public override IReadOnlyCollection<SyntaxTree> SyntaxTreeCollection => this.SyntaxTreesByDocumentKey.Values.ToImmutableArray();
 
             public override bool TryGetSyntaxTree( DocumentKey documentKey, [NotNullWhen( true )] out SyntaxTree? syntaxTree )
-                => this.SyntaxTreesByPath.TryGetValue( documentKey.Path, out syntaxTree );
+                => this.SyntaxTreesByDocumentKey.TryGetValue( documentKey, out syntaxTree );
 
             public override ImmutableHashSet<INamedTypeSymbol> Types => this._types ?? throw new NotImplementedException();
 
@@ -112,7 +113,7 @@ namespace Metalama.Framework.Engine.CodeModel
             {
                 Validate( transformations );
 
-                var syntaxTrees = this.SyntaxTreesByPath.ToBuilder();
+                var syntaxTrees = this.SyntaxTreesByDocumentKey.ToBuilder();
 
                 if ( transformations != null )
                 {
@@ -123,7 +124,7 @@ namespace Metalama.Framework.Engine.CodeModel
                         // that this partial compilation does not hold has to be rejected here. Left to Roslyn it fails
                         // with a message that names neither the path nor the caller.
                         if ( transformation.OldTree != null
-                             && (!this.SyntaxTreesByPath.TryGetValue( transformation.FilePath, out var existingTree )
+                             && (!this.SyntaxTreesByDocumentKey.TryGetValue( DocumentKey.FromPath( transformation.FilePath ), out var existingTree )
                                  || existingTree != transformation.OldTree) )
                         {
                             throw new KeyNotFoundException(
@@ -137,12 +138,12 @@ namespace Metalama.Framework.Engine.CodeModel
 
                             case SyntaxTreeTransformationKind.Add:
                             case SyntaxTreeTransformationKind.Replace:
-                                syntaxTrees[transformation.FilePath] = transformation.NewTree.AssertNotNull();
+                                syntaxTrees[DocumentKey.FromPath( transformation.FilePath )] = transformation.NewTree.AssertNotNull();
 
                                 break;
 
                             case SyntaxTreeTransformationKind.Remove:
-                                syntaxTrees.Remove( transformation.FilePath );
+                                syntaxTrees.Remove( DocumentKey.FromPath( transformation.FilePath ) );
 
                                 break;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.cs
@@ -13,6 +13,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Metalama.Framework.Engine.CodeModel
@@ -45,7 +46,14 @@ namespace Metalama.Framework.Engine.CodeModel
         /// <summary>
         /// Gets the list of syntax trees in the current subset indexed by path.
         /// </summary>
+        [Obsolete( "Use SyntaxTreeCollection to enumerate the syntax trees, or TryGetSyntaxTree to find one by its DocumentKey." )]
         public abstract ImmutableDictionary<string, SyntaxTree> SyntaxTrees { get; }
+
+        /// <inheritdoc cref="IPartialCompilation.SyntaxTreeCollection"/>
+        public abstract IReadOnlyCollection<SyntaxTree> SyntaxTreeCollection { get; }
+
+        /// <inheritdoc cref="IPartialCompilation.TryGetSyntaxTree"/>
+        public abstract bool TryGetSyntaxTree( DocumentKey documentKey, [NotNullWhen( true )] out SyntaxTree? syntaxTree );
 
         /// <summary>
         /// Returns whether the given path is of interest to the current <see cref="PartialCompilation"/>.
@@ -77,9 +85,9 @@ namespace Metalama.Framework.Engine.CodeModel
         {
             get
             {
-                if ( this.SyntaxTrees.Count > 0 )
+                if ( this.SyntaxTreeCollection.Count > 0 )
                 {
-                    var parseOptions = (CSharpParseOptions) this.SyntaxTrees.Values.First().Options;
+                    var parseOptions = (CSharpParseOptions) this.SyntaxTreeCollection.First().Options;
 
                     return new LanguageOptions( parseOptions );
                 }
@@ -124,7 +132,10 @@ namespace Metalama.Framework.Engine.CodeModel
                         continue;
                     }
 
-                    // Find the tree in InitialCompilation.
+                    // Find the tree in InitialCompilation. When the path has not been modified since, the tree the
+                    // transformation applies to is itself the initial tree, so it is taken from the transformation
+                    // rather than looked up by path: Compilation.ReplaceSyntaxTree resolves the tree by identity, and
+                    // resolving it by path here would let the two disagree.
                     SyntaxTree? initialTree;
 
                     if ( transformation.OldTree == null )
@@ -135,9 +146,9 @@ namespace Metalama.Framework.Engine.CodeModel
                     {
                         initialTree = initialTreeReplacement.OldTree;
                     }
-                    else if ( !baseCompilation.SyntaxTrees.TryGetValue( transformation.FilePath, out initialTree! ) )
+                    else
                     {
-                        initialTree = transformation.OldTree.AssertNotNull();
+                        initialTree = transformation.OldTree;
                     }
 
                     SyntaxTreeTransformation? transformationFromInitialCompilation;
@@ -202,8 +213,16 @@ namespace Metalama.Framework.Engine.CodeModel
         /// <summary>
         /// Creates a <see cref="PartialCompilation"/> that represents a complete compilation.
         /// </summary>
+        /// <remarks>
+        /// The compilation is normalized so that a path identifies a syntax tree of it. See
+        /// <see cref="Metalama.Framework.Engine.Utilities.Roslyn.CompilationExtensions.RemoveDuplicatePathSyntaxTrees(Microsoft.CodeAnalysis.Compilation)"/>; the call costs nothing and returns the
+        /// argument unchanged when no path is duplicated, which is every compilation produced by the command-line
+        /// compiler and every compilation the design-time pipeline has already normalized. It is applied here as well
+        /// because <c>AspectDatabase</c>, the preview service and the introspection API reach this method without
+        /// passing through the design-time diff layer.
+        /// </remarks>
         public static PartialCompilation CreateComplete( Compilation compilation, ImmutableArray<ManagedResource> resources = default )
-            => CreateComplete( compilation.GetCompilationContext(), resources );
+            => CreateComplete( compilation.RemoveDuplicatePathSyntaxTrees().GetCompilationContext(), resources );
 
         private static PartialCompilation CreateComplete( CompilationContext compilationContext, ImmutableArray<ManagedResource> resources = default )
             => new CompleteImpl( compilationContext, new Lazy<DerivedTypeIndex>( () => GetDerivedTypeIndex( compilationContext.Compilation ) ), resources );
@@ -216,8 +235,9 @@ namespace Metalama.Framework.Engine.CodeModel
             SyntaxTree syntaxTree,
             ImmutableArray<ManagedResource> resources = default )
         {
-            var compilationContext = compilation.GetCompilationContext();
-            var syntaxTrees = new[] { syntaxTree };
+            var normalizedCompilation = compilation.RemoveDuplicatePathSyntaxTrees();
+            var compilationContext = normalizedCompilation.GetCompilationContext();
+            var syntaxTrees = MapToNormalizedCompilation( compilation, normalizedCompilation,new[] { syntaxTree } );
             var closure = GetClosure( compilationContext, syntaxTrees );
 
             return new PartialImpl(
@@ -241,8 +261,9 @@ namespace Metalama.Framework.Engine.CodeModel
             ImmutableHashSet<string>? observedSyntaxTreePaths = null,
             ImmutableArray<ManagedResource> resources = default )
         {
-            var compilationContext = compilation.GetCompilationContext();
-            var closure = GetClosure( compilationContext, syntaxTrees );
+            var normalizedCompilation = compilation.RemoveDuplicatePathSyntaxTrees();
+            var compilationContext = normalizedCompilation.GetCompilationContext();
+            var closure = GetClosure( compilationContext, MapToNormalizedCompilation( compilation, normalizedCompilation,syntaxTrees ) );
 
             return new PartialImpl(
                 compilationContext,
@@ -268,6 +289,68 @@ namespace Metalama.Framework.Engine.CodeModel
             IReadOnlyCollection<SyntaxTreeTransformation>? transformations = null,
             ImmutableArray<ManagedResource> resources = default );
 
+        /// <summary>
+        /// Translates the syntax trees the caller asked for, which belong to <paramref name="requestedCompilation"/>,
+        /// into the corresponding syntax trees of <paramref name="normalizedCompilation"/>.
+        /// </summary>
+        /// <param name="requestedCompilation">The compilation the caller passed to <c>CreatePartial</c>.</param>
+        /// <param name="normalizedCompilation">
+        /// The result of
+        /// <see cref="Metalama.Framework.Engine.Utilities.Roslyn.CompilationExtensions.RemoveDuplicatePathSyntaxTrees(Microsoft.CodeAnalysis.Compilation)"/>
+        /// on <paramref name="requestedCompilation"/>: the same compilation minus every syntax tree whose path an
+        /// earlier tree already held.
+        /// </param>
+        /// <param name="requestedSyntaxTrees">Syntax trees of <paramref name="requestedCompilation"/>.</param>
+        /// <returns>The corresponding syntax trees of <paramref name="normalizedCompilation"/>, without duplicates.</returns>
+        /// <remarks>
+        /// <para>
+        /// The problem this solves: <c>CreatePartial</c> builds the closure against the normalized compilation, and
+        /// asking that compilation for the semantic model of a syntax tree it does not contain throws. The caller,
+        /// however, selected its trees from the compilation it holds, which is the compilation before normalization. So
+        /// whenever normalization removed anything, the two sets have to be reconciled before the closure is computed.
+        /// </para>
+        /// <para>
+        /// Two cases arise, and both are handled by looking the tree up by its path in the normalized compilation.
+        /// A tree that survived normalization is found and maps to itself. A tree that was removed, because an earlier
+        /// tree held its path, is found as that earlier tree: under the one-document model the two are the same
+        /// document, so the caller asking for one is asking for that document, and the surviving tree is what
+        /// represents it. Two requested trees can therefore map to one, hence the duplicate check on the way out.
+        /// </para>
+        /// <para>
+        /// A lookup can also fail, which happens only if the caller passes a tree belonging to some other compilation
+        /// entirely. Such a tree is dropped rather than reported, matching what <c>CreatePartial</c> did before: it
+        /// would previously have produced a closure whose semantic model lookups failed further along.
+        /// </para>
+        /// <para>
+        /// Nothing is allocated and nothing is looked up in the ordinary case, in which no path was duplicated and
+        /// normalization returned the compilation itself. See issue #1742.
+        /// </para>
+        /// </remarks>
+        private static IReadOnlyList<SyntaxTree> MapToNormalizedCompilation(
+            Compilation requestedCompilation,
+            Compilation normalizedCompilation,
+            IReadOnlyList<SyntaxTree> requestedSyntaxTrees )
+        {
+            if ( ReferenceEquals( requestedCompilation, normalizedCompilation ) )
+            {
+                return requestedSyntaxTrees;
+            }
+
+            var syntaxTreesByPath = normalizedCompilation.GetIndexedSyntaxTrees();
+            var mappedSyntaxTrees = new List<SyntaxTree>( requestedSyntaxTrees.Count );
+
+            foreach ( var requestedSyntaxTree in requestedSyntaxTrees )
+            {
+                if ( syntaxTreesByPath.TryGetValue( requestedSyntaxTree.FilePath, out var mappedSyntaxTree )
+                     && !mappedSyntaxTrees.Contains( mappedSyntaxTree ) )
+                {
+                    mappedSyntaxTrees.Add( mappedSyntaxTree );
+                }
+            }
+
+            return mappedSyntaxTrees;
+        }
+
         private sealed record Closure(
             ImmutableHashSet<INamedTypeSymbol> DeclaredTypes,
             ImmutableHashSet<SyntaxTree> Trees,
@@ -287,14 +370,11 @@ namespace Metalama.Framework.Engine.CodeModel
             var trees = ImmutableHashSet.CreateBuilder<SyntaxTree>();
             var derivedTypesBuilder = new DerivedTypeIndex.Builder( compilationContext );
 
-            void AddTree( SyntaxTree newTree )
-            {
-                // At design time, the collection of syntax trees can contain duplicates.
-                if ( trees.All( t => t.FilePath != newTree.FilePath ) )
-                {
-                    trees.Add( newTree );
-                }
-            }
+            // The trees are those of a compilation from which CompilationExtensions.RemoveDuplicatePathSyntaxTrees has
+            // already removed every tree that shared a path with an earlier one, so a path identifies a tree here and
+            // membership of the set is enough. The previous guard compared the path of the candidate against the path of
+            // every tree already collected, which made building the closure quadratic in the number of trees.
+            void AddTree( SyntaxTree newTree ) => trees.Add( newTree );
 
             void AddTypeRecursive( INamedTypeSymbol type )
             {
@@ -378,7 +458,7 @@ namespace Metalama.Framework.Engine.CodeModel
         internal ImmutableArray<SyntaxTreeTransformation> ToTransformations() => this.ModifiedSyntaxTrees.Values.ToImmutableArray();
 
         public override string ToString()
-            => $"{{Assembly={this.Compilation.AssemblyName}, SyntaxTrees={this.SyntaxTrees.Count}/{this.Compilation.SyntaxTrees.Count()}}}";
+            => $"{{Assembly={this.Compilation.AssemblyName}, SyntaxTrees={this.SyntaxTreeCollection.Count}/{this.Compilation.SyntaxTrees.Count()}}}";
 
         /// <summary>
         /// Gets the compilation with respect to which the <see cref="ModifiedSyntaxTrees"/> collection has been constructed.

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.cs
@@ -132,10 +132,14 @@ namespace Metalama.Framework.Engine.CodeModel
                         continue;
                     }
 
-                    // Find the tree in InitialCompilation. When the path has not been modified since, the tree the
-                    // transformation applies to is itself the initial tree, so it is taken from the transformation
-                    // rather than looked up by path: Compilation.ReplaceSyntaxTree resolves the tree by identity, and
-                    // resolving it by path here would let the two disagree.
+                    // Find the tree in InitialCompilation.
+                    //
+                    // The tree of the base compilation is preferred over the one the transformation carries, and the
+                    // difference shows when two transformations of one batch apply to the same path: the second carries
+                    // the tree the first produced, which is not in the initial compilation, whereas the base compilation
+                    // still holds the initial one. What is recorded here reaches Metalama.Compiler as the transformation
+                    // to apply, and it tracks the replacement to map diagnostics back to the source, so an intermediate
+                    // tree recorded as the initial one leaves a diagnostic pointing into a tree it does not belong to.
                     SyntaxTree? initialTree;
 
                     if ( transformation.OldTree == null )
@@ -146,7 +150,7 @@ namespace Metalama.Framework.Engine.CodeModel
                     {
                         initialTree = initialTreeReplacement.OldTree;
                     }
-                    else
+                    else if ( !baseCompilation.TryGetSyntaxTree( DocumentKey.FromPath( transformation.FilePath ), out initialTree ) )
                     {
                         initialTree = transformation.OldTree;
                     }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CodeModel/PartialCompilation.cs
@@ -242,7 +242,7 @@ namespace Metalama.Framework.Engine.CodeModel
 
             return new PartialImpl(
                 compilationContext,
-                closure.Trees.ToImmutableDictionary( t => t.FilePath, t => t ),
+                closure.Trees.ToImmutableDictionary( t => t.GetDocumentKey(), t => t ),
                 observedSyntaxTreePaths: null,
                 closure.DeclaredTypes,
                 new Lazy<DerivedTypeIndex>( () => closure.DerivedTypeIndex ),
@@ -267,7 +267,7 @@ namespace Metalama.Framework.Engine.CodeModel
 
             return new PartialImpl(
                 compilationContext,
-                closure.Trees.ToImmutableDictionary( t => t.FilePath, t => t ),
+                closure.Trees.ToImmutableDictionary( t => t.GetDocumentKey(), t => t ),
                 observedSyntaxTreePaths,
                 closure.DeclaredTypes.ToImmutableHashSet(),
                 new Lazy<DerivedTypeIndex>( () => closure.DerivedTypeIndex ),
@@ -341,7 +341,7 @@ namespace Metalama.Framework.Engine.CodeModel
 
             foreach ( var requestedSyntaxTree in requestedSyntaxTrees )
             {
-                if ( syntaxTreesByPath.TryGetValue( requestedSyntaxTree.FilePath, out var mappedSyntaxTree )
+                if ( syntaxTreesByPath.TryGetValue( requestedSyntaxTree.GetDocumentKey(), out var mappedSyntaxTree )
                      && !mappedSyntaxTrees.Contains( mappedSyntaxTree ) )
                 {
                     mappedSyntaxTrees.Add( mappedSyntaxTree );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.TransformedFileGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.TransformedFileGenerator.cs
@@ -19,13 +19,7 @@ internal sealed partial class CompileTimeCompilationBuilder
     /// </remarks>
     internal sealed class TransformedPathGenerator
     {
-        /// <summary>
-        /// The number of characters reserved for the ordinal that disambiguates a collision, including its separator.
-        /// </summary>
-        private const int _maxOrdinalLength = 3;
-
-        private static int NameMaxLength
-            => OutputPathHelper.MaxOutputFilenameLength - 1 /* backslash */ - 1 /* - */ - 8 /* hash */ - 3 /* .cs */ - _maxOrdinalLength;
+        private static int NameMaxLength => OutputPathHelper.MaxOutputFilenameLength - 1 /* backslash */ - 1 /* - */ - 8 /* hash */ - 3 /* .cs */;
 
         private readonly HashSet<string> _generatedNames = new( StringComparer.OrdinalIgnoreCase );
 
@@ -52,40 +46,45 @@ internal sealed partial class CompileTimeCompilationBuilder
         /// before calling. Widening the hash instead would only make the collision rarer, and would spend eight
         /// characters of a name budget that <see cref="OutputPathHelper.MaxOutputFilenameLength"/> already constrains.
         /// </para>
+        /// <para>
+        /// The first name of a series carries no ordinal, so a file that collides with nothing keeps the name it had
+        /// before collisions were resolved at all. That matters because the name reaches the compile-time project and
+        /// its manifest, which a later build reads from the cache: shortening every name to reserve room for an ordinal
+        /// would have changed names that no collision ever touches.
+        /// </para>
         /// </remarks>
         public string GetTransformedFilePath( string fileName, ulong hash )
         {
-            var transformedFileName = fileName;
-
-            if ( transformedFileName.Length > NameMaxLength )
-            {
-                transformedFileName = transformedFileName.Substring( 0, NameMaxLength );
-            }
-
-            string fileNameWithHash;
-
-            unchecked
-            {
-                fileNameWithHash = $"{transformedFileName}_{(uint) hash:x8}";
-            }
-
-            var candidate = fileNameWithHash + ".cs";
-
-            for ( var ordinal = 2; !this._generatedNames.Add( candidate ); ordinal++ )
+            for ( var ordinal = 1;; ordinal++ )
             {
                 if ( ordinal > 99 )
                 {
                     // Unreachable in practice: it would take a hundred compile-time files of one name colliding on the
-                    // same thirty-two bits. Reported rather than silently truncated, because beyond this the ordinal no
-                    // longer fits the reserved budget and the name could exceed the maximum length.
+                    // same thirty-two bits.
                     throw new InvalidOperationException(
-                        $"More than 99 compile-time files named '{transformedFileName}' have a content hash with the same lower 32 bits." );
+                        $"More than 99 compile-time files named '{fileName}' have a content hash with the same lower 32 bits." );
                 }
 
-                candidate = $"{fileNameWithHash}_{ordinal}.cs";
-            }
+                var suffix = ordinal == 1 ? "" : $"_{ordinal}";
+                var transformedFileName = fileName;
 
-            return candidate;
+                if ( transformedFileName.Length > NameMaxLength - suffix.Length )
+                {
+                    transformedFileName = transformedFileName.Substring( 0, NameMaxLength - suffix.Length );
+                }
+
+                string candidate;
+
+                unchecked
+                {
+                    candidate = $"{transformedFileName}_{(uint) hash:x8}{suffix}.cs";
+                }
+
+                if ( this._generatedNames.Add( candidate ) )
+                {
+                    return candidate;
+                }
+            }
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.TransformedFileGenerator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.TransformedFileGenerator.cs
@@ -9,18 +9,52 @@ namespace Metalama.Framework.Engine.CompileTime;
 
 internal sealed partial class CompileTimeCompilationBuilder
 {
-    private sealed class TransformedPathGenerator
+    /// <summary>
+    /// Allocates the path of a transformed compile-time syntax tree.
+    /// </summary>
+    /// <remarks>
+    /// Internal rather than private so that <c>TransformedPathGeneratorTests</c> can exercise the uniqueness contract
+    /// directly. Reaching it through <see cref="CompileTimeCompilationBuilder"/> would require constructing a hash
+    /// collision through real source code, which no test can arrange deterministically.
+    /// </remarks>
+    internal sealed class TransformedPathGenerator
     {
-        private static int NameMaxLength => OutputPathHelper.MaxOutputFilenameLength - 1 /* backslash */ - 1 /* - */ - 8 /* hash */ - 3 /* .cs */;
+        /// <summary>
+        /// The number of characters reserved for the ordinal that disambiguates a collision, including its separator.
+        /// </summary>
+        private const int _maxOrdinalLength = 3;
+
+        private static int NameMaxLength
+            => OutputPathHelper.MaxOutputFilenameLength - 1 /* backslash */ - 1 /* - */ - 8 /* hash */ - 3 /* .cs */ - _maxOrdinalLength;
 
         private readonly HashSet<string> _generatedNames = new( StringComparer.OrdinalIgnoreCase );
 
+        /// <summary>
+        /// Gets the path of the transformed tree of a compile-time file, given the file name without its extension and
+        /// the hash of its content.
+        /// </summary>
+        /// <remarks>
+        /// <para>
+        /// The name must not depend on the directory the repository is checked out in. If it did, the same project built
+        /// on two machines, or checked out in two directories, would have one source hash and two different
+        /// <c>manifest.json</c> files. Only the file name and the content therefore contribute to it.
+        /// </para>
+        /// <para>
+        /// That leaves a collision reachable, because the name carries only the low thirty-two bits of the hash: two
+        /// compile-time files of one name whose contents differ can agree on those bits. Two files of one name and
+        /// identical content collide as well, though that is rarer, since identical content usually means duplicate type
+        /// declarations. Neither is a reason to fail the compile-time project, which is what this method used to do. See
+        /// issue #1742.
+        /// </para>
+        /// <para>
+        /// A collision is resolved by appending an ordinal. That keeps the result independent of the checkout directory
+        /// as long as the call order is, and it is: the caller orders the trees by file name and then by content hash
+        /// before calling. Widening the hash instead would only make the collision rarer, and would spend eight
+        /// characters of a name budget that <see cref="OutputPathHelper.MaxOutputFilenameLength"/> already constrains.
+        /// </para>
+        /// </remarks>
         public string GetTransformedFilePath( string fileName, ulong hash )
         {
-            // It is essential that the file name here does NOT depend on the directory where the repo is checked out. If this happens, then the same project
-            // built on different machines, or checked out in different directories, may have the same source hash but a different `manifest.json` file.
-            // So, we hash the file according to its content, not according to its directory.
-
             var transformedFileName = fileName;
 
             if ( transformedFileName.Length > NameMaxLength )
@@ -32,16 +66,26 @@ internal sealed partial class CompileTimeCompilationBuilder
 
             unchecked
             {
-                fileNameWithHash = $"{transformedFileName}_{(uint) hash:x8}.cs";
+                fileNameWithHash = $"{transformedFileName}_{(uint) hash:x8}";
             }
 
-            if ( !this._generatedNames.Add( fileNameWithHash ) )
+            var candidate = fileNameWithHash + ".cs";
+
+            for ( var ordinal = 2; !this._generatedNames.Add( candidate ); ordinal++ )
             {
-                throw new InvalidOperationException(
-                    $"There cannot be two files in the compilation with the same filename '{transformedFileName}' and exactly the same code." );
+                if ( ordinal > 99 )
+                {
+                    // Unreachable in practice: it would take a hundred compile-time files of one name colliding on the
+                    // same thirty-two bits. Reported rather than silently truncated, because beyond this the ordinal no
+                    // longer fits the reserved budget and the name could exceed the maximum length.
+                    throw new InvalidOperationException(
+                        $"More than 99 compile-time files named '{transformedFileName}' have a content hash with the same lower 32 bits." );
+                }
+
+                candidate = $"{fileNameWithHash}_{ordinal}.cs";
             }
 
-            return fileNameWithHash;
+            return candidate;
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
@@ -1242,14 +1242,22 @@ internal sealed partial class CompileTimeCompilationBuilder
 
                         if ( diagnostics.Any() )
                         {
-                            // Distinct paths, because a compilation is not guaranteed to hold one syntax tree per path
-                            // and this index only has to give each path a number. See issue #1742.
-                            sourceFilePathIndexes = new Dictionary<string, int>( StringComparer.Ordinal );
+                            // The index assigned here is a persistent identifier: it is written to the compile-time
+                            // project manifest and read back by a later build to resolve the file a cached diagnostic
+                            // belongs to. Changing the order in which the indexes are handed out therefore makes an
+                            // existing manifest resolve an index to a different file, and the text span of one file is
+                            // then applied to another. The ordering must stay exactly as it was, which is why the
+                            // default comparer is kept here even though it is culture-sensitive.
+                            sourceFilePathIndexes = new Dictionary<string, int>();
 
+                            // Distinct, because a compilation is not guaranteed to hold one syntax tree per path and
+                            // this index only has to give each path a number. This does not disturb the order, and
+                            // therefore does not disturb the indexes, of a compilation that has no duplicate. See issue
+                            // #1742.
                             var distinctSourceFilePaths = sourceTreesWithCompileTimeCode
                                 .SelectAsArray( x => x.FilePath )
-                                .Distinct( StringComparer.Ordinal )
-                                .OrderBy( x => x, StringComparer.Ordinal );
+                                .Distinct()
+                                .OrderBy( x => x );
 
                             foreach ( var filePath in distinctSourceFilePaths )
                             {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CompileTimeCompilationBuilder.cs
@@ -1242,10 +1242,19 @@ internal sealed partial class CompileTimeCompilationBuilder
 
                         if ( diagnostics.Any() )
                         {
-                            sourceFilePathIndexes = sourceTreesWithCompileTimeCode
-                                .OrderBy( x => x.FilePath )
-                                .Select( ( tree, index ) => (tree.FilePath, index) )
-                                .ToDictionary( x => x.FilePath, x => x.index );
+                            // Distinct paths, because a compilation is not guaranteed to hold one syntax tree per path
+                            // and this index only has to give each path a number. See issue #1742.
+                            sourceFilePathIndexes = new Dictionary<string, int>( StringComparer.Ordinal );
+
+                            var distinctSourceFilePaths = sourceTreesWithCompileTimeCode
+                                .SelectAsArray( x => x.FilePath )
+                                .Distinct( StringComparer.Ordinal )
+                                .OrderBy( x => x, StringComparer.Ordinal );
+
+                            foreach ( var filePath in distinctSourceFilePaths )
+                            {
+                                sourceFilePathIndexes.Add( filePath, sourceFilePathIndexes.Count );
+                            }
                         }
 
                         var manifest = new CompileTimeProjectManifest(

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.TransformationCollection.cs
@@ -868,7 +868,7 @@ internal sealed partial class LinkerInjectionStep
             // In this case, there will be an attempt to add an existing syntax tree to the compilation. Here we work around this issue,
             // however the problem is upstream. Even if we solve the issue, it may be good to be tolerant of upstream bugs in this code.
 
-            if ( this._finalCompilationModel.RoslynCompilation.GetIndexedSyntaxTrees().ContainsKey( transformedSyntaxTree.FilePath ) )
+            if ( this._finalCompilationModel.RoslynCompilation.GetIndexedSyntaxTrees().ContainsKey( transformedSyntaxTree.GetDocumentKey() ) )
             {
                 return;
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Linking/LinkerInjectionStep.cs
@@ -82,7 +82,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
 
         ConcurrentDictionary<IFullRef<IMember>, AuxiliaryMemberTransformations> auxiliaryMemberTransformations = new( RefEqualityComparer<IMember>.Default );
 
-        var existingSyntaxTrees = input.FinalCompilationModel.PartialCompilation.SyntaxTrees;
+        var existingCompilation = input.FinalCompilationModel.PartialCompilation;
 
         void IndexTransformationsInSyntaxTree( IGrouping<SyntaxTree, ISyntaxTreeTransformation> transformationGroup )
         {
@@ -94,7 +94,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
             foreach ( var transformation in sortedTransformations )
             {
                 IndexIntroduceDeclarationTransformation(
-                    existingSyntaxTrees,
+                    existingCompilation,
                     transformation,
                     transformationCollection );
             }
@@ -288,7 +288,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
 
         var syntaxTreeForGlobalAttributes = input.FinalCompilationModel.PartialCompilation.SyntaxTreeForCompilationLevelAttributes;
 
-        if ( !input.FinalCompilationModel.PartialCompilation.SyntaxTrees.ContainsKey( syntaxTreeForGlobalAttributes.FilePath )
+        if ( !input.FinalCompilationModel.PartialCompilation.TryGetSyntaxTree( syntaxTreeForGlobalAttributes.GetDocumentKey(), out _ )
              && input.Transformations.OfType<IntroduceAttributeTransformation>().Any( t => t.TransformedSyntaxTree == syntaxTreeForGlobalAttributes ) )
         {
             transformationCollection.AddIntroducedSyntaxTree( syntaxTreeForGlobalAttributes );
@@ -361,7 +361,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
 
         await
             this._concurrentTaskRunner.RunConcurrentlyAsync(
-                compilationWithIntroducedTrees.SyntaxTrees.Values,
+                compilationWithIntroducedTrees.SyntaxTreeCollection,
                 RewriteSyntaxTreeAsync,
                 cancellationToken );
 
@@ -441,7 +441,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
     }
 
     private static void IndexIntroduceDeclarationTransformation(
-        ImmutableDictionary<string, SyntaxTree> existingSyntaxTrees,
+        PartialCompilation existingCompilation,
         ISyntaxTreeTransformation transformation,
         TransformationCollection transformationCollection )
     {
@@ -451,7 +451,7 @@ internal sealed partial class LinkerInjectionStep : AspectLinkerPipelineStep<Asp
                 introduceDeclarationTransformation.DeclarationBuilderData,
                 introduceDeclarationTransformation );
 
-            if ( !existingSyntaxTrees.ContainsKey( transformation.TransformedSyntaxTree.FilePath ) )
+            if ( !existingCompilation.TryGetSyntaxTree( transformation.TransformedSyntaxTree.GetDocumentKey(), out _ ) )
             {
                 transformationCollection.AddIntroducedSyntaxTree( transformation.TransformedSyntaxTree );
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompilePipelineStage.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/CompileTime/WpfPrecompilePipelineStage.cs
@@ -45,7 +45,7 @@ namespace Metalama.Framework.Engine.Pipeline.CompileTime
 
             // Generated trees default to C# 1 parse options; copy the project's options so the new trees share the
             // same LangVersion, preprocessor symbols and nullable context as the original sources.
-            var projectParseOptions = input.LastCompilation.SyntaxTrees.Values.FirstOrDefault()?.Options;
+            var projectParseOptions = input.LastCompilation.SyntaxTreeCollection.FirstOrDefault()?.Options;
 
             var addTransformations = introducedSyntaxTrees.SelectAsArray(
                 t =>

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/TestDesignTimeAspectPipeline.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/DesignTime/TestDesignTimeAspectPipeline.cs
@@ -26,7 +26,7 @@ public sealed class TestDesignTimeAspectPipeline : BaseDesignTimeAspectPipeline
         var partialCompilation = PartialCompilation.CreateComplete( inputCompilation );
 
         // Run the validator, which is run in design-time and may crash on invalid code.
-        foreach ( var syntaxTree in partialCompilation.SyntaxTrees.Values )
+        foreach ( var syntaxTree in partialCompilation.SyntaxTreeCollection )
         {
             var semanticModel = partialCompilation.Compilation.GetSemanticModel( syntaxTree );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/CompilationExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/CompilationExtensions.cs
@@ -7,6 +7,7 @@ using Metalama.Framework.Engine.Utilities.Caching;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System;
+using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
@@ -16,13 +17,51 @@ namespace Metalama.Framework.Engine.Utilities.Roslyn;
 [PublicAPI]
 public static class CompilationExtensions
 {
-    private static readonly WeakCache<Compilation, ImmutableDictionary<string, SyntaxTree>> _indexedSyntaxTreesCache = new( isStaticCache: true );
+    private static readonly WeakCache<Compilation, SyntaxTreeIndex> _syntaxTreeIndexCache = new( isStaticCache: true );
 
-    public static ImmutableDictionary<string, SyntaxTree> GetIndexedSyntaxTrees( this Compilation compilation )
-        => _indexedSyntaxTreesCache.GetOrAdd( compilation, GetIndexedSyntaxTreesCore );
+    internal static SyntaxTreeIndex GetSyntaxTreeIndex( this Compilation compilation )
+        => _syntaxTreeIndexCache.GetOrAdd( compilation, SyntaxTreeIndex.Create );
 
-    private static ImmutableDictionary<string, SyntaxTree> GetIndexedSyntaxTreesCore( Compilation compilation )
-        => compilation.SyntaxTrees.ToImmutableDictionary( x => x.FilePath, x => x );
+    /// <summary>
+    /// Gets the syntax trees of a <see cref="Compilation"/> indexed by <see cref="SyntaxTree.FilePath"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// When two syntax trees share a path, the first one in the order of <see cref="Compilation.SyntaxTrees"/> is
+    /// indexed and the others are not. See <see cref="SyntaxTreeIndex"/> for why that condition is reachable and why it
+    /// is resolved rather than reported here. A caller that goes on to process the indexed trees must first remove the
+    /// others from the compilation, which <see cref="RemoveDuplicatePathSyntaxTrees"/> does.
+    /// </para>
+    /// <para>
+    /// The dictionary is read-only rather than immutable, because it is built once per compilation and never updated.
+    /// </para>
+    /// </remarks>
+    public static IReadOnlyDictionary<string, SyntaxTree> GetIndexedSyntaxTrees( this Compilation compilation )
+        => compilation.GetSyntaxTreeIndex().SyntaxTreesByPath;
+
+    /// <summary>
+    /// Gets the syntax trees of a <see cref="Compilation"/> that share their <see cref="SyntaxTree.FilePath"/> with an
+    /// earlier tree, and are therefore excluded from <see cref="GetIndexedSyntaxTrees"/>. Empty for every compilation
+    /// produced by the command-line compiler, which deduplicates source files itself.
+    /// </summary>
+    public static ImmutableArray<SyntaxTree> GetDuplicatePathSyntaxTrees( this Compilation compilation )
+        => compilation.GetSyntaxTreeIndex().DuplicatePathSyntaxTrees;
+
+    /// <summary>
+    /// Removes from a <see cref="Compilation"/> every syntax tree that shares its path with an earlier one, so that a
+    /// path identifies a syntax tree of the result. Returns the argument unchanged, without allocating, when no path is
+    /// duplicated, which is the ordinary case.
+    /// </summary>
+    /// <remarks>
+    /// This is the single point at which Metalama resolves the condition. Everything downstream may then assume that
+    /// the index of <see cref="GetIndexedSyntaxTrees"/> covers the compilation it describes.
+    /// </remarks>
+    public static Compilation RemoveDuplicatePathSyntaxTrees( this Compilation compilation )
+    {
+        var index = compilation.GetSyntaxTreeIndex();
+
+        return index.HasDuplicatePaths ? compilation.RemoveSyntaxTrees( index.DuplicatePathSyntaxTrees ) : compilation;
+    }
 
     internal static INamespaceSymbol? GetDescendant( this INamespaceSymbol parentNamespace, string ns )
     {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/CompilationExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/CompilationExtensions.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using JetBrains.Annotations;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Utilities.Caching;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -23,21 +24,22 @@ public static class CompilationExtensions
         => _syntaxTreeIndexCache.GetOrAdd( compilation, SyntaxTreeIndex.Create );
 
     /// <summary>
-    /// Gets the syntax trees of a <see cref="Compilation"/> indexed by <see cref="SyntaxTree.FilePath"/>.
+    /// Gets the syntax trees of a <see cref="Compilation"/> indexed by <see cref="DocumentKey"/>.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// When two syntax trees share a path, the first one in the order of <see cref="Compilation.SyntaxTrees"/> is
-    /// indexed and the others are not. See <see cref="SyntaxTreeIndex"/> for why that condition is reachable and why it
-    /// is resolved rather than reported here. A caller that goes on to process the indexed trees must first remove the
-    /// others from the compilation, which <see cref="RemoveDuplicatePathSyntaxTrees"/> does.
+    /// When two syntax trees represent one document, the first one in the order of
+    /// <see cref="Compilation.SyntaxTrees"/> is indexed and the others are not. See <see cref="SyntaxTreeIndex"/> for
+    /// why that condition is reachable and why it is resolved rather than reported here. A caller that goes on to
+    /// process the indexed trees must first remove the others from the compilation, which
+    /// <see cref="RemoveDuplicatePathSyntaxTrees"/> does.
     /// </para>
     /// <para>
     /// The dictionary is read-only rather than immutable, because it is built once per compilation and never updated.
     /// </para>
     /// </remarks>
-    public static IReadOnlyDictionary<string, SyntaxTree> GetIndexedSyntaxTrees( this Compilation compilation )
-        => compilation.GetSyntaxTreeIndex().SyntaxTreesByPath;
+    public static IReadOnlyDictionary<DocumentKey, SyntaxTree> GetIndexedSyntaxTrees( this Compilation compilation )
+        => compilation.GetSyntaxTreeIndex().SyntaxTreesByDocumentKey;
 
     /// <summary>
     /// Gets the syntax trees of a <see cref="Compilation"/> that share their <see cref="SyntaxTree.FilePath"/> with an

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxTreeIndex.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxTreeIndex.cs
@@ -2,16 +2,16 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Microsoft.CodeAnalysis;
-using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
 
 namespace Metalama.Framework.Engine.Utilities.Roslyn;
 
 /// <summary>
-/// Indexes the syntax trees of a <see cref="Compilation"/> by <see cref="SyntaxTree.FilePath"/> and records the trees
-/// that had to be excluded from the index because an earlier tree already held their path.
+/// Indexes the syntax trees of a <see cref="Compilation"/> by <see cref="DocumentKey"/> and records the trees that had
+/// to be excluded from the index because an earlier tree already represented their document.
 /// </summary>
 /// <remarks>
 /// <para>
@@ -29,65 +29,68 @@ namespace Metalama.Framework.Engine.Utilities.Roslyn;
 /// cross-process preview contract, so a second document at the same path would have no way of being asked for.
 /// </para>
 /// <para>
-/// The first tree of a path wins, in the order of <see cref="Compilation.SyntaxTrees"/>, which is deterministic for a
-/// given compilation. <see cref="DuplicatePathSyntaxTrees"/> holds the others so that the caller can remove them from
+/// The first tree of a document wins, in the order of <see cref="Compilation.SyntaxTrees"/>, which is deterministic for
+/// a given compilation. <see cref="DuplicatePathSyntaxTrees"/> holds the others so that the caller can remove them from
 /// the compilation as well: an index that excludes a tree the compilation still contains describes a compilation it
 /// does not match, and the pipeline would then leave that tree unrewritten while its declarations remain visible in the
 /// code model.
 /// </para>
-/// <para>
-/// Comparison is ordinal, matching <c>DocumentKey</c>. Case-insensitive comparison would match the command-line
-/// compiler on Windows and be wrong on Linux, where two paths differing in case are two files.
-/// </para>
 /// </remarks>
 internal sealed class SyntaxTreeIndex
 {
+    private readonly Dictionary<DocumentKey, SyntaxTree> _syntaxTreesByDocumentKey;
+
     /// <summary>
-    /// Gets the syntax trees of the compilation indexed by path, holding the first tree of each path.
+    /// Gets the syntax trees of the compilation indexed by <see cref="DocumentKey"/>, holding the first tree of each
+    /// document.
     /// </summary>
     /// <remarks>
+    /// <para>
+    /// Keyed by <see cref="DocumentKey"/> rather than by the path it wraps, so that a lookup made from a key reuses the
+    /// hash the key computed once, instead of hashing a long path string again on every call.
+    /// </para>
+    /// <para>
     /// A <see cref="Dictionary{TKey,TValue}"/> and not an <see cref="ImmutableDictionary{TKey,TValue}"/>. The index is
     /// built once per compilation and never updated, so the structural sharing an immutable dictionary provides buys
     /// nothing, while its cost is paid on every build and every lookup: an ordered tree walk instead of a hash lookup,
     /// and two allocations per entry instead of one array.
+    /// </para>
     /// </remarks>
-    public IReadOnlyDictionary<string, SyntaxTree> SyntaxTreesByPath => this._syntaxTreesByPath;
+    public IReadOnlyDictionary<DocumentKey, SyntaxTree> SyntaxTreesByDocumentKey => this._syntaxTreesByDocumentKey;
 
     /// <summary>
-    /// Gets the syntax trees of the compilation, one per path.
+    /// Gets the syntax trees of the compilation, one per document.
     /// </summary>
-    public IReadOnlyCollection<SyntaxTree> SyntaxTrees => this._syntaxTreesByPath.Values;
+    public IReadOnlyCollection<SyntaxTree> SyntaxTrees => this._syntaxTreesByDocumentKey.Values;
 
     /// <summary>
-    /// Gets the syntax trees that share a path with an earlier tree of the compilation, and are therefore absent from
-    /// <see cref="SyntaxTreesByPath"/>.
+    /// Gets the syntax trees that represent a document an earlier tree of the compilation already represents, and are
+    /// therefore absent from <see cref="SyntaxTreesByDocumentKey"/>.
     /// </summary>
     public ImmutableArray<SyntaxTree> DuplicatePathSyntaxTrees { get; }
 
     public bool HasDuplicatePaths => !this.DuplicatePathSyntaxTrees.IsEmpty;
 
-    private readonly Dictionary<string, SyntaxTree> _syntaxTreesByPath;
-
-    private SyntaxTreeIndex( Dictionary<string, SyntaxTree> syntaxTreesByPath, ImmutableArray<SyntaxTree> duplicatePathSyntaxTrees )
+    private SyntaxTreeIndex( Dictionary<DocumentKey, SyntaxTree> syntaxTreesByDocumentKey, ImmutableArray<SyntaxTree> duplicatePathSyntaxTrees )
     {
-        this._syntaxTreesByPath = syntaxTreesByPath;
+        this._syntaxTreesByDocumentKey = syntaxTreesByDocumentKey;
         this.DuplicatePathSyntaxTrees = duplicatePathSyntaxTrees;
     }
 
     public static SyntaxTreeIndex Create( Compilation compilation )
     {
-        var syntaxTreesByPath = new Dictionary<string, SyntaxTree>( StringComparer.Ordinal );
+        var syntaxTreesByDocumentKey = new Dictionary<DocumentKey, SyntaxTree>();
         ImmutableArray<SyntaxTree>.Builder? duplicatesBuilder = null;
 
         foreach ( var syntaxTree in compilation.SyntaxTrees )
         {
-            if ( !syntaxTreesByPath.TryAdd( syntaxTree.FilePath, syntaxTree ) )
+            if ( !syntaxTreesByDocumentKey.TryAdd( syntaxTree.GetDocumentKey(), syntaxTree ) )
             {
                 duplicatesBuilder ??= ImmutableArray.CreateBuilder<SyntaxTree>();
                 duplicatesBuilder.Add( syntaxTree );
             }
         }
 
-        return new SyntaxTreeIndex( syntaxTreesByPath, duplicatesBuilder?.ToImmutable() ?? ImmutableArray<SyntaxTree>.Empty );
+        return new SyntaxTreeIndex( syntaxTreesByDocumentKey, duplicatesBuilder?.ToImmutable() ?? ImmutableArray<SyntaxTree>.Empty );
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxTreeIndex.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/Roslyn/SyntaxTreeIndex.cs
@@ -1,0 +1,93 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Metalama.Framework.Engine.Utilities.Roslyn;
+
+/// <summary>
+/// Indexes the syntax trees of a <see cref="Compilation"/> by <see cref="SyntaxTree.FilePath"/> and records the trees
+/// that had to be excluded from the index because an earlier tree already held their path.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Roslyn does not guarantee that a path identifies a syntax tree. The command-line compiler deduplicates source files
+/// itself, reporting <c>CS2002</c>, so a compilation built by <c>csc</c> never contains two trees with one path. A
+/// compilation built by Roslyn Workspaces can, because the project system creates one document per <c>Compile</c> item
+/// and does not deduplicate: overlapping globs, an explicit item that repeats a glob, <c>Link</c> metadata pointing two
+/// items at one file, or a shared project all produce the condition, out of a project that is otherwise valid. See
+/// issue #1742.
+/// </para>
+/// <para>
+/// Metalama treats such a pair as one document included twice rather than as two documents, which is the conclusion
+/// the command-line compiler reaches. The alternative cannot be represented: every design-time consumer addresses a
+/// document by its path, from the Roslyn analyzer callback that carries only a <see cref="SemanticModel"/> to the
+/// cross-process preview contract, so a second document at the same path would have no way of being asked for.
+/// </para>
+/// <para>
+/// The first tree of a path wins, in the order of <see cref="Compilation.SyntaxTrees"/>, which is deterministic for a
+/// given compilation. <see cref="DuplicatePathSyntaxTrees"/> holds the others so that the caller can remove them from
+/// the compilation as well: an index that excludes a tree the compilation still contains describes a compilation it
+/// does not match, and the pipeline would then leave that tree unrewritten while its declarations remain visible in the
+/// code model.
+/// </para>
+/// <para>
+/// Comparison is ordinal, matching <c>DocumentKey</c>. Case-insensitive comparison would match the command-line
+/// compiler on Windows and be wrong on Linux, where two paths differing in case are two files.
+/// </para>
+/// </remarks>
+internal sealed class SyntaxTreeIndex
+{
+    /// <summary>
+    /// Gets the syntax trees of the compilation indexed by path, holding the first tree of each path.
+    /// </summary>
+    /// <remarks>
+    /// A <see cref="Dictionary{TKey,TValue}"/> and not an <see cref="ImmutableDictionary{TKey,TValue}"/>. The index is
+    /// built once per compilation and never updated, so the structural sharing an immutable dictionary provides buys
+    /// nothing, while its cost is paid on every build and every lookup: an ordered tree walk instead of a hash lookup,
+    /// and two allocations per entry instead of one array.
+    /// </remarks>
+    public IReadOnlyDictionary<string, SyntaxTree> SyntaxTreesByPath => this._syntaxTreesByPath;
+
+    /// <summary>
+    /// Gets the syntax trees of the compilation, one per path.
+    /// </summary>
+    public IReadOnlyCollection<SyntaxTree> SyntaxTrees => this._syntaxTreesByPath.Values;
+
+    /// <summary>
+    /// Gets the syntax trees that share a path with an earlier tree of the compilation, and are therefore absent from
+    /// <see cref="SyntaxTreesByPath"/>.
+    /// </summary>
+    public ImmutableArray<SyntaxTree> DuplicatePathSyntaxTrees { get; }
+
+    public bool HasDuplicatePaths => !this.DuplicatePathSyntaxTrees.IsEmpty;
+
+    private readonly Dictionary<string, SyntaxTree> _syntaxTreesByPath;
+
+    private SyntaxTreeIndex( Dictionary<string, SyntaxTree> syntaxTreesByPath, ImmutableArray<SyntaxTree> duplicatePathSyntaxTrees )
+    {
+        this._syntaxTreesByPath = syntaxTreesByPath;
+        this.DuplicatePathSyntaxTrees = duplicatePathSyntaxTrees;
+    }
+
+    public static SyntaxTreeIndex Create( Compilation compilation )
+    {
+        var syntaxTreesByPath = new Dictionary<string, SyntaxTree>( StringComparer.Ordinal );
+        ImmutableArray<SyntaxTree>.Builder? duplicatesBuilder = null;
+
+        foreach ( var syntaxTree in compilation.SyntaxTrees )
+        {
+            if ( !syntaxTreesByPath.TryAdd( syntaxTree.FilePath, syntaxTree ) )
+            {
+                duplicatesBuilder ??= ImmutableArray.CreateBuilder<SyntaxTree>();
+                duplicatesBuilder.Add( syntaxTree );
+            }
+        }
+
+        return new SyntaxTreeIndex( syntaxTreesByPath, duplicatesBuilder?.ToImmutable() ?? ImmutableArray<SyntaxTree>.Empty );
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
@@ -56,12 +56,14 @@ public readonly struct DocumentKey : IEquatable<DocumentKey>, IComparable<Docume
     public string Path => this._path ?? "";
 
     /// <summary>
-    /// Gets a value indicating whether this key is the default value, which identifies no document.
+    /// Gets a value indicating whether this key is the default value, which identifies no document. This is the key
+    /// under which a design-time cache files what belongs to the compilation rather than to any document.
     /// </summary>
     /// <remarks>
-    /// Distinct from a key over the empty path. <c>SplitResultsByTree</c> files results that belong to the compilation
-    /// rather than to a document under the empty path, so the empty path is a legitimate key with a defined meaning
-    /// and must not be confused with the absence of a key.
+    /// The default key cannot collide with a document, which is the reason it, rather than a key over the empty path,
+    /// marks the absence of one. It wraps a null path, and no key of a document can: <see cref="FromPath"/> rejects
+    /// null and <see cref="FromSyntaxTree"/> reads <see cref="SyntaxTree.FilePath"/>, which Roslyn never returns as
+    /// null. The empty path carries no such guarantee, because a syntax tree may have one.
     /// </remarks>
     public bool IsDefault => this._path == null;
 
@@ -86,11 +88,6 @@ public readonly struct DocumentKey : IEquatable<DocumentKey>, IComparable<Docume
     /// Gets the key of the document a <see cref="SyntaxTree"/> belongs to.
     /// </summary>
     public static DocumentKey FromSyntaxTree( SyntaxTree syntaxTree ) => new( syntaxTree.FilePath );
-
-    /// <summary>
-    /// Gets the key under which results that belong to the compilation rather than to any document are filed.
-    /// </summary>
-    public static DocumentKey Compilation { get; } = new( "" );
 
     public bool Equals( DocumentKey other )
         => this._hashCode == other._hashCode && string.Equals( this._path, other._path, StringComparison.Ordinal );

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
@@ -4,6 +4,7 @@
 
 using Microsoft.CodeAnalysis;
 using System;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.CodeModel;
 
@@ -123,6 +124,21 @@ public static class DocumentKeyExtensions
     /// Gets the key of the document a <see cref="SyntaxTree"/> belongs to.
     /// </summary>
     public static DocumentKey GetDocumentKey( this SyntaxTree syntaxTree ) => DocumentKey.FromSyntaxTree( syntaxTree );
+
+    /// <summary>
+    /// Gets the syntax tree of an <see cref="IPartialCompilation"/> that represents the document at a given path.
+    /// </summary>
+    /// <remarks>
+    /// The <see cref="string"/> counterpart of
+    /// <see cref="IPartialCompilation.TryGetSyntaxTree(DocumentKey,out SyntaxTree)"/>, for the boundaries at which a
+    /// path arrives as a <see cref="string"/> and nothing else is available: the Roslyn analyzer callbacks and the
+    /// cross-process contracts. Everything inside those boundaries holds a <see cref="DocumentKey"/> already.
+    /// </remarks>
+    public static bool TryGetSyntaxTreeByPath(
+        this IPartialCompilation compilation,
+        string path,
+        [NotNullWhen( true )] out SyntaxTree? syntaxTree )
+        => compilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out syntaxTree );
 
     /// <summary>
     /// Gets the key of the document a <see cref="Location"/> points into, or <see langword="false"/> when the location

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
@@ -139,24 +139,4 @@ public static class DocumentKeyExtensions
         string path,
         [NotNullWhen( true )] out SyntaxTree? syntaxTree )
         => compilation.TryGetSyntaxTree( DocumentKey.FromPath( path ), out syntaxTree );
-
-    /// <summary>
-    /// Gets the key of the document a <see cref="Location"/> points into, or <see langword="false"/> when the location
-    /// is not in a document.
-    /// </summary>
-    public static bool TryGetDocumentKey( this Location location, out DocumentKey documentKey )
-    {
-        var path = location.GetLineSpan().Path;
-
-        if ( path == null )
-        {
-            documentKey = default;
-
-            return false;
-        }
-
-        documentKey = DocumentKey.FromPath( path );
-
-        return true;
-    }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/DocumentKey.cs
@@ -1,0 +1,146 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Microsoft.CodeAnalysis;
+using System;
+
+namespace Metalama.Framework.Engine.CodeModel;
+
+/// <summary>
+/// Identifies a document of a project across the compilations of that project. This is the key of every design-time
+/// cache that has to survive an edit.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A <see cref="SyntaxTree"/> is a transient artifact: the IDE produces a new <see cref="Compilation"/> holding new
+/// trees on every keystroke, so reference identity distinguishes trees only <em>within</em> one compilation and cannot
+/// key a cache that outlives it. The permanent identity of a document is therefore needed, and
+/// <see cref="SyntaxTree.FilePath"/> is the only candidate reachable where it is needed: a Roslyn analyzer callback
+/// carries a <see cref="SemanticModel"/> and nothing else, the cross-process contract passes a path, and
+/// <c>WorkspaceProvider</c> returns no workspace at all in a supported host, so no <c>DocumentId</c> is available. See
+/// issue #1742.
+/// </para>
+/// <para>
+/// This type exists because a bare <see cref="string"/> made two mistakes easy. It let the comparer be chosen per
+/// dictionary, which is how the design-time indexes came to compare paths ordinally while the command-line compiler
+/// deduplicates them with <see cref="StringComparer.OrdinalIgnoreCase"/>. And it let one key space be confused with
+/// another, because a document path, an introduced syntax tree name and a source generator hint name are all strings;
+/// the duplicate-introduction assertion of <c>DesignTimeAspectPipelineResult</c> was exactly such a confusion. Keeping
+/// document paths in a distinct type makes both a compile error.
+/// </para>
+/// <para>
+/// The comparison is ordinal. Case-insensitive comparison would match the command-line compiler on Windows and be
+/// wrong on Linux, where two paths differing in case are two files.
+/// </para>
+/// <para>
+/// The hash code is computed once, on construction. These keys are long strings compared and hashed on every lookup of
+/// the design-time hot path, so caching the hash is why this type is not slower than the string it replaces.
+/// </para>
+/// <para>
+/// A key is a value, not a reference into a compilation. It does not guarantee that the document exists in any given
+/// compilation, and it deliberately does not carry the <see cref="SyntaxTree"/>: a cache entry that held one would
+/// root the syntax tree of an earlier compilation.
+/// </para>
+/// </remarks>
+public readonly struct DocumentKey : IEquatable<DocumentKey>, IComparable<DocumentKey>
+{
+    private readonly string? _path;
+    private readonly int _hashCode;
+
+    /// <summary>
+    /// Gets the path of the document, which is the <see cref="SyntaxTree.FilePath"/> of every syntax tree that
+    /// represents it.
+    /// </summary>
+    public string Path => this._path ?? "";
+
+    /// <summary>
+    /// Gets a value indicating whether this key is the default value, which identifies no document.
+    /// </summary>
+    /// <remarks>
+    /// Distinct from a key over the empty path. <c>SplitResultsByTree</c> files results that belong to the compilation
+    /// rather than to a document under the empty path, so the empty path is a legitimate key with a defined meaning
+    /// and must not be confused with the absence of a key.
+    /// </remarks>
+    public bool IsDefault => this._path == null;
+
+    /// <remarks>
+    /// Private, so that every key is created through a named factory. Which key space a string belongs to is the
+    /// distinction this type exists to make, and a public constructor over <see cref="string"/> would let a name of
+    /// another space be turned into a document key by an implicit conversion of intent.
+    /// </remarks>
+    private DocumentKey( string path )
+    {
+        this._path = path;
+        this._hashCode = StringComparer.Ordinal.GetHashCode( path );
+    }
+
+    /// <summary>
+    /// Gets the key of the document at a given path.
+    /// </summary>
+    public static DocumentKey FromPath( string path )
+        => new( path ?? throw new ArgumentNullException( nameof(path) ) );
+
+    /// <summary>
+    /// Gets the key of the document a <see cref="SyntaxTree"/> belongs to.
+    /// </summary>
+    public static DocumentKey FromSyntaxTree( SyntaxTree syntaxTree ) => new( syntaxTree.FilePath );
+
+    /// <summary>
+    /// Gets the key under which results that belong to the compilation rather than to any document are filed.
+    /// </summary>
+    public static DocumentKey Compilation { get; } = new( "" );
+
+    public bool Equals( DocumentKey other )
+        => this._hashCode == other._hashCode && string.Equals( this._path, other._path, StringComparison.Ordinal );
+
+    public override bool Equals( object? obj ) => obj is DocumentKey other && this.Equals( other );
+
+    /// <summary>
+    /// Compares two keys by path, ordinally.
+    /// </summary>
+    /// <remarks>
+    /// Ordering exists so that anything enumerating a key-indexed collection can produce a stable sequence: test
+    /// baselines, trace output and the manifest indexes all depend on an order that does not vary between runs.
+    /// </remarks>
+    public int CompareTo( DocumentKey other ) => string.CompareOrdinal( this._path, other._path );
+
+    public override int GetHashCode() => this._hashCode;
+
+    public static bool operator ==( DocumentKey left, DocumentKey right ) => left.Equals( right );
+
+    public static bool operator !=( DocumentKey left, DocumentKey right ) => !left.Equals( right );
+
+    public override string ToString() => this._path ?? "(none)";
+}
+
+/// <summary>
+/// Extension methods to obtain a <see cref="DocumentKey"/>.
+/// </summary>
+public static class DocumentKeyExtensions
+{
+    /// <summary>
+    /// Gets the key of the document a <see cref="SyntaxTree"/> belongs to.
+    /// </summary>
+    public static DocumentKey GetDocumentKey( this SyntaxTree syntaxTree ) => DocumentKey.FromSyntaxTree( syntaxTree );
+
+    /// <summary>
+    /// Gets the key of the document a <see cref="Location"/> points into, or <see langword="false"/> when the location
+    /// is not in a document.
+    /// </summary>
+    public static bool TryGetDocumentKey( this Location location, out DocumentKey documentKey )
+    {
+        var path = location.GetLineSpan().Path;
+
+        if ( path == null )
+        {
+            documentKey = default;
+
+            return false;
+        }
+
+        documentKey = DocumentKey.FromPath( path );
+
+        return true;
+    }
+}

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/IPartialCompilation.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/IPartialCompilation.cs
@@ -4,9 +4,12 @@
 
 using JetBrains.Annotations;
 using Metalama.Compiler;
+using Metalama.Framework.Utilities;
 using Microsoft.CodeAnalysis;
+using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Diagnostics.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.CodeModel;
 
@@ -39,6 +42,7 @@ namespace Metalama.Framework.Engine.CodeModel;
 /// <seealso cref="Metalama.Framework.Engine.AspectWeavers.AspectWeaverContext"/>
 /// <seealso href="@aspect-weavers"/>
 [PublicAPI]
+[InternalImplement]
 public interface IPartialCompilation
 {
     /// <summary>
@@ -49,7 +53,29 @@ public interface IPartialCompilation
     /// <summary>
     /// Gets the syntax trees in the current subset, keyed by file path.
     /// </summary>
+    [Obsolete( "Use SyntaxTreeCollection to enumerate the syntax trees, or TryGetSyntaxTree to find one by its DocumentKey." )]
     ImmutableDictionary<string, SyntaxTree> SyntaxTrees { get; }
+
+    /// <summary>
+    /// Gets the syntax trees in the current subset.
+    /// </summary>
+    /// <remarks>
+    /// Replaces <see cref="SyntaxTrees"/> for the majority of uses, which enumerate the trees and never read the path
+    /// that keyed them. The collection is identified by the trees themselves, so it costs no string hashing, and it is
+    /// not an <see cref="ImmutableDictionary{TKey,TValue}"/>, which is only useful to a caller building a modified copy.
+    /// </remarks>
+    IReadOnlyCollection<SyntaxTree> SyntaxTreeCollection { get; }
+
+    /// <summary>
+    /// Gets the syntax tree of the current subset that represents a given document, and returns
+    /// <see langword="false"/> if there is none.
+    /// </summary>
+    /// <remarks>
+    /// At most one syntax tree of an <see cref="IPartialCompilation"/> represents a document. Roslyn does not guarantee
+    /// that of a <see cref="Microsoft.CodeAnalysis.Compilation"/>, so Metalama establishes it: a tree whose path an
+    /// earlier tree already holds is removed from the compilation before the subset is built. See issue #1742.
+    /// </remarks>
+    bool TryGetSyntaxTree( DocumentKey documentKey, [NotNullWhen( true )] out SyntaxTree? syntaxTree );
 
     /// <summary>
     /// Gets a value indicating whether this <see cref="IPartialCompilation"/> represents a subset of the full compilation,

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/PartialCompilationExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/CodeModel/PartialCompilationExtensions.cs
@@ -53,7 +53,7 @@ namespace Metalama.Framework.Engine.CodeModel
             Func<SyntaxTree, CancellationToken, SyntaxTree> updateTree,
             CancellationToken cancellationToken = default )
             => compilation.WithSyntaxTreeTransformations(
-                compilation.SyntaxTrees.Values.Select( t => SyntaxTreeTransformation.ReplaceTree( t, updateTree( t, cancellationToken ) ) )
+                compilation.SyntaxTreeCollection.Select( t => SyntaxTreeTransformation.ReplaceTree( t, updateTree( t, cancellationToken ) ) )
                     .Where( t => t.NewTree != t.OldTree )
                     .ToList() );
 
@@ -70,7 +70,7 @@ namespace Metalama.Framework.Engine.CodeModel
             Func<SyntaxNode, CancellationToken, SyntaxNode> updateSyntaxRoot,
             CancellationToken cancellationToken = default )
             => compilation.WithSyntaxTreeTransformations(
-                compilation.SyntaxTrees.Values.Select( t => (OldTree: t, NewRoot: updateSyntaxRoot( t.GetRoot( cancellationToken ), cancellationToken )) )
+                compilation.SyntaxTreeCollection.Select( t => (OldTree: t, NewRoot: updateSyntaxRoot( t.GetRoot( cancellationToken ), cancellationToken )) )
                     .Where( x => x.OldTree.GetRoot( cancellationToken ) != x.NewRoot )
                     .Select(
                         x => SyntaxTreeTransformation.ReplaceTree(
@@ -83,9 +83,9 @@ namespace Metalama.Framework.Engine.CodeModel
             Func<SyntaxTree, SyntaxTree> updateTree,
             CancellationToken cancellationToken = default )
         {
-            var modifiedSyntaxTrees = new List<SyntaxTreeTransformation>( compilation.SyntaxTrees.Count );
+            var modifiedSyntaxTrees = new List<SyntaxTreeTransformation>( compilation.SyntaxTreeCollection.Count );
 
-            foreach ( var tree in compilation.SyntaxTrees.Values )
+            foreach ( var tree in compilation.SyntaxTreeCollection )
             {
                 var newTree = updateTree( tree );
 
@@ -116,19 +116,18 @@ namespace Metalama.Framework.Engine.CodeModel
             var taskScheduler = serviceProvider.GetRequiredService<IConcurrentTaskRunner>();
             var modifiedSyntaxTrees = new ConcurrentQueue<SyntaxTreeTransformation>();
 
-            await taskScheduler.RunConcurrentlyAsync( compilation.SyntaxTrees, RewriteSyntaxTreeAsync, cancellationToken );
+            await taskScheduler.RunConcurrentlyAsync( compilation.SyntaxTreeCollection, RewriteSyntaxTreeAsync, cancellationToken );
 
-            async Task RewriteSyntaxTreeAsync( KeyValuePair<string, SyntaxTree> tree )
+            async Task RewriteSyntaxTreeAsync( SyntaxTree tree )
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var oldRoot = await tree.Value.GetRootAsync( cancellationToken );
+                var oldRoot = await tree.GetRootAsync( cancellationToken );
                 var newRoot = rewriterFactory( oldRoot ).Visit( oldRoot );
 
                 if ( newRoot != oldRoot )
                 {
-                    modifiedSyntaxTrees.Enqueue(
-                        SyntaxTreeTransformation.ReplaceTree( tree.Value, tree.Value.WithRootAndOptions( newRoot, tree.Value.Options ) ) );
+                    modifiedSyntaxTrees.Enqueue( SyntaxTreeTransformation.ReplaceTree( tree, tree.WithRootAndOptions( newRoot, tree.Options ) ) );
                 }
             }
 
@@ -146,7 +145,7 @@ namespace Metalama.Framework.Engine.CodeModel
         /// </summary>
         public static ParseOptions GetParseOptions( this IPartialCompilation compilation )
         {
-            var firstTree = compilation.SyntaxTrees.Values.FirstOrDefault();
+            var firstTree = compilation.SyntaxTreeCollection.FirstOrDefault();
 
             if ( firstTree == null )
             {

--- a/Metalama.Framework/src/Metalama.Testing.AspectTesting/LiveTemplateTestRunner.cs
+++ b/Metalama.Framework/src/Metalama.Testing.AspectTesting/LiveTemplateTestRunner.cs
@@ -50,7 +50,7 @@ namespace Metalama.Testing.AspectTesting
 
             var targets = new List<(ISymbol Target, INamedTypeSymbol AspectType)>();
 
-            foreach ( var syntaxTree in partialCompilation.SyntaxTrees.Values )
+            foreach ( var syntaxTree in partialCompilation.SyntaxTreeCollection )
             {
                 var semanticModel = partialCompilation.Compilation.GetCachedSemanticModel( syntaxTree );
                 new TargetAttributeWalker( semanticModel, targets.Add ).Visit( await syntaxTree.GetRootAsync() );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/Mocks/TestProjectVersion.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/Mocks/TestProjectVersion.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.DesignTime;
 using Metalama.Framework.DesignTime.Pipeline;
 using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -16,11 +17,11 @@ namespace Metalama.Framework.Tests.UnitTestHelpers.Mocks;
 
 public sealed class TestProjectVersion : IProjectVersion
 {
-    private readonly Dictionary<string, ulong> _hashes;
+    private readonly Dictionary<DocumentKey, ulong> _hashes;
 
     public TestProjectVersion(
         string assemblyName,
-        Dictionary<string, ulong>? hashes = null,
+        Dictionary<DocumentKey, ulong>? hashes = null,
         IProjectVersion[]? referencedCompilations = null ) : this(
         ProjectKeyFactory.CreateTest( assemblyName ),
         hashes,
@@ -28,15 +29,15 @@ public sealed class TestProjectVersion : IProjectVersion
 
     public TestProjectVersion(
         ProjectKey assemblyIdentity,
-        Dictionary<string, ulong>? hashes = null,
+        Dictionary<DocumentKey, ulong>? hashes = null,
         IProjectVersion[]? referencedCompilations = null )
     {
-        this._hashes = hashes ?? new Dictionary<string, ulong>();
+        this._hashes = hashes ?? new Dictionary<DocumentKey, ulong>();
         this.ProjectKey = assemblyIdentity;
 
         this.Compilation = CSharpCompilation.Create(
             assemblyIdentity.AssemblyName,
-            hashes?.SelectAsArray( p => CSharpSyntaxTree.ParseText( "", path: p.Key, options: SupportedCSharpVersions.DefaultParseOptions ) ) );
+            hashes?.SelectAsArray( p => CSharpSyntaxTree.ParseText( "", path: p.Key.Path, options: SupportedCSharpVersions.DefaultParseOptions ) ) );
 
         this.ReferencedProjectVersions = referencedCompilations?.ToImmutableDictionary( c => c.ProjectKey, c => c )
                                          ?? ImmutableDictionary<ProjectKey, IProjectVersion>.Empty;
@@ -54,16 +55,21 @@ public sealed class TestProjectVersion : IProjectVersion
             .GroupBy( r => r.Compilation.GetProjectKey() )
             .ToImmutableDictionary( g => g.Key, g => (IProjectVersion) new TestProjectVersion( g.First().Compilation ) );
 
+        // Grouped by path, keeping the first, because a compilation can hold two syntax trees with one path and
+        // ToDictionary would throw on the duplicate. This mirrors what ProjectVersion.Create does in the product
+        // (issue #1742).
 #pragma warning disable CA1307
-        this._hashes = compilation.SyntaxTrees.ToDictionary( t => t.FilePath, t => (ulong) t.GetRoot().ToFullString().GetHashCode() );
+        this._hashes = compilation.SyntaxTrees
+            .GroupBy( t => t.GetDocumentKey() )
+            .ToDictionary( g => g.Key, g => (ulong) g.First().GetRoot().ToFullString().GetHashCode() );
 #pragma warning restore CA1307
     }
 
     public ProjectKey ProjectKey { get; }
 
-    public bool TryGetSyntaxTreeVersion( string path, out SyntaxTreeVersion syntaxTreeVersion )
+    public bool TryGetSyntaxTreeVersion( DocumentKey documentKey, out SyntaxTreeVersion syntaxTreeVersion )
     {
-        if ( this._hashes.TryGetValue( path, out var hash ) )
+        if ( this._hashes.TryGetValue( documentKey, out var hash ) )
         {
             syntaxTreeVersion = new SyntaxTreeVersion( null!, false, hash );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/DesignTimePipelineTestsBase.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/DesignTimePipelineTestsBase.cs
@@ -73,7 +73,11 @@ public abstract class DesignTimePipelineTestsBase : UnitTestClass
 
             i++;
 
-            var syntaxTree = syntaxTreeResult.SyntaxTreePath != null ? results.ProjectVersion.SyntaxTrees[syntaxTreeResult.SyntaxTreePath].SyntaxTree : null;
+            // Probed rather than indexed, because a result can be filed under DocumentKey.Compilation, which identifies
+            // no document and is therefore absent from the version index.
+            var syntaxTree = results.ProjectVersion.SyntaxTrees.TryGetValue( syntaxTreeResult.SyntaxTreePath, out var syntaxTreeVersion )
+                ? syntaxTreeVersion.SyntaxTree
+                : null;
 
             DumpSyntaxTreeResult( syntaxTree, syntaxTreeResult, stringBuilder );
         }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/DesignTimePipelineTestsBase.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTestHelpers/TestClasses/DesignTimePipelineTestsBase.cs
@@ -73,7 +73,7 @@ public abstract class DesignTimePipelineTestsBase : UnitTestClass
 
             i++;
 
-            // Probed rather than indexed, because a result can be filed under DocumentKey.Compilation, which identifies
+            // Probed rather than indexed, because a result can be filed under the default DocumentKey, which identifies
             // no document and is therefore absent from the version index.
             var syntaxTree = results.ProjectVersion.SyntaxTrees.TryGetValue( syntaxTreeResult.SyntaxTreePath, out var syntaxTreeVersion )
                 ? syntaxTreeVersion.SyntaxTree

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/FormatSensitiveTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/FormatSensitiveTests.cs
@@ -63,7 +63,7 @@ public class TestClass
 
         var result = await CompileAsync( testContext, code );
 
-        var transformedProperty = result.Value.ResultingCompilation.SyntaxTrees.SelectAsReadOnlyCollection( x => x.Value.GetRoot() )
+        var transformedProperty = result.Value.ResultingCompilation.SyntaxTreeCollection.SelectAsReadOnlyCollection( x => x.GetRoot() )
             .SelectMany( x => x.DescendantNodes() )
             .Single( x => x is PropertyDeclarationSyntax { Identifier.Text: "Prop132" } )
             .NormalizeWhitespace()

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/XmlDocTriviaTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Aspects/XmlDocTriviaTests.cs
@@ -81,7 +81,7 @@ public class TestClass
 
         Assert.Empty( emitResult.Diagnostics.Where( d => d.Id is not "CS0067" and not "CS8019" ) );
 
-        var transformedProperty = result.Value.ResultingCompilation.SyntaxTrees.SelectAsReadOnlyCollection( x => x.Value.GetRoot() )
+        var transformedProperty = result.Value.ResultingCompilation.SyntaxTreeCollection.SelectAsReadOnlyCollection( x => x.GetRoot() )
             .SelectMany( x => x.DescendantNodes() )
             .Single( x => x is TypeDeclarationSyntax { Identifier.Text: "TestClass" } )
             .NormalizeWhitespace()

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/TransformedPathGeneratorTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CompileTime/TransformedPathGeneratorTests.cs
@@ -1,0 +1,123 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CompileTime;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.CompileTime;
+
+/// <summary>
+/// Tests the uniqueness contract of <see cref="CompileTimeCompilationBuilder.TransformedPathGenerator"/>, one of the
+/// sites of issue https://github.com/metalama/Metalama/issues/1742.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This site is the odd one of the family. It does not key on the file path at all: it keys on the file name without
+/// its directory, combined with the <em>low thirty-two bits</em> of the content hash. Two consequences follow. It is
+/// reachable at compile time, unlike the other sites, because the command-line compiler deduplicates source paths but
+/// says nothing about file names. And its message, which asserts that the two files have "exactly the same code", is
+/// wrong in the case that reaches production: two files of the same name whose contents differ but whose truncated
+/// hashes collide.
+/// </para>
+/// <para>
+/// The transformed name must remain independent of the directory in which the repository is checked out, so that one
+/// project produces one source hash on every machine, and it is bounded by
+/// <see cref="OutputPathHelper.MaxOutputFilenameLength"/>. A resolution therefore has to be deterministic and short.
+/// The caller orders its input by name and then by hash before calling, so a collision ordinal derived from the call
+/// order satisfies both.
+/// </para>
+/// </remarks>
+public sealed class TransformedPathGeneratorTests
+{
+    /// <summary>
+    /// Two compile-time files of the same name whose contents differ, but whose hashes agree in their low thirty-two
+    /// bits. The generator sees one collision and throws, claiming the two files hold identical code.
+    /// </summary>
+    [Fact]
+    public void TruncatedHashCollisionOnSameFileName()
+    {
+        var generator = new CompileTimeCompilationBuilder.TransformedPathGenerator();
+
+        // Distinct 64-bit hashes, hence distinct file contents, agreeing on the 32 bits that reach the name.
+        const ulong firstHash = 0x1111_1111_ABCD_EF01;
+        const ulong secondHash = 0x2222_2222_ABCD_EF01;
+
+        var firstPath = generator.GetTransformedFilePath( "Fabric", firstHash );
+        var secondPath = generator.GetTransformedFilePath( "Fabric", secondHash );
+
+        Assert.NotEqual( firstPath, secondPath );
+    }
+
+    /// <summary>
+    /// Two compile-time files of the same name and identical content, the case the current message describes. It is
+    /// the rarer of the two, because identical content in two files usually means duplicate type declarations, but the
+    /// generator must not fail the whole project over it either.
+    /// </summary>
+    [Fact]
+    public void SameFileNameAndSameContent()
+    {
+        var generator = new CompileTimeCompilationBuilder.TransformedPathGenerator();
+
+        const ulong hash = 0x0123_4567_89AB_CDEF;
+
+        var firstPath = generator.GetTransformedFilePath( "Fabric", hash );
+        var secondPath = generator.GetTransformedFilePath( "Fabric", hash );
+
+        Assert.NotEqual( firstPath, secondPath );
+    }
+
+    /// <summary>
+    /// The resolution of a collision must be a function of the call order alone, because the caller derives that order
+    /// from the file name and the content hash and never from the directory. Two generators fed the same sequence must
+    /// therefore produce the same names, on any machine and from any checkout directory.
+    /// </summary>
+    [Fact]
+    public void CollisionResolutionIsDeterministic()
+    {
+        static IReadOnlyList<string> Generate()
+        {
+            var generator = new CompileTimeCompilationBuilder.TransformedPathGenerator();
+
+            return new[]
+            {
+                generator.GetTransformedFilePath( "Fabric", 0x1111_1111_ABCD_EF01 ),
+                generator.GetTransformedFilePath( "Fabric", 0x2222_2222_ABCD_EF01 ),
+                generator.GetTransformedFilePath( "Fabric", 0x3333_3333_ABCD_EF01 )
+            };
+        }
+
+        Assert.Equal( Generate(), Generate() );
+    }
+
+    /// <summary>
+    /// The control case: names that do not collide must keep the shape they have today, because the transformed path
+    /// participates in the compile-time project hash and any change to it invalidates every cached compile-time
+    /// project.
+    /// </summary>
+    [Fact]
+    public void DistinctNamesAreUnaffected()
+    {
+        var generator = new CompileTimeCompilationBuilder.TransformedPathGenerator();
+
+        Assert.Equal( "Aspect_abcdef01.cs", generator.GetTransformedFilePath( "Aspect", 0x1111_1111_ABCD_EF01 ) );
+        Assert.Equal( "Fabric_abcdef01.cs", generator.GetTransformedFilePath( "Fabric", 0x1111_1111_ABCD_EF01 ) );
+    }
+
+    /// <summary>
+    /// Documents that the throw, and not merely the collision, is the defect: the generator is asked for a path and
+    /// fails the entire compile-time project instead of returning one.
+    /// </summary>
+    [Fact]
+    public void CollisionDoesNotThrow()
+    {
+        var generator = new CompileTimeCompilationBuilder.TransformedPathGenerator();
+
+        _ = generator.GetTransformedFilePath( "Fabric", 0x1111_1111_ABCD_EF01 );
+
+        var exception = Record.Exception( () => generator.GetTransformedFilePath( "Fabric", 0x2222_2222_ABCD_EF01 ) );
+
+        Assert.Null( exception );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.PartialTypes.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.PartialTypes.cs
@@ -22,13 +22,13 @@ public sealed partial class DependencyCollectorTests : UnitTestClass
         var assemblyIdentity = ProjectKeyFactory.CreateTest( "DependentAssembly" );
         var dependencies = new BaseDependencyCollector( new TestProjectVersion( assemblyIdentity ) );
 
-        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
+        var dependentDocumentKey = DocumentKey.FromPath( "dependent.cs" );
         var masterType = new TypeDependencyKey( "type" );
-        dependencies.AddPartialTypeDependency( dependentFilePath, assemblyIdentity, masterType );
+        dependencies.AddPartialTypeDependency( dependentDocumentKey, assemblyIdentity, masterType );
 
         Assert.Contains(
             masterType,
-            dependencies.DependenciesByDependentFilePath[dependentFilePath]
+            dependencies.DependenciesByDependentDocumentKey[dependentDocumentKey]
                 .DependenciesByMasterProject.Values.Single()
                 .MasterPartialTypes );
     }
@@ -39,14 +39,14 @@ public sealed partial class DependencyCollectorTests : UnitTestClass
         var projectKey = ProjectKeyFactory.CreateTest( "DependentAssembly" );
         var dependencies = new BaseDependencyCollector( new TestProjectVersion( projectKey ) );
 
-        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
+        var dependentDocumentKey = DocumentKey.FromPath( "dependent.cs" );
         var masterType = new TypeDependencyKey( "type" );
-        dependencies.AddPartialTypeDependency( dependentFilePath, projectKey, masterType );
-        dependencies.AddPartialTypeDependency( dependentFilePath, projectKey, masterType );
+        dependencies.AddPartialTypeDependency( dependentDocumentKey, projectKey, masterType );
+        dependencies.AddPartialTypeDependency( dependentDocumentKey, projectKey, masterType );
 
         Assert.Contains(
             masterType,
-            dependencies.DependenciesByDependentFilePath[dependentFilePath]
+            dependencies.DependenciesByDependentDocumentKey[dependentDocumentKey]
                 .DependenciesByMasterProject.Values.Single()
                 .MasterPartialTypes );
     }
@@ -77,7 +77,7 @@ public sealed partial class DependencyCollectorTests : UnitTestClass
 
         var actualDependencies = string.Join(
             Environment.NewLine,
-            dependencyCollector.EnumeratePartialTypeDependencies().Select( x => $"'{x.MasterType}'->'{x.DependentFilePath}'" ).OrderBy( x => x ) );
+            dependencyCollector.EnumeratePartialTypeDependencies().Select( x => $"'{x.MasterType}'->'{x.DependentDocumentKey}'" ).OrderBy( x => x ) );
 
         const string expectedDependencies = @"'Class1'->'Class2_1.cs'
 'Class1'->'Class2_2.cs'
@@ -123,7 +123,7 @@ public sealed partial class DependencyCollectorTests : UnitTestClass
 
         var actualDependencies = string.Join(
             "\r\n",
-            dependencyCollector.EnumeratePartialTypeDependencies().Select( x => $"'{x.MasterType}'->'{x.DependentFilePath}'" ).OrderBy( x => x ) );
+            dependencyCollector.EnumeratePartialTypeDependencies().Select( x => $"'{x.MasterType}'->'{x.DependentDocumentKey}'" ).OrderBy( x => x ) );
 
         const string expectedDependencies = @"'Class1'->'Class2_1.cs'
 'Class1'->'Class2_2.cs'

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.PartialTypes.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.PartialTypes.cs
@@ -22,7 +22,7 @@ public sealed partial class DependencyCollectorTests : UnitTestClass
         var assemblyIdentity = ProjectKeyFactory.CreateTest( "DependentAssembly" );
         var dependencies = new BaseDependencyCollector( new TestProjectVersion( assemblyIdentity ) );
 
-        const string dependentFilePath = "dependent.cs";
+        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
         var masterType = new TypeDependencyKey( "type" );
         dependencies.AddPartialTypeDependency( dependentFilePath, assemblyIdentity, masterType );
 
@@ -39,7 +39,7 @@ public sealed partial class DependencyCollectorTests : UnitTestClass
         var projectKey = ProjectKeyFactory.CreateTest( "DependentAssembly" );
         var dependencies = new BaseDependencyCollector( new TestProjectVersion( projectKey ) );
 
-        const string dependentFilePath = "dependent.cs";
+        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
         var masterType = new TypeDependencyKey( "type" );
         dependencies.AddPartialTypeDependency( dependentFilePath, projectKey, masterType );
         dependencies.AddPartialTypeDependency( dependentFilePath, projectKey, masterType );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.SyntaxTrees.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.SyntaxTrees.cs
@@ -22,17 +22,17 @@ public sealed partial class DependencyCollectorTests
         var dependencies = new BaseDependencyCollector( new TestProjectVersion( projectKey ) );
         const ulong hash = 54;
 
-        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        dependencies.AddSyntaxTreeDependency( dependentFilePath, projectKey, masterFilePath, hash );
+        var dependentDocumentKey = DocumentKey.FromPath( "dependent.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        dependencies.AddSyntaxTreeDependency( dependentDocumentKey, projectKey, masterDocumentKey, hash );
 
-        Assert.Equal( dependentFilePath, dependencies.DependenciesByDependentFilePath[dependentFilePath].DependentFilePath );
+        Assert.Equal( dependentDocumentKey, dependencies.DependenciesByDependentDocumentKey[dependentDocumentKey].DependentDocumentKey );
 
         Assert.Equal(
             hash,
-            dependencies.DependenciesByDependentFilePath[dependentFilePath]
+            dependencies.DependenciesByDependentDocumentKey[dependentDocumentKey]
                 .DependenciesByMasterProject.Values.Single()
-                .MasterFilePathsAndHashes[masterFilePath] );
+                .MasterDocumentKeysAndHashes[masterDocumentKey] );
     }
 
     [Fact]
@@ -43,18 +43,18 @@ public sealed partial class DependencyCollectorTests
 
         const ulong hash = 54;
 
-        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        dependencies.AddSyntaxTreeDependency( dependentFilePath, projectKey, masterFilePath, hash );
-        dependencies.AddSyntaxTreeDependency( dependentFilePath, projectKey, masterFilePath, hash );
+        var dependentDocumentKey = DocumentKey.FromPath( "dependent.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        dependencies.AddSyntaxTreeDependency( dependentDocumentKey, projectKey, masterDocumentKey, hash );
+        dependencies.AddSyntaxTreeDependency( dependentDocumentKey, projectKey, masterDocumentKey, hash );
 
-        Assert.Equal( dependentFilePath, dependencies.DependenciesByDependentFilePath[dependentFilePath].DependentFilePath );
+        Assert.Equal( dependentDocumentKey, dependencies.DependenciesByDependentDocumentKey[dependentDocumentKey].DependentDocumentKey );
 
         Assert.Equal(
             hash,
-            dependencies.DependenciesByDependentFilePath[dependentFilePath]
+            dependencies.DependenciesByDependentDocumentKey[dependentDocumentKey]
                 .DependenciesByMasterProject.Values.Single()
-                .MasterFilePathsAndHashes[masterFilePath] );
+                .MasterDocumentKeysAndHashes[masterDocumentKey] );
     }
 
     [Fact]
@@ -82,7 +82,7 @@ public sealed partial class DependencyCollectorTests
 
         var actualDependencies = string.Join(
             Environment.NewLine,
-            dependencyCollector.EnumerateSyntaxTreeDependencies().Select( x => $"'{x.MasterFilePath}'->'{x.DependentFilePath}'" ).OrderBy( x => x ) );
+            dependencyCollector.EnumerateSyntaxTreeDependencies().Select( x => $"'{x.MasterDocumentKey}'->'{x.DependentDocumentKey}'" ).OrderBy( x => x ) );
 
         const string expectedDependencies = @"'Class2.cs'->'Class3.cs'
 'Class2.cs'->'Class4.cs'
@@ -130,7 +130,7 @@ public sealed partial class DependencyCollectorTests
 
         var actualDependencies = string.Join(
             "\r\n",
-            dependencyCollector.EnumerateSyntaxTreeDependencies().Select( x => $"'{x.MasterFilePath}'->'{x.DependentFilePath}'" ).OrderBy( x => x ) );
+            dependencyCollector.EnumerateSyntaxTreeDependencies().Select( x => $"'{x.MasterDocumentKey}'->'{x.DependentDocumentKey}'" ).OrderBy( x => x ) );
 
         const string expectedDependencies = @"'Class2.cs'->'Class3.cs'
 'Class2.cs'->'Class4.cs'

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.SyntaxTrees.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyCollectorTests.SyntaxTrees.cs
@@ -22,8 +22,8 @@ public sealed partial class DependencyCollectorTests
         var dependencies = new BaseDependencyCollector( new TestProjectVersion( projectKey ) );
         const ulong hash = 54;
 
-        const string dependentFilePath = "dependent.cs";
-        const string masterFilePath = "master.cs";
+        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
         dependencies.AddSyntaxTreeDependency( dependentFilePath, projectKey, masterFilePath, hash );
 
         Assert.Equal( dependentFilePath, dependencies.DependenciesByDependentFilePath[dependentFilePath].DependentFilePath );
@@ -43,8 +43,8 @@ public sealed partial class DependencyCollectorTests
 
         const ulong hash = 54;
 
-        const string dependentFilePath = "dependent.cs";
-        const string masterFilePath = "master.cs";
+        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
         dependencies.AddSyntaxTreeDependency( dependentFilePath, projectKey, masterFilePath, hash );
         dependencies.AddSyntaxTreeDependency( dependentFilePath, projectKey, masterFilePath, hash );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyGraphInvalidationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyGraphInvalidationTests.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime;
 using Metalama.Framework.DesignTime.Pipeline.Dependencies;
 using Metalama.Framework.DesignTime.Pipeline.Diff;
@@ -35,15 +36,15 @@ public sealed class DependencyGraphInvalidationTests : DesignTimeTestBase
             if ( dependency.Kind == DependencyKind.SyntaxTree )
             {
                 dependencyCollector.AddSyntaxTreeDependency(
-                    dependency.Dependent,
+                    DocumentKey.FromPath( dependency.Dependent ),
                     compilation1.GetProjectKey(),
-                    dependency.Master,
-                    compilationVersion1.SyntaxTrees[dependency.Master].DeclarationHash );
+                    DocumentKey.FromPath( dependency.Master ),
+                    compilationVersion1.SyntaxTrees[DocumentKey.FromPath( dependency.Master )].DeclarationHash );
             }
             else
             {
                 dependencyCollector.AddPartialTypeDependency(
-                    dependency.Dependent,
+                    DocumentKey.FromPath( dependency.Dependent ),
                     compilation1.GetProjectKey(),
                     new TypeDependencyKey( dependency.Master ) );
             }
@@ -57,7 +58,7 @@ public sealed class DependencyGraphInvalidationTests : DesignTimeTestBase
         var invalidatedSyntaxTrees = new HashSet<string>();
 
         var newDependencyGraph =
-            await compilationChangesProvider.ProcessCompilationChangesAsync( changes, dependencyGraph, t => invalidatedSyntaxTrees.Add( t ), true );
+            await compilationChangesProvider.ProcessCompilationChangesAsync( changes, dependencyGraph, t => invalidatedSyntaxTrees.Add( t.Path ), true );
 
         return (invalidatedSyntaxTrees.ToOrderedList( x => x ), dependencyGraph, newDependencyGraph);
     }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyGraphTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyGraphTests.cs
@@ -24,17 +24,17 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
 
         const ulong hash = 54;
 
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        var dependentDocumentKey = DocumentKey.FromPath( "dependent.cs" );
 
-        dependencyCollector.AddSyntaxTreeDependency( dependentFilePath, masterCompilation, masterFilePath, hash );
+        dependencyCollector.AddSyntaxTreeDependency( dependentDocumentKey, masterCompilation, masterDocumentKey, hash );
 
         var graph = DependencyGraph.Create( dependencyCollector );
 
         var dependenciesByCompilation = graph.DependenciesByMasterProject.Values.Single();
         Assert.Equal( masterCompilation, dependenciesByCompilation.ProjectKey );
-        var dependenciesByMasterFile = graph.DependenciesByMasterProject[masterCompilation].DependenciesByMasterFilePath.Single();
-        Assert.Equal( masterFilePath, dependenciesByMasterFile.Key );
+        var dependenciesByMasterFile = graph.DependenciesByMasterProject[masterCompilation].DependenciesByMasterDocumentKey.Single();
+        Assert.Equal( masterDocumentKey, dependenciesByMasterFile.Key );
         Assert.Equal( hash, dependenciesByMasterFile.Value.DeclarationHash );
     }
 
@@ -45,12 +45,12 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         var dependencyCollector = new BaseDependencyCollector( new TestProjectVersion( masterProject ) );
         const ulong hash = 54;
 
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
-        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        var dependentDocumentKey1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentDocumentKey2 = DocumentKey.FromPath( "dependent2.cs" );
 
-        dependencyCollector.AddSyntaxTreeDependency( dependentFilePath1, masterProject, masterFilePath, hash );
-        dependencyCollector.AddSyntaxTreeDependency( dependentFilePath2, masterProject, masterFilePath, hash );
+        dependencyCollector.AddSyntaxTreeDependency( dependentDocumentKey1, masterProject, masterDocumentKey, hash );
+        dependencyCollector.AddSyntaxTreeDependency( dependentDocumentKey2, masterProject, masterDocumentKey, hash );
 
         var graph = DependencyGraph.Create( dependencyCollector );
 
@@ -58,12 +58,12 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         Assert.Equal( masterProject, dependenciesByProject.ProjectKey );
 
         Assert.Contains(
-            dependentFilePath1,
-            graph.DependenciesByMasterProject[masterProject].DependenciesByMasterFilePath[masterFilePath].DependentFilePaths );
+            dependentDocumentKey1,
+            graph.DependenciesByMasterProject[masterProject].DependenciesByMasterDocumentKey[masterDocumentKey].DependentDocumentKeys );
 
         Assert.Contains(
-            dependentFilePath2,
-            graph.DependenciesByMasterProject[masterProject].DependenciesByMasterFilePath[masterFilePath].DependentFilePaths );
+            dependentDocumentKey2,
+            graph.DependenciesByMasterProject[masterProject].DependenciesByMasterDocumentKey[masterDocumentKey].DependentDocumentKeys );
     }
 
     [Fact]
@@ -80,22 +80,22 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
 
         const ulong hash = 54;
 
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
-        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        var dependentDocumentKey1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentDocumentKey2 = DocumentKey.FromPath( "dependent2.cs" );
 
-        dependencyCollector.AddSyntaxTreeDependency( dependentFilePath1, masterCompilation1.ProjectKey, masterFilePath, hash );
-        dependencyCollector.AddSyntaxTreeDependency( dependentFilePath2, masterCompilation2.ProjectKey, masterFilePath, hash );
+        dependencyCollector.AddSyntaxTreeDependency( dependentDocumentKey1, masterCompilation1.ProjectKey, masterDocumentKey, hash );
+        dependencyCollector.AddSyntaxTreeDependency( dependentDocumentKey2, masterCompilation2.ProjectKey, masterDocumentKey, hash );
 
         var graph = DependencyGraph.Create( dependencyCollector );
 
         Assert.Contains(
-            dependentFilePath1,
-            graph.DependenciesByMasterProject[masterCompilation1.ProjectKey].DependenciesByMasterFilePath[masterFilePath].DependentFilePaths );
+            dependentDocumentKey1,
+            graph.DependenciesByMasterProject[masterCompilation1.ProjectKey].DependenciesByMasterDocumentKey[masterDocumentKey].DependentDocumentKeys );
 
         Assert.Contains(
-            dependentFilePath2,
-            graph.DependenciesByMasterProject[masterCompilation2.ProjectKey].DependenciesByMasterFilePath[masterFilePath].DependentFilePaths );
+            dependentDocumentKey2,
+            graph.DependenciesByMasterProject[masterCompilation2.ProjectKey].DependenciesByMasterDocumentKey[masterDocumentKey].DependentDocumentKeys );
     }
 
     [Fact]
@@ -103,18 +103,18 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
     {
         const ulong hash = 54;
 
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        var dependentDocumentKey = DocumentKey.FromPath( "dependent.cs" );
 
         using var testContext = this.CreateTestContext();
 
         var masterCompilation = testContext.CreateCSharpCompilation(
-            new Dictionary<string, string>() { [masterFilePath.Path] = "", [dependentFilePath.Path] = "" },
+            new Dictionary<string, string>() { [masterDocumentKey.Path] = "", [dependentDocumentKey.Path] = "" },
             assemblyName: "MasterAssembly" );
 
         var dependencies1 = new BaseDependencyCollector( new TestProjectVersion( masterCompilation ) );
 
-        dependencies1.AddSyntaxTreeDependency( dependentFilePath, masterCompilation.GetProjectKey(), masterFilePath, hash );
+        dependencies1.AddSyntaxTreeDependency( dependentDocumentKey, masterCompilation.GetProjectKey(), masterDocumentKey, hash );
 
         var graph1 = DependencyGraph.Create( dependencies1 );
 
@@ -129,28 +129,28 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
     {
         const ulong hash = 54;
 
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
-        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        var dependentDocumentKey1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentDocumentKey2 = DocumentKey.FromPath( "dependent2.cs" );
 
         var masterCompilation = new TestProjectVersion( "MasterAssembly" );
 
         // Create a 1st version of the dependent assembly with two references to master.cs.
         var dependentCompilationVersion1 = new TestProjectVersion(
             ProjectKeyFactory.CreateTest( "DependentAssembly" ),
-            hashes: new Dictionary<DocumentKey, ulong>() { [dependentFilePath1] = hash, [dependentFilePath2] = hash },
+            hashes: new Dictionary<DocumentKey, ulong>() { [dependentDocumentKey1] = hash, [dependentDocumentKey2] = hash },
             referencedCompilations: new IProjectVersion[] { masterCompilation } );
 
         var dependencyCollector1 = new BaseDependencyCollector( dependentCompilationVersion1 );
 
-        dependencyCollector1.AddSyntaxTreeDependency( dependentFilePath1, masterCompilation.ProjectKey, masterFilePath, hash );
-        dependencyCollector1.AddSyntaxTreeDependency( dependentFilePath2, masterCompilation.ProjectKey, masterFilePath, hash );
+        dependencyCollector1.AddSyntaxTreeDependency( dependentDocumentKey1, masterCompilation.ProjectKey, masterDocumentKey, hash );
+        dependencyCollector1.AddSyntaxTreeDependency( dependentDocumentKey2, masterCompilation.ProjectKey, masterDocumentKey, hash );
 
         var graph1 = DependencyGraph.Create( dependencyCollector1 );
 
         // Create a 1st version of the dependent assembly with just 1 reference to master.cs.
         var dependencyCollector2 = new BaseDependencyCollector( dependentCompilationVersion1 );
-        dependencyCollector2.AddSyntaxTreeDependency( dependentFilePath1, masterCompilation.ProjectKey, masterFilePath, hash );
+        dependencyCollector2.AddSyntaxTreeDependency( dependentDocumentKey1, masterCompilation.ProjectKey, masterDocumentKey, hash );
 
         var graph2 = graph1
             .Update( dependencyCollector2 );
@@ -159,12 +159,12 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         Assert.Equal( masterCompilation.ProjectKey, dependenciesByCompilation.ProjectKey );
 
         Assert.Contains(
-            dependentFilePath1,
-            graph2.DependenciesByMasterProject[masterCompilation.ProjectKey].DependenciesByMasterFilePath[masterFilePath].DependentFilePaths );
+            dependentDocumentKey1,
+            graph2.DependenciesByMasterProject[masterCompilation.ProjectKey].DependenciesByMasterDocumentKey[masterDocumentKey].DependentDocumentKeys );
 
         Assert.DoesNotContain(
-            dependentFilePath2,
-            graph2.DependenciesByMasterProject[masterCompilation.ProjectKey].DependenciesByMasterFilePath[masterFilePath].DependentFilePaths );
+            dependentDocumentKey2,
+            graph2.DependenciesByMasterProject[masterCompilation.ProjectKey].DependenciesByMasterDocumentKey[masterDocumentKey].DependentDocumentKeys );
     }
 
     [Fact]
@@ -174,20 +174,20 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         const ulong hash1 = 54;
         const ulong hash2 = 55;
 
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
-        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
+        var dependentDocumentKey = DocumentKey.FromPath( "dependent.cs" );
 
         var dependencies1 = new BaseDependencyCollector( new TestProjectVersion( "dummy" ) );
-        dependencies1.AddSyntaxTreeDependency( dependentFilePath, masterCompilation, masterFilePath, hash1 );
+        dependencies1.AddSyntaxTreeDependency( dependentDocumentKey, masterCompilation, masterDocumentKey, hash1 );
 
         var graph1 = DependencyGraph.Create( dependencies1 );
 
         var dependencies2 = new BaseDependencyCollector( new TestProjectVersion( "dummy" ) );
-        dependencies2.AddSyntaxTreeDependency( dependentFilePath, masterCompilation, masterFilePath, hash2 );
+        dependencies2.AddSyntaxTreeDependency( dependentDocumentKey, masterCompilation, masterDocumentKey, hash2 );
 
         var graph2 = graph1.Update( dependencies2 );
 
-        Assert.Equal( hash2, graph2.DependenciesByMasterProject[masterCompilation].DependenciesByMasterFilePath[masterFilePath].DeclarationHash );
+        Assert.Equal( hash2, graph2.DependenciesByMasterProject[masterCompilation].DependenciesByMasterDocumentKey[masterDocumentKey].DeclarationHash );
     }
 
     [Fact]
@@ -197,20 +197,20 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         var masterCompilation = ProjectKeyFactory.CreateTest( "MasterAssembly" );
         const ulong hash1 = 54;
 
-        var masterFilePath = DocumentKey.FromPath( "master.cs" );
+        var masterDocumentKey = DocumentKey.FromPath( "master.cs" );
 
         // We need two dependent files to make appear a bug in DependencyGraph.Builder.RemoveDependentSyntaxTree
-        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
-        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
+        var dependentDocumentKey1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentDocumentKey2 = DocumentKey.FromPath( "dependent2.cs" );
 
         var compilation = testContext.CreateCSharpCompilation(
-            new Dictionary<string, string> { [masterFilePath.Path] = "", [dependentFilePath1.Path] = "", [dependentFilePath2.Path] = "" } );
+            new Dictionary<string, string> { [masterDocumentKey.Path] = "", [dependentDocumentKey1.Path] = "", [dependentDocumentKey2.Path] = "" } );
 
         var partialCompilation = PartialCompilation.CreateComplete( compilation );
 
         var dependencies1 = new BaseDependencyCollector( new TestProjectVersion( "dummy" ), partialCompilation );
-        dependencies1.AddSyntaxTreeDependency( dependentFilePath1, masterCompilation, masterFilePath, hash1 );
-        dependencies1.AddSyntaxTreeDependency( dependentFilePath2, masterCompilation, masterFilePath, hash1 );
+        dependencies1.AddSyntaxTreeDependency( dependentDocumentKey1, masterCompilation, masterDocumentKey, hash1 );
+        dependencies1.AddSyntaxTreeDependency( dependentDocumentKey2, masterCompilation, masterDocumentKey, hash1 );
 
         var graph1 = DependencyGraph.Create( dependencies1 );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyGraphTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DependencyGraphTests.cs
@@ -24,8 +24,8 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
 
         const ulong hash = 54;
 
-        const string masterFilePath = "master.cs";
-        const string dependentFilePath = "dependent.cs";
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
+        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
 
         dependencyCollector.AddSyntaxTreeDependency( dependentFilePath, masterCompilation, masterFilePath, hash );
 
@@ -45,9 +45,9 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         var dependencyCollector = new BaseDependencyCollector( new TestProjectVersion( masterProject ) );
         const ulong hash = 54;
 
-        const string masterFilePath = "master.cs";
-        const string dependentFilePath1 = "dependent1.cs";
-        const string dependentFilePath2 = "dependent2.cs";
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
+        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
 
         dependencyCollector.AddSyntaxTreeDependency( dependentFilePath1, masterProject, masterFilePath, hash );
         dependencyCollector.AddSyntaxTreeDependency( dependentFilePath2, masterProject, masterFilePath, hash );
@@ -80,9 +80,9 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
 
         const ulong hash = 54;
 
-        const string masterFilePath = "master.cs";
-        const string dependentFilePath1 = "dependent1.cs";
-        const string dependentFilePath2 = "dependent2.cs";
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
+        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
 
         dependencyCollector.AddSyntaxTreeDependency( dependentFilePath1, masterCompilation1.ProjectKey, masterFilePath, hash );
         dependencyCollector.AddSyntaxTreeDependency( dependentFilePath2, masterCompilation2.ProjectKey, masterFilePath, hash );
@@ -103,13 +103,13 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
     {
         const ulong hash = 54;
 
-        const string masterFilePath = "master.cs";
-        const string dependentFilePath = "dependent.cs";
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
+        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
 
         using var testContext = this.CreateTestContext();
 
         var masterCompilation = testContext.CreateCSharpCompilation(
-            new Dictionary<string, string>() { [masterFilePath] = "", [dependentFilePath] = "" },
+            new Dictionary<string, string>() { [masterFilePath.Path] = "", [dependentFilePath.Path] = "" },
             assemblyName: "MasterAssembly" );
 
         var dependencies1 = new BaseDependencyCollector( new TestProjectVersion( masterCompilation ) );
@@ -129,16 +129,16 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
     {
         const ulong hash = 54;
 
-        const string masterFilePath = "master.cs";
-        const string dependentFilePath1 = "dependent1.cs";
-        const string dependentFilePath2 = "dependent2.cs";
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
+        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
 
         var masterCompilation = new TestProjectVersion( "MasterAssembly" );
 
         // Create a 1st version of the dependent assembly with two references to master.cs.
         var dependentCompilationVersion1 = new TestProjectVersion(
             ProjectKeyFactory.CreateTest( "DependentAssembly" ),
-            hashes: new Dictionary<string, ulong>() { [dependentFilePath1] = hash, [dependentFilePath2] = hash },
+            hashes: new Dictionary<DocumentKey, ulong>() { [dependentFilePath1] = hash, [dependentFilePath2] = hash },
             referencedCompilations: new IProjectVersion[] { masterCompilation } );
 
         var dependencyCollector1 = new BaseDependencyCollector( dependentCompilationVersion1 );
@@ -174,8 +174,8 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         const ulong hash1 = 54;
         const ulong hash2 = 55;
 
-        const string masterFilePath = "master.cs";
-        const string dependentFilePath = "dependent.cs";
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
+        var dependentFilePath = DocumentKey.FromPath( "dependent.cs" );
 
         var dependencies1 = new BaseDependencyCollector( new TestProjectVersion( "dummy" ) );
         dependencies1.AddSyntaxTreeDependency( dependentFilePath, masterCompilation, masterFilePath, hash1 );
@@ -197,14 +197,14 @@ public sealed class DependencyGraphTests : DesignTimeTestBase
         var masterCompilation = ProjectKeyFactory.CreateTest( "MasterAssembly" );
         const ulong hash1 = 54;
 
-        const string masterFilePath = "master.cs";
+        var masterFilePath = DocumentKey.FromPath( "master.cs" );
 
         // We need two dependent files to make appear a bug in DependencyGraph.Builder.RemoveDependentSyntaxTree
-        const string dependentFilePath1 = "dependent1.cs";
-        const string dependentFilePath2 = "dependent2.cs";
+        var dependentFilePath1 = DocumentKey.FromPath( "dependent1.cs" );
+        var dependentFilePath2 = DocumentKey.FromPath( "dependent2.cs" );
 
         var compilation = testContext.CreateCSharpCompilation(
-            new Dictionary<string, string> { [masterFilePath] = "", [dependentFilePath1] = "", [dependentFilePath2] = "" } );
+            new Dictionary<string, string> { [masterFilePath.Path] = "", [dependentFilePath1.Path] = "", [dependentFilePath2.Path] = "" } );
 
         var partialCompilation = PartialCompilation.CreateComplete( compilation );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
@@ -1856,7 +1856,7 @@ Target.cs:
                                   """;
 
         var expectedResult = $"""
-                              :
+                              (none):
                               2 diagnostic(s):
                                  Error LAMA0113 on ``: `Cannot find in the current compilation the aspect type 'MyAspect' defined in the aspect library '{aspect1AssemblyName}'.`
                                  Error LAMA0113 on ``: `Cannot find in the current compilation the aspect type 'MyAspect' defined in the aspect library '{aspect2AssemblyName}'.`

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DesignTimePipelineTests.cs
@@ -247,7 +247,7 @@ Target.cs:
 
         Assert.Equal( DesignTimeAspectPipelineStatus.Paused, pipeline.Status );
         Assert.True( factory.EventHub.IsEditingCompileTimeCode );
-        Assert.True( pipeline.IsCompileTimeSyntaxTreeOutdated( "Aspect.cs" ) );
+        Assert.True( pipeline.IsCompileTimeSyntaxTreeOutdated( DocumentKey.FromPath( "Aspect.cs" ) ) );
 
         var dumpedResults4 = DumpResults( results4 );
 
@@ -302,7 +302,7 @@ Target.cs:
         AssertEx.EolInvariantEqual( expectedResult.ReplaceOrdinal( "$AspectVersion$", "3" ).ReplaceOrdinal( "$TargetVersion$", "2" ).Trim(), dumpedResults6 );
         Assert.Equal( 3, pipeline.PipelineExecutionCount );
         Assert.Equal( 2, pipeline.PipelineInitializationCount );
-        Assert.False( pipeline.IsCompileTimeSyntaxTreeOutdated( "Aspect.cs" ) );
+        Assert.False( pipeline.IsCompileTimeSyntaxTreeOutdated( DocumentKey.FromPath( "Aspect.cs" ) ) );
 
         List<Diagnostic> diagnostics6 = new();
 
@@ -398,7 +398,7 @@ Target.cs:
         Assert.Equal( DesignTimeAspectPipelineStatus.Paused, targetProjectPipeline.Status );
         Assert.Equal( DesignTimeAspectPipelineStatus.Paused, aspectProjectPipeline.Status );
         Assert.True( factory.EventHub.IsEditingCompileTimeCode );
-        Assert.True( aspectProjectPipeline.IsCompileTimeSyntaxTreeOutdated( "Aspect.cs" ) );
+        Assert.True( aspectProjectPipeline.IsCompileTimeSyntaxTreeOutdated( DocumentKey.FromPath( "Aspect.cs" ) ) );
 
         var dumpedResults3 = DumpResults( results3 );
 
@@ -423,7 +423,7 @@ Target.cs:
         await aspectProjectPipeline.ProcessJobQueueWhenLockAvailableAsync();
         Assert.Equal( 2, targetProjectPipeline.PipelineExecutionCount );
         Assert.Equal( 2, targetProjectPipeline.PipelineInitializationCount );
-        Assert.False( targetProjectPipeline.IsCompileTimeSyntaxTreeOutdated( "Aspect.cs" ) );
+        Assert.False( targetProjectPipeline.IsCompileTimeSyntaxTreeOutdated( DocumentKey.FromPath( "Aspect.cs" ) ) );
     }
 
     [Fact]
@@ -942,7 +942,7 @@ class D{version}
         Assert.True( pipeline.TryExecute( compilation2, default, out var compilationResult ) );
 
         // Note that LAMA0118 is no longer reported by the pipeline but by the analyzer.
-        Assert.Empty( compilationResult.GetDiagnosticsOnSyntaxTree( "Aspect.cs" ) );
+        Assert.Empty( compilationResult.GetDiagnosticsOnSyntaxTree( DocumentKey.FromPath( "Aspect.cs" ) ) );
 
         Assert.Equal( DesignTimeAspectPipelineStatus.Paused, pipeline.Status );
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DuplicateSyntaxTreePathTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DuplicateSyntaxTreePathTests.cs
@@ -1,0 +1,342 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Compiler;
+using Metalama.Framework.DesignTime;
+using Metalama.Framework.DesignTime.DiagnosticAnalysis;
+using Metalama.Framework.DesignTime.Diagnostics;
+using Metalama.Framework.DesignTime.Pipeline.Diff;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.Utilities;
+using Metalama.Framework.Engine.Utilities.Roslyn;
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
+
+/// <summary>
+/// Tests for https://github.com/metalama/Metalama/issues/1742: Metalama indexes the syntax trees of a compilation by
+/// <see cref="SyntaxTree.FilePath"/> and assumes the path identifies the tree. Roslyn makes no such guarantee.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The condition does not arise from the command-line compiler, which deduplicates source files by normalized path,
+/// reports <c>CS2002</c> and drops the duplicate. It arises from Roslyn Workspaces, which has no equivalent step: the
+/// project system creates one document per <c>Compile</c> item, so overlapping globs, an explicit <c>Include</c> that
+/// repeats a glob, <c>Link</c> metadata pointing two items at one file, or a shared project all produce two
+/// <see cref="SyntaxTree"/> objects with one path in one <see cref="Compilation"/>. Nothing in the user's project is
+/// invalid, and nothing Metalama does can prevent it.
+/// </para>
+/// <para>
+/// Each test names the site it covers. They are grouped here rather than spread over the files they exercise, because
+/// the value of the set is that the sites disagree: two of them tolerate the condition, four throw, and one tolerates
+/// it in its own index while leaving the compilation it describes unchanged.
+/// </para>
+/// </remarks>
+public sealed class DuplicateSyntaxTreePathTests : UnitTestClass
+{
+    public DuplicateSyntaxTreePathTests( ITestOutputHelper testOutput ) : base( testOutput ) { }
+
+    private const string _duplicatePath = "Duplicated.cs";
+
+    /// <summary>
+    /// The two trees declare different types, so the compilation has no C# error. This is the faithful shape of a
+    /// generated document whose hint name lands on the path of a real file, and it keeps the tests free of the
+    /// <c>CS0101</c> noise that identical content would produce.
+    /// </summary>
+    private const string _firstCode = "public class FirstType { }";
+
+    private const string _secondCode = "public class SecondType { }";
+
+    /// <summary>
+    /// Builds a compilation holding two distinct syntax trees that share <see cref="_duplicatePath"/>. Roslyn accepts
+    /// this: <see cref="Compilation.AddSyntaxTrees(SyntaxTree[])"/> rejects only the same instance twice.
+    /// </summary>
+    private static (CSharpCompilation Compilation, SyntaxTree First, SyntaxTree Second) CreateCompilationWithDuplicatePath(
+        TestContext testContext )
+    {
+        var parseOptions = testContext.GetCompilationParseOptions();
+
+        var compilation = testContext.CreateCSharpCompilation( new Dictionary<string, string> { [_duplicatePath] = _firstCode } );
+        var first = compilation.SyntaxTrees.Single( t => t.FilePath == _duplicatePath );
+
+        var second = SyntaxFactory.ParseSyntaxTree( _secondCode, path: _duplicatePath, options: parseOptions );
+
+        return (compilation.AddSyntaxTrees( second ), first, second);
+    }
+
+    /// <summary>
+    /// Site 1, the fatal one. <c>GetIndexedSyntaxTreesCore</c> builds the index with <c>ToImmutableDictionary</c>,
+    /// which throws <see cref="System.ArgumentException"/> on the second tree. The throw happens inside a
+    /// <c>WeakCache</c> factory, so nothing is memoized and every later request for the same compilation repeats it.
+    /// </summary>
+    [Fact]
+    public void GetIndexedSyntaxTreesTolerates()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, _, _) = CreateCompilationWithDuplicatePath( testContext );
+
+        var index = compilation.GetIndexedSyntaxTrees();
+
+        Assert.True( index.ContainsKey( _duplicatePath ) );
+    }
+
+    /// <summary>
+    /// The same site reached through the entry point that fails in production.
+    /// <c>DesignTimeAspectPipeline.ExecuteAsync</c> calls <see cref="PartialCompilation.CreateComplete"/> whenever the
+    /// pipeline status is <c>Default</c>, which is the case on the first execution for a project and for every
+    /// referenced project, so a single duplicated path stops the pipeline before it has produced anything.
+    /// </summary>
+    [Fact]
+    public void CreateCompleteTolerates()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, _, _) = CreateCompilationWithDuplicatePath( testContext );
+
+        var partialCompilation = PartialCompilation.CreateComplete( compilation );
+
+        Assert.NotEmpty( partialCompilation.SyntaxTreeCollection );
+    }
+
+    /// <summary>
+    /// The invariant that distinguishes a correct fix from a fix that trades a crash for wrong output: the set of
+    /// trees a <see cref="PartialCompilation"/> exposes must cover the trees of the <see cref="Compilation"/> it
+    /// carries.
+    /// </summary>
+    /// <remarks>
+    /// <c>LinkerInjectionStep</c> rewrites <c>SyntaxTrees.Values</c>. A tree that stays in the Roslyn compilation
+    /// while being absent from that collection keeps its declarations in the code model and is never rewritten, so
+    /// aspects apply to some declarations of the project and silently do not apply to others. Making the index merely
+    /// tolerant, by keeping the first tree per path and dropping the rest, produces exactly that state. Removing the
+    /// dropped trees from the compilation as well is what keeps the two in agreement.
+    /// </remarks>
+    [Fact]
+    public void CompletePartialCompilationCoversItsCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, _, _) = CreateCompilationWithDuplicatePath( testContext );
+
+        var partialCompilation = PartialCompilation.CreateComplete( compilation );
+
+        Assert.Equal(
+            partialCompilation.Compilation.SyntaxTrees.OrderBy( t => t.ToString() ),
+            partialCompilation.SyntaxTreeCollection.OrderBy( t => t.ToString() ) );
+    }
+
+    /// <summary>
+    /// The same invariant for the partial path. Site 2, <c>GetClosure.AddTree</c>, already tolerates the condition by
+    /// keeping the first tree of a path and discarding the rest, so this compilation reaches the pipeline with a tree
+    /// that no stage will visit.
+    /// </summary>
+    [Fact]
+    public void PartialCompilationCoversItsCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, first, second) = CreateCompilationWithDuplicatePath( testContext );
+
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, new[] { first, second } );
+
+        Assert.Equal(
+            partialCompilation.Compilation.SyntaxTrees.OrderBy( t => t.ToString() ),
+            partialCompilation.SyntaxTreeCollection.OrderBy( t => t.ToString() ) );
+    }
+
+    /// <summary>
+    /// The consequence of the previous test, stated as behaviour rather than as a set comparison: a rewrite of every
+    /// syntax tree of the partial compilation must leave no tree of the resulting compilation unrewritten.
+    /// <see cref="PartialCompilationExtensions.UpdateSyntaxTrees(Metalama.Framework.Engine.CodeModel.IPartialCompilation,System.Func{SyntaxTree,SyntaxTree},System.Threading.CancellationToken)"/>
+    /// is the public analogue of the loop the linker runs.
+    /// </summary>
+    [Fact]
+    public void EverySyntaxTreeIsRewritten()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, first, second) = CreateCompilationWithDuplicatePath( testContext );
+
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, new[] { first, second } );
+
+        const string marker = "// rewritten";
+
+        var rewritten = partialCompilation.UpdateSyntaxTrees(
+            tree => tree.WithRootAndOptions(
+                tree.GetCompilationUnitRoot().WithLeadingTrivia( SyntaxFactory.Comment( marker ) ),
+                tree.Options ) );
+
+        var notRewritten = rewritten.Compilation.SyntaxTrees
+            .Where( t => t.FilePath == _duplicatePath && !t.ToString().ContainsOrdinal( marker ) )
+            .ToList();
+
+        Assert.Empty( notRewritten );
+    }
+
+    /// <summary>
+    /// Sites 3 and 4, the diff layer, which is the only place that already detects the condition and reports it. It
+    /// resolves the duplicate in the version index by keeping the first tree of a path, but
+    /// <c>ProjectVersion.CompilationToAnalyze</c> removes only the trees generated by Metalama, so the compilation the
+    /// pipeline then analyses still holds both. That mismatch is what leaves every downstream index describing a
+    /// compilation it does not match.
+    /// </summary>
+    [Fact]
+    public void CompilationToAnalyzeHasUniquePaths()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, _, _) = CreateCompilationWithDuplicatePath( testContext );
+
+        var projectVersion = ProjectVersion.Create(
+            compilation,
+            compilation.GetProjectKey(),
+            new DiffStrategy( isTest: true, detectCompileTimeCode: true, detectPartialTypes: true ),
+            serviceProvider: testContext.ServiceProvider.Underlying );
+
+        var duplicatedPaths = projectVersion.CompilationToAnalyze.SyntaxTrees
+            .GroupBy( t => t.FilePath )
+            .Where( g => g.Count() > 1 )
+            .Select( g => g.Key )
+            .ToList();
+
+        Assert.Empty( duplicatedPaths );
+    }
+
+    /// <summary>
+    /// The user-visible failure: the design-time pipeline of a project holding one duplicated path never completes, so
+    /// the project has no Metalama diagnostic, no code lens and no generated document, on the first execution and on
+    /// every one after it.
+    /// </summary>
+    [Fact]
+    public void DesignTimePipelineSucceeds()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (compilation, _, _) = CreateCompilationWithDuplicatePath( testContext );
+
+        Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out var result ) );
+        Assert.NotNull( result );
+    }
+
+    /// <summary>
+    /// The code model must describe exactly the compilation the pipeline analyzes, and no more. Under the one-document
+    /// model the second tree is not a second document, so its declarations are absent from both. The alternative, in
+    /// which the type is visible to aspects while its tree is never rewritten, is the silent failure that
+    /// <see cref="EverySyntaxTreeIsRewritten"/> guards against.
+    /// </summary>
+    /// <remarks>
+    /// This is the case in which the model costs something: the two trees here declare different types, which is the
+    /// shape of a generated document whose hint name lands on the path of a real file, so a real declaration is
+    /// dropped. That is why the condition is reported to the user rather than merely resolved. See
+    /// <see cref="DesignTimePipelineReportsTheDuplicatePath"/>.
+    /// </remarks>
+    [Fact]
+    public void CodeModelMatchesTheAnalyzedCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, _, _) = CreateCompilationWithDuplicatePath( testContext );
+
+        var partialCompilation = PartialCompilation.CreateComplete( compilation );
+
+        var compilationModel = CompilationModel.CreateInitialInstance(
+            new ProjectModel( compilation, testContext.ServiceProvider ),
+            partialCompilation );
+
+        var typeNames = compilationModel.Types.SelectAsReadOnlyCollection( t => t.Name ).OrderBy( n => n );
+
+        Assert.Equal( new[] { "FirstType" }, typeNames );
+    }
+
+    /// <summary>
+    /// The condition is resolved without failing the project, but it is a project-file defect that costs the user a
+    /// declaration, so it must be reported where the user can see it.
+    /// </summary>
+    [Fact]
+    public void DesignTimePipelineReportsTheDuplicatePath()
+    {
+        var additionalServices = new AdditionalServiceCollection();
+        additionalServices.AddGlobalService<IUserDiagnosticRegistrationService>( new TestUserDiagnosticRegistrationService() );
+
+        using var testContext = this.CreateTestContext( additionalServices );
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (compilation, first, _) = CreateCompilationWithDuplicatePath( testContext );
+
+        var analyzer = new TheDiagnosticAnalyzer( factory.ServiceProvider );
+
+        var analysisContext = new TestSemanticModelAnalysisContext( compilation.GetSemanticModel( first ), testContext.ProjectOptions );
+
+        analyzer.AnalyzeSemanticModel( analysisContext );
+
+        Assert.Contains(
+            analysisContext.ReportedDiagnostics,
+            d => d.Id == "LAMA0307" && d.GetMessage().ContainsOrdinal( _duplicatePath ) );
+    }
+
+    /// <summary>
+    /// <see cref="PartialCompilation.Update"/> resolved the tree a <c>SyntaxTreeTransformation</c> replaces by its
+    /// path, while <c>Compilation.ReplaceSyntaxTree</c>, which it calls, resolves it by identity. The transformation
+    /// carries <c>OldTree</c>, so the identity is available and the path lookup was unnecessary. Replacing the tree
+    /// that represents the document must update the index and the compilation consistently.
+    /// </summary>
+    [Fact]
+    public void UpdateReplacesTheNamedTree()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, first, second) = CreateCompilationWithDuplicatePath( testContext );
+
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, new[] { first, second } );
+
+        var tree = Assert.Single( partialCompilation.SyntaxTreeCollection );
+
+        var replacement = SyntaxFactory.ParseSyntaxTree(
+            "public class Replaced { }",
+            path: _duplicatePath,
+            options: testContext.GetCompilationParseOptions() );
+
+        var updated = partialCompilation.Update( new[] { SyntaxTreeTransformation.ReplaceTree( tree, replacement ) } );
+
+        Assert.Contains( replacement, updated.SyntaxTreeCollection );
+
+        Assert.Equal(
+            updated.Compilation.SyntaxTrees.OrderBy( t => t.ToString() ),
+            updated.SyntaxTreeCollection.OrderBy( t => t.ToString() ) );
+    }
+
+    /// <summary>
+    /// A transformation that names a syntax tree the partial compilation does not hold must be rejected where it is
+    /// named. Under the one-document model, a tree that lost its path to an earlier tree is not part of the analysed
+    /// compilation, so replacing it is a programming error rather than an operation with an ambiguous result.
+    /// </summary>
+    [Fact]
+    public void UpdateRejectsATreeThatIsNotInTheCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var (compilation, first, second) = CreateCompilationWithDuplicatePath( testContext );
+
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, new[] { first, second } );
+
+        var absentTree = partialCompilation.SyntaxTreeCollection.Contains( first ) ? second : first;
+
+        var replacement = SyntaxFactory.ParseSyntaxTree(
+            "public class Replaced { }",
+            path: _duplicatePath,
+            options: testContext.GetCompilationParseOptions() );
+
+        Assert.Throws<KeyNotFoundException>(
+            () => partialCompilation.Update( new[] { SyntaxTreeTransformation.ReplaceTree( absentTree, replacement ) } ) );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DuplicateSyntaxTreePathTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/DuplicateSyntaxTreePathTests.cs
@@ -87,7 +87,7 @@ public sealed class DuplicateSyntaxTreePathTests : UnitTestClass
 
         var index = compilation.GetIndexedSyntaxTrees();
 
-        Assert.True( index.ContainsKey( _duplicatePath ) );
+        Assert.True( index.ContainsKey( DocumentKey.FromPath( _duplicatePath ) ) );
     }
 
     /// <summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/IntroducedSyntaxTreeOwnershipTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/IntroducedSyntaxTreeOwnershipTests.cs
@@ -1,0 +1,135 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.DesignTime.Pipeline;
+using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Collections;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Extensibility;
+using Metalama.Framework.Engine.HierarchicalOptions;
+using Metalama.Framework.Engine.Pipeline;
+using Metalama.Framework.Engine.Transformations;
+using Metalama.Framework.Options;
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
+
+/// <summary>
+/// Covers the third site named by https://github.com/metalama/Metalama/issues/1742,
+/// <c>DesignTimeAspectPipelineResult.Update</c>, which throws
+/// <see cref="AssertionFailedException"/> when the same introduced syntax tree name arrives twice.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The site is worth separating from the path-uniqueness family, because it is not fixed by making the path index
+/// tolerant. <c>Update</c> un-indexes the previous results by the <em>source path</em> they were filed under, and
+/// re-indexes the new introductions by their <em>name</em>. The name comes from
+/// <c>DesignTimeSyntaxTreeGenerator.GetUniqueFilenameForType</c>, which renders the target type and never the path.
+/// The two keys are therefore independent, and the pass is not a transaction: when a name moves from one source path
+/// to another between two runs, only the new path is un-indexed, the entry the old path left behind survives, and
+/// <c>TryAdd</c> fails.
+/// </para>
+/// <para>
+/// The name is deterministic; its ownership is not. A partial type whose primary declaration moves between files is
+/// enough, and two trees sharing a path make it routine, because which of them represents the path in the
+/// path-keyed result builders is not stable across compilations.
+/// </para>
+/// <para>
+/// The test drives <c>Update</c> directly, as <see cref="SplitResultsByTreePathLookupTests"/> does, because which
+/// trees the pipeline considers dirty is a function of the change graph and not something a test can dictate.
+/// </para>
+/// </remarks>
+public sealed class IntroducedSyntaxTreeOwnershipTests : UnitTestClass
+{
+    public IntroducedSyntaxTreeOwnershipTests( ITestOutputHelper testOutput ) : base( testOutput ) { }
+
+    private const string _aspectCode = """
+                                       using Metalama.Framework.Aspects;
+
+                                       public class Aspect : TypeAspect { }
+                                       """;
+
+    private const string _firstCode = "public partial class TargetClass { }";
+
+    private const string _secondCode = "public partial class TargetClass { }";
+
+    private const string _introducedName = "TargetClass.cs";
+
+    /// <summary>
+    /// The same introduced name is filed first under <c>first.cs</c> and then under <c>second.cs</c>, which is what
+    /// happens when the primary declaration of a partial type moves between the two files. The second update must
+    /// succeed and the index must name the tree the second run produced.
+    /// </summary>
+    [Fact]
+    public void IntroducedNameChangesOwningPath()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var compilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["aspect.cs"] = _aspectCode, ["first.cs"] = _firstCode, ["second.cs"] = _secondCode } );
+
+        Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out var executed ) );
+
+        var firstTree = compilation.SyntaxTrees.Single( t => t.FilePath == "first.cs" );
+        var secondTree = compilation.SyntaxTrees.Single( t => t.FilePath == "second.cs" );
+
+        var afterFirst = Update( testContext, executed.Result, compilation, firstTree );
+
+        Assert.True( afterFirst.IntroducedSyntaxTrees.ContainsKey( _introducedName ) );
+
+        var afterSecond = Update( testContext, afterFirst, compilation, secondTree );
+
+        Assert.Equal( secondTree, afterSecond.IntroducedSyntaxTrees[_introducedName].SourceSyntaxTree );
+    }
+
+    /// <summary>
+    /// Files a result that introduces a tree named <see cref="_introducedName"/> whose source is
+    /// <paramref name="sourceTree"/>, over a partial compilation restricted to that tree, which is the state the
+    /// pipeline is in when only that file is dirty.
+    /// </summary>
+    private static DesignTimeAspectPipelineResult Update(
+        TestContext testContext,
+        DesignTimeAspectPipelineResult previous,
+        Compilation compilation,
+        SyntaxTree sourceTree )
+    {
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, sourceTree );
+
+        var generatedTree = SyntaxFactory.ParseSyntaxTree(
+            "public partial class TargetClass { }",
+            path: _introducedName,
+            options: testContext.GetCompilationParseOptions() );
+
+        var pipelineResults = new DesignTimePipelineExecutionResult(
+            partialCompilation.SyntaxTreeCollection,
+            ImmutableArray.Create( new IntroducedSyntaxTree( _introducedName, sourceTree, generatedTree ) ),
+            ImmutableUserDiagnosticList.Empty,
+            ImmutableArray<InheritableAspectInstance>.Empty,
+            ImmutableArray<KeyValuePair<HierarchicalOptionsKey, IHierarchicalOptions>>.Empty,
+            ImmutableArray<ITransitivePipelineContributor>.Empty,
+            ImmutableArray<IAspectInstance>.Empty,
+            ImmutableArray<ITransformationBase>.Empty,
+            ImmutableDictionaryOfArray<IRef<IDeclaration>, AnnotationInstance>.Empty );
+
+        var projectVersion = new DesignTimeProjectVersion(
+            new TestProjectVersion( compilation ),
+            ImmutableArray<DesignTimeProjectReference>.Empty,
+            DesignTimeAspectPipelineStatus.Default );
+
+        return previous.Update( partialCompilation, projectVersion, pipelineResults, previous.Configuration.AssertNotNull() );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/PartialCompilationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/PartialCompilationTests.cs
@@ -149,7 +149,7 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline
 
             var compilation = testContext.CreateCSharpCompilation( code );
             var partialCompilation = PartialCompilation.CreatePartial( compilation, compilation.SyntaxTrees[0] );
-            Assert.Single( partialCompilation.SyntaxTrees );
+            Assert.Single( partialCompilation.SyntaxTreeCollection );
         }
 
         [Fact]
@@ -169,14 +169,14 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline
 
             // Test the initial compilation.
             const string path1 = "1.cs";
-            Assert.Single( partialCompilation1.SyntaxTrees );
+            Assert.Single( partialCompilation1.SyntaxTreeCollection );
             Assert.Empty( partialCompilation1.ModifiedSyntaxTrees );
 
             // Add a syntax tree.
             var partialCompilation2 = (PartialCompilation) partialCompilation1.AddSyntaxTrees(
                 CSharpSyntaxTree.ParseText( "", path: path1, options: SupportedCSharpVersions.DefaultParseOptions ) );
 
-            Assert.Equal( 2, partialCompilation2.SyntaxTrees.Count );
+            Assert.Equal( 2, partialCompilation2.SyntaxTreeCollection.Count );
             Assert.Single( partialCompilation2.ModifiedSyntaxTrees );
             Assert.Same( initialCompilation, partialCompilation2.InitialCompilation );
             Assert.Null( partialCompilation2.ModifiedSyntaxTrees[path1].OldTree );
@@ -185,7 +185,7 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline
             var partialCompilation3 = (PartialCompilation) partialCompilation2.AddSyntaxTrees(
                 CSharpSyntaxTree.ParseText( "", path: "2.cs", options: SupportedCSharpVersions.DefaultParseOptions ) );
 
-            Assert.Equal( 3, partialCompilation3.SyntaxTrees.Count );
+            Assert.Equal( 3, partialCompilation3.SyntaxTreeCollection.Count );
             Assert.Equal( 2, partialCompilation3.ModifiedSyntaxTrees.Count );
             Assert.Null( partialCompilation3.ModifiedSyntaxTrees[path1].OldTree );
             Assert.Same( initialCompilation, partialCompilation3.InitialCompilation );
@@ -195,7 +195,7 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline
                 _ => new Rewriter(),
                 ServiceProvider<IProjectService>.Empty.WithService( new SingleThreadedTaskRunner() ) );
 
-            Assert.Equal( 3, partialCompilation4.SyntaxTrees.Count );
+            Assert.Equal( 3, partialCompilation4.SyntaxTreeCollection.Count );
             Assert.Equal( 3, partialCompilation4.ModifiedSyntaxTrees.Count );
             Assert.Null( partialCompilation4.ModifiedSyntaxTrees[path1].OldTree );
             Assert.Same( initialCompilation, partialCompilation4.InitialCompilation );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreePathLookupTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreePathLookupTests.cs
@@ -90,19 +90,19 @@ public sealed class SplitResultsByTreePathLookupTests : UnitTestClass
         var targetTree = compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" );
         var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
 
-        Assert.DoesNotContain( "base.cs", partialCompilation.SyntaxTrees.Keys );
+        Assert.DoesNotContain( "base.cs", partialCompilation.SyntaxTreeCollection.SelectAsReadOnlyCollection( t => t.FilePath ) );
 
         var updated = Update( executed, compilation, partialCompilation, inheritableAspect );
 
         // The aspect must survive the update. It is carried by the result of base.cs, which the run that did include
         // that tree produced and which this update must leave alone: overwriting it with a result holding the aspect
         // and nothing else would drop the diagnostics and introductions of a file that has not changed.
-        Assert.Contains( inheritableAspect, updated.SyntaxTreeResults["base.cs"].InheritableAspects );
+        Assert.Contains( inheritableAspect, updated.SyntaxTreeResults[DocumentKey.FromPath( "base.cs" )].InheritableAspects );
         Assert.Contains( inheritableAspect, updated.GetInheritableAspects( "Aspect" ) );
 
         AssertEx.EolInvariantEqual(
-            DumpSyntaxTreeResult( executed.Result.SyntaxTreeResults["base.cs"] ),
-            DumpSyntaxTreeResult( updated.SyntaxTreeResults["base.cs"] ) );
+            DumpSyntaxTreeResult( executed.Result.SyntaxTreeResults[DocumentKey.FromPath( "base.cs" )] ),
+            DumpSyntaxTreeResult( updated.SyntaxTreeResults[DocumentKey.FromPath( "base.cs" )] ) );
     }
 
     /// <summary>
@@ -120,11 +120,11 @@ public sealed class SplitResultsByTreePathLookupTests : UnitTestClass
         var baseTree = compilation.SyntaxTrees.Single( t => t.FilePath == "base.cs" );
         var partialCompilation = PartialCompilation.CreatePartial( compilation, baseTree );
 
-        Assert.Contains( "base.cs", partialCompilation.SyntaxTrees.Keys );
+        Assert.Contains( "base.cs", partialCompilation.SyntaxTreeCollection.SelectAsReadOnlyCollection( t => t.FilePath ) );
 
         var updated = Update( executed, compilation, partialCompilation, inheritableAspect );
 
-        Assert.Contains( inheritableAspect, updated.SyntaxTreeResults["base.cs"].InheritableAspects );
+        Assert.Contains( inheritableAspect, updated.SyntaxTreeResults[DocumentKey.FromPath( "base.cs" )].InheritableAspects );
         Assert.Contains( inheritableAspect, updated.GetInheritableAspects( "Aspect" ) );
     }
 
@@ -157,7 +157,7 @@ public sealed class SplitResultsByTreePathLookupTests : UnitTestClass
         InheritableAspectInstance inheritableAspect )
     {
         var pipelineResults = new DesignTimePipelineExecutionResult(
-            partialCompilation.SyntaxTrees,
+            partialCompilation.SyntaxTreeCollection,
             ImmutableArray<IntroducedSyntaxTree>.Empty,
             ImmutableUserDiagnosticList.Empty,
             ImmutableArray.Create( inheritableAspect ),

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SyntaxTreeChangeMergeTests.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.DesignTime.Pipeline;
 using Metalama.Framework.DesignTime.Pipeline.Dependencies;
 using Metalama.Framework.DesignTime.Pipeline.Diff;
@@ -31,7 +32,7 @@ public sealed class SyntaxTreeChangeMergeTests
         in SyntaxTreeVersion oldVersion,
         in SyntaxTreeVersion newVersion,
         string path = "code.cs" )
-        => new( path, changeKind, compileTimeChangeKind, oldVersion, newVersion );
+        => new( DocumentKey.FromPath( path ), changeKind, compileTimeChangeKind, oldVersion, newVersion );
 
     // --- SyntaxTreeChangeKind transition tests ---
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/TransitiveManifestValidatorChannelTests.cs
@@ -89,7 +89,7 @@ public sealed class TransitiveManifestValidatorChannelTests : UnitTestClass
         var partialCompilation = PartialCompilation.CreateComplete( compilation );
 
         var pipelineResults = new DesignTimePipelineExecutionResult(
-            partialCompilation.SyntaxTrees,
+            partialCompilation.SyntaxTreeCollection,
             ImmutableArray<IntroducedSyntaxTree>.Empty,
             ImmutableUserDiagnosticList.Empty,
             ImmutableArray<InheritableAspectInstance>.Empty,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Linker/LinkerTriviaPreservationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Linker/LinkerTriviaPreservationTests.cs
@@ -114,7 +114,7 @@ public sealed class LinkerTriviaPreservationTests : UnitTestClass
                 continue;
             }
 
-            var outputText = string.Concat( result.Value.SyntaxTrees.Values.Select( t => t.GetRoot().ToFullString() ) );
+            var outputText = string.Concat( result.Value.SyntaxTreeCollection.SelectAsReadOnlyCollection( t => t.GetRoot().ToFullString() ) );
             var occurrences = CountOccurrences( outputText, probeId );
 
             if ( occurrences != 1 )

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/ReferenceIndex/InboundReferenceIndexTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/ReferenceIndex/InboundReferenceIndexTests.cs
@@ -357,7 +357,7 @@ public sealed class InboundReferenceIndexTests : UnitTestClass
             new ReferenceIndexerOptions( validators ),
             SymbolEqualityComparer.Default );
 
-        foreach ( var syntaxTree in compilation.PartialCompilation.SyntaxTrees.Values )
+        foreach ( var syntaxTree in compilation.PartialCompilation.SyntaxTreeCollection )
         {
             builder.IndexSyntaxTree( syntaxTree, compilation.CompilationContext.SemanticModelProvider );
         }


### PR DESCRIPTION
Fixes #1742.

Metalama indexed the syntax trees of a compilation by `SyntaxTree.FilePath` and assumed the path identified the tree. Roslyn makes no such guarantee. The command-line compiler deduplicates source files itself (`CS2002`), but Roslyn Workspaces has no equivalent step, so overlapping globs, an explicit `Compile` item repeating a glob, `Link` metadata, or a shared project all produce two trees with one path out of an otherwise valid project.

**Seven sites** made the assumption and disagreed about it: two tolerated a duplicate silently, one tolerated it with a log warning, and four threw. The design-time pipeline therefore died on its first execution for the project and kept dying, because the throw happened inside a `WeakCache` factory.

## The model

A duplicated path is **one document included twice**, which is the conclusion the command-line compiler reaches. The alternative cannot be represented: every design-time consumer addresses a document by path, from the Roslyn analyzer callback that carries only a `SemanticModel` to the cross-process preview contract, so a second document at the same path could never be asked for.

## What changed

**Resolved once, at the boundary.** `RemoveDuplicatePathSyntaxTrees` drops every tree whose path an earlier tree already holds, applied in the diff layer and in `PartialCompilation.CreateComplete`/`CreatePartial`. It returns its argument without allocating when nothing is duplicated, which is every compilation the command-line compiler produces.

This matters more than making the index tolerant. `LinkerInjectionStep` rewrites the trees the index exposes; a tree left in the compilation but absent from the index keeps its declarations in the code model and is never rewritten, so aspects would apply to some declarations of the project and silently not to others. `EverySyntaxTreeIsRewritten` pins that.

**Reported as `LAMA0307`**, once, on the file that keeps the path. The condition costs the user a declaration, so it is not merely resolved.

**Two keys for two lifetimes.** Within a compilation, membership and enumeration are keyed by syntax tree identity. Across compilations, every design-time cache is keyed by the new `DocumentKey`: ordinal comparison baked in, hash cached on construction, and distinct from the introduced-tree and hint-name key spaces, which is where the third crash came from.

**An ordering bug the tests uncovered.** `DesignTimeAspectPipelineResult.Update` interleaved un-indexing an old result with indexing a new one, per tree. Introduced trees are keyed by a name rendered from the target type while the results carrying them are keyed by a source path, so when a partial type's primary declaration moves between files the old owner's un-index deleted the entry the new owner had just written. The pass is now two-phase.

**Incidental fixes.** `GetClosure.AddTree` was quadratic in the tree count. `PartialCompilation.Update` resolved the replaced tree by path while `Compilation.ReplaceSyntaxTree` resolves it by identity. `TransformedPathGenerator` threw on a collision of `(file name, low 32 bits of the content hash)` with a message asserting the two files held identical code, which is wrong in the case that reaches production; it now resolves the collision with a deterministic ordinal.

## API

`IPartialCompilation` gains `[InternalImplement]`, which it should always have had: only `PartialCompilation` implements it and weavers only consume it.

| Member | State |
|---|---|
| `SyntaxTrees` | `[Obsolete]`, unchanged in type and behaviour |
| `SyntaxTreeCollection` | new, `IReadOnlyCollection<SyntaxTree>` |
| `TryGetSyntaxTree( DocumentKey, out SyntaxTree? )` | new |

Every call site in the repository is migrated. `Metalama.Framework.DesignTime.Contracts` is untouched.

## Tests

18 new tests across `DuplicateSyntaxTreePathTests`, `IntroducedSyntaxTreeOwnershipTests` and `TransformedPathGeneratorTests`, written red first: all three exception texts quoted in the issue were reproduced verbatim before the fix.

| Suite (net8.0) | Result |
|---|---|
| `Tests.UnitTests` | 2243 passed, 0 failed |
| `Tests.AspectTests` | 2271 passed, 0 failed |
| `Tests.TemplateTests` | 317 passed, 0 failed |
| `Tests.LinkerTests` | 189 passed, 0 failed |

Whole solution builds warning-free on all target frameworks.

— Claude for @gfraiteur
