### PR TITLE
Release old Roslyn compilations at design time

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,15 @@ The testing strategies and every test suite (unit, aspect, template, linker, sta
 - **Unit tests** inherit `UnitTestClass` and use `CreateTestContext()` / `CreateCompilationModel(code)`.
 - To emit output from a test, use `ITestOutputService`; for deterministic timing use `ITestSynchronizationProvider` sync points, never hardcoded delays.
 
+## Design-Time Memory
+
+The rules that keep the design-time code from accumulating memory are documented in `Metalama.Framework/docs/design-time-memory.md`. Read it before adding a field, a cache, a background task or an event handler to `Metalama.Framework.DesignTime`, and before storing anything derived from the code model in an object that outlives a single request. The core rule:
+
+- The analysis process is long-lived and Roslyn produces a **new `Compilation` per keystroke**. An object that outlives a single request must not strongly reference a `Compilation`, `SyntaxTree`, `SemanticModel`, `ISymbol`, `CompilationModel` or `PartialCompilation`, nor anything that transitively reaches one, apart from the single most recent version of the project.
+- Persist declarations as durable references (`IRef.ToDurable()`), and key caches by file path rather than by syntax tree or compilation instance.
+- Never pass a cancellation token to `Task.Run`: when the token is already signalled the delegate never runs, so any `finally` that removes the task from a pending-work collection never executes and the closure, with everything it captured, is retained forever.
+- The guard suite is `Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/`; its `RetentionPathFinder` reports the chain of fields that retains an object when an assertion fails.
+
 ## Syntax Generation and Simplification
 
 The syntax generation pipeline intentionally produces over-specified syntax (redundant casts, fully-qualified type names, explicit `new DelegateType(methodGroup)` wrappers) to ensure correctness. The `CodeFormatter` pipeline then simplifies in context:

--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -1,0 +1,176 @@
+# Design-Time Memory: What May Hold a Compilation
+
+This document describes the rules that keep the design-time code from accumulating memory, and the mechanisms the
+codebase provides to follow them. It exists because a violation of these rules does not fail a test, does not throw,
+and does not degrade anything measurably on a small project. It surfaces days later as a report that Visual Studio
+consumes several gigabytes after a few hours of editing, on a solution nobody on the team has.
+
+Read this before adding a field, a cache, a background task or an event handler to `Metalama.Framework.DesignTime`,
+and before storing anything derived from the code model in an object that outlives a single request.
+
+## Why design time is different
+
+At compile time the process handles one compilation and exits. Retaining it costs nothing.
+
+At design time the process is the Roslyn out-of-process analysis service, which lives for as long as the solution is
+open, and Roslyn hands us a **new** `Compilation` on essentially every keystroke. It releases the previous one as
+soon as the components it hosts do. Whatever we still reference, it cannot release.
+
+The unit of the leak is therefore not a byte or a node, it is a version of the project. A single retained
+`Compilation` pins:
+
+- every `SyntaxTree` of the project, and therefore the full text and the full green node tree of every file;
+- the symbol tables built from it, and the metadata symbol tables of every referenced assembly;
+- its `SemanticModel` cache, and the `CompilationContext` and `RefFactory` caches Metalama built on top of it.
+
+Tens of megabytes on a medium project. Retain one per keystroke and the arithmetic explains the reports exactly.
+
+## The rule
+
+> An object that outlives a single request must not hold a strong reference to a `Compilation`, a `SyntaxTree`, a
+> `SemanticModel`, an `ISymbol`, a `CompilationModel`, a `PartialCompilation`, or anything that transitively reaches
+> one, with the single exception of the most recent version of the project.
+
+The exception is what makes the design-time pipeline possible at all: the pipeline serves the results of the version
+it has most recently analysed, so it must keep that version. One version. Not two, and above all not one per edit.
+
+It is useful to classify every field by the lifetime of the object that declares it.
+
+| Scope of the declaring object | May hold a compilation-bound object? |
+|---|---|
+| A single request (locals, parameters, a `PartialCompilation` being processed) | Yes, freely. |
+| The current version of a project (`PipelineState.ProjectVersion`) | Yes, exactly one version. |
+| A project (`DesignTimeAspectPipeline`, a `ProjectSourceGenerator`) | No. |
+| The process (a static field, an `IGlobalService`, an analyzer or generator instance) | No. |
+
+The last row deserves emphasis: Roslyn keeps **one instance** of a `DiagnosticAnalyzer` or an `IIncrementalGenerator`
+alive for the lifetime of the process. Any instance field on such a type that accumulates is a process-lifetime leak.
+
+## The mechanisms
+
+### Key results by path, not by instance
+
+`DesignTimeAspectPipelineResult.SyntaxTreeResults` is an `ImmutableDictionary<string, SyntaxTreePipelineResult>` keyed
+by **file path**. The number of entries is therefore bounded by the number of files, and a new version of a file
+replaces the entry of the old one rather than adding to it. A dictionary keyed by `SyntaxTree` would be bounded by
+the number of edits instead.
+
+The same reasoning applies to `ProjectVersion.SyntaxTrees` and to the dependency graph, which store paths.
+
+### Make persisted references durable
+
+A reference obtained from the code model is bound to the compilation it came from: it holds the `ISymbol` and it
+holds the `RefFactory`, which reaches `CompilationContext.Compilation`. Such a reference is correct and fast inside a
+request, and is a retention as soon as it is stored.
+
+`IRef<T>.ToDurable()` converts it to an `IDurableRef<T>`, backed by a `SerializableDeclarationId` or a
+`SerializableTypeId`, which reaches nothing. Resolve it later with `GetTarget( compilation )` against whichever
+compilation is current.
+
+This is why `SyntaxTreePipelineResult` documents itself as *compilation-independent and cacheable*: the pipeline
+re-analyses only the syntax trees that changed and carries the results of every other file forward from an earlier
+run, so a compilation-bound reference in one of them pins the version it was computed in for as long as the project
+stays open. `InheritableAspectInstance` and `FabricDriver` both convert their target declaration for this reason.
+
+When adding a member to a type that is stored in a `SyntaxTreePipelineResult`, the question to ask is not "is this
+convenient to keep" but "does this reach a `Compilation`". Note that a `Microsoft.CodeAnalysis.Diagnostic` does: it
+holds a `Location`, which holds its source tree.
+
+### Understand `ConditionalWeakTable` before relying on it
+
+`WeakCache<TKey, TValue>` wraps a `ConditionalWeakTable`, and the diff subsystem is built on it. The semantics are
+ephemeron semantics, and they are easy to get subtly wrong:
+
+- The table does **not** keep its keys alive. A compilation used only as a key is collectable.
+- The table keeps a value alive **only while its key is alive**.
+- A value may reference **its own key** freely. That is not a leak, and the garbage collector resolves it correctly.
+  `ProjectVersionProvider`'s cache relies on this: the `ChangeList` stored for a compilation holds a `ProjectVersion`
+  whose `Compilation` is that same compilation.
+- A value that references a **different** object which is itself a key elsewhere extends that object's lifetime, and
+  the reasoning repeats from there. A value that reaches an *older* compilation therefore keeps the whole history
+  alive for as long as the newest entry is alive. This is the failure mode to look for in any cache keyed by
+  `Compilation`.
+
+### Hold "last known" pointers weakly, and say so
+
+Where a component wants the previous version only as an optimisation, it holds it weakly and tolerates its absence.
+The codebase marks such members with a `Dangerous` suffix, which is a warning to the reader that the value may be
+gone and that the caller is responsible for establishing that it is not:
+
+- `ProjectVersionProvider.Implementation._lastCompilationPerProject` is a
+  `Dictionary<ProjectKey, WeakReference<Compilation>>`.
+- `CompilationChanges.OldProjectVersionDangerous` and `ReferencedProjectChange.OldCompilationDangerous` are backed by
+  `WeakReference`.
+
+Prefer this over a strong reference whenever the value is a cache rather than a result.
+
+### Do not let a background task outlive what it captured
+
+This is the trap that costs the most, because the captured object is invisible in the source: a lambda that mentions
+`compilation` produces a closure object holding it, and whatever holds the delegate holds the compilation.
+
+Two rules follow.
+
+**A queue of pending work must remove an entry on every path that ends the work, including cancellation.** The
+canonical mistake is `Task.Run( action, cancellationToken )`: when the token is already signalled at the moment the
+thread pool would invoke the delegate, the runtime **does not invoke the delegate at all** and the task goes straight
+to the canceled state. Any bookkeeping written inside that delegate, such as a `finally` that removes the entry from
+a dictionary, never runs. Observe the token from **inside** the delegate instead, so that the delegate always runs
+and its `finally` always executes. `TaskBag.Enqueue` does this.
+
+**A `TaskCompletionSource` that is never completed retains the continuation of its awaiter**, and that continuation is
+the suspended state machine of the awaiting method, holding every parameter and local of that method. So a wait must
+be endable: register the cancellation for the whole duration of the `await`, not merely for the statement that
+publishes the source, and use `TrySetCanceled` rather than `SetCanceled` because the source may already have been
+completed by the event being waited for.
+
+### Unsubscribe, or subscribe weakly
+
+An event handler holds its target. `AnalysisProcessEventHub` exposes its high-traffic events through
+`WeakEvent<T>` and `AsyncWeakEvent<T>`, which hold subscribers weakly and compact their list. Where a plain event is
+used instead, the subscriber must unsubscribe in `Dispose`, and the event must carry only values, such as a
+`ProjectKey`, rather than compilation-bound objects.
+
+## Testing it
+
+`Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/` contains the suite that guards these rules.
+Add to it whenever a change touches something the rules cover.
+
+The shape of a test is: build a project, run the design-time pipeline, apply a number of edits to **run-time** code,
+force a full collection, and assert on the liveness of weak references to the versions that were superseded.
+
+Three parts of the harness matter more than the tests themselves.
+
+- **`MemoryLeakAssert`** reports, on failure, the chain of fields that retains the object, computed by
+  `RetentionPathFinder` from the objects a design-time host keeps alive. An assertion that says only "something
+  retains this compilation" is nearly useless; one that names the field is a fix.
+- **`RetentionPathFinder` applies ephemeron marking**, exactly as described above: it follows the value of a
+  conditional-weak-table entry only once the key of that entry has been proven reachable by strong references, and it
+  never reports a key as retained through the table. Without that rule it reports paths that are circular, or paths
+  along which the collector is in fact free to reclaim the object.
+- **`MemoryLeakAssertSelfTests`** plants a retention deliberately and requires the assertions to catch it and name the
+  field. A suite of liveness tests that all pass is indistinguishable from a suite whose assertions never fire, so
+  this positive control is what gives the rest of the suite its value.
+
+Two practical points when writing such a test.
+
+**Never let a compilation reach a local variable of the test method.** A debug build keeps every local alive until the
+end of the method that declares it, so a single `var compilation = ...` in the test body defeats the assertion.
+Confine every strong reference to a helper marked `[MethodImpl( MethodImplOptions.NoInlining )]` that returns only a
+`WeakReference`. `DesignTimeEditingSimulator` is built around this constraint and never hands a compilation back.
+
+**A single `GC.Collect()` is not enough.** An object with a finalizer is reclaimed only by a later collection, so
+`GarbageCollectionHelper.Collect` performs several blocking, compacting rounds with `WaitForPendingFinalizers`
+between them.
+
+Finally, note what a passing test does **not** prove. Both of the largest defects found in
+[#1793](https://github.com/metalama/Metalama/issues/1793) required *cancellation* to trigger. A scenario that submits
+one version at a time and waits for each to be analysed never cancels anything and shows no growth at all, which is
+why the growth was so hard to reproduce outside a real editing session. When testing a component that cancels
+superseded work, the test must cancel too.
+
+## Related documents
+
+- `pipeline.md` for the structure of the pipeline whose state these rules constrain.
+- `testing.md` for the test suites and how to run them.
+- `compilation-model.md` for what a `CompilationModel` holds, and therefore what a reference to one costs.

--- a/Metalama.Framework/docs/testing.md
+++ b/Metalama.Framework/docs/testing.md
@@ -97,6 +97,8 @@ Some unit tests do run the real pipeline — e.g. `Aspects/AspectTestBase.cs` ru
 
 **Analyzer tests.** [`Metalama.Framework.Engine.Analyzers.Tests`](../src/tests/Metalama.Framework.Engine.Analyzers.Tests) (net8.0 only, no Roslyn variant) tests the internal Roslyn analyzers that police Metalama's own source (e.g. `KindCheckOptimizationAnalyzer`/`LAMA0860`). It does not use `UnitTestClass`; it builds raw `CSharpCompilation`s and runs `compilation.WithAnalyzers(...)`.
 
+**Memory-retention tests.** `DesignTime/Pipeline/MemoryLeaks` holds the suite that asserts that a design-time editing session releases the versions of the project it has superseded. These tests simulate an editing session and assert on the liveness of weak references after a forced collection, so they follow conventions of their own: no compilation may reach a local of the test method, the collection must be forced in several rounds, and a failure reports the chain of fields that retains the object. The rules they enforce, and the reasons for those conventions, are in [`design-time-memory.md`](design-time-memory.md). Read it before extending the suite.
+
 ## Aspect tests
 
 Aspect tests are the primary way the transformation behavior of the framework is verified. Each test is a **single C# file** placed anywhere under a project's `Tests/` tree; the framework compiles it through Metalama and compares the transformed output to a checked-in golden file.

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineFactory.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineFactory.cs
@@ -38,7 +38,19 @@ public class DesignTimeAspectPipelineFactory : IDisposable, IAspectPipelineConfi
     private readonly ConcurrentDictionary<ProjectKey, DesignTimeAspectPipeline> _pipelinesByProjectKey = new();
 
     private readonly ILogger _logger;
-    private readonly ConcurrentQueue<TaskCompletionSource<DesignTimeAspectPipeline>> _newPipelineListeners = new();
+
+    /// <summary>
+    /// The callers that are waiting for the pipeline of a project that does not exist yet, indexed by an arbitrary
+    /// identifier so that a caller can remove its own entry when it stops waiting.
+    /// </summary>
+    /// <remarks>
+    /// A queue was used previously, but its entries were completed by enumerating it and were never dequeued, so the
+    /// collection grew for the lifetime of the process and an entry that was never completed retained the suspended
+    /// state machine of its waiter, and therefore the compilation that waiter had been given. See issue #1793.
+    /// </remarks>
+    private readonly ConcurrentDictionary<long, TaskCompletionSource<DesignTimeAspectPipeline>> _newPipelineListeners = new();
+
+    private long _nextPipelineListenerId;
 
     private readonly CancellationToken _globalCancellationToken;
     private readonly IMetalamaProjectClassifier _projectClassifier;
@@ -165,7 +177,9 @@ public class DesignTimeAspectPipelineFactory : IDisposable, IAspectPipelineConfi
                 throw new AssertionFailedException( $"The pipeline '{projectKey}' has already been created." );
             }
 
-            foreach ( var listener in this._newPipelineListeners )
+            // The entries are removed by the waiters themselves, in the finally block of GetPipelineAndWaitAsync,
+            // because a waiter must also remove its entry when it gives up because its token was cancelled.
+            foreach ( var listener in this._newPipelineListeners.Values )
             {
                 listener.TrySetResult( pipeline );
             }
@@ -445,18 +459,33 @@ public class DesignTimeAspectPipelineFactory : IDisposable, IAspectPipelineConfi
 
             this._logger.Trace?.Log( $"Awaiting for the pipeline '{projectKey}'." );
 
-            var taskCompletionSource = new TaskCompletionSource<DesignTimeAspectPipeline>();
+            // The continuations run asynchronously because the listeners are completed while the lock on
+            // _pipelinesByProjectKey is held, and a synchronous continuation would run arbitrary code under that lock.
+            var taskCompletionSource = new TaskCompletionSource<DesignTimeAspectPipeline>( TaskCreationOptions.RunContinuationsAsynchronously );
 
+            var listenerId = Interlocked.Increment( ref this._nextPipelineListenerId );
+
+            // The registration covers the whole wait, not only the registration of the listener. It previously
+            // covered only the latter, so a cancelled token did not end the wait and the caller was never released.
+            // TrySetCanceled is used rather than SetCanceled because the listener may already have been completed by
+            // the creation of a pipeline. See issue #1793.
 #if NET6_0_OR_GREATER
-            await using ( cancellationToken.Register( () => taskCompletionSource.SetCanceled( cancellationToken ) ) )
+            await using ( cancellationToken.Register( () => taskCompletionSource.TrySetCanceled( cancellationToken ) ) )
 #else
-            using ( cancellationToken.Register( () => taskCompletionSource.SetCanceled() ) )
+            using ( cancellationToken.Register( () => taskCompletionSource.TrySetCanceled() ) )
 #endif
             {
-                this._newPipelineListeners.Enqueue( taskCompletionSource );
-            }
+                this._newPipelineListeners[listenerId] = taskCompletionSource;
 
-            await taskCompletionSource.Task;
+                try
+                {
+                    await taskCompletionSource.Task;
+                }
+                finally
+                {
+                    this._newPipelineListeners.TryRemove( listenerId, out _ );
+                }
+            }
         }
 
         return pipeline;

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/TaskBag.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/TaskBag.cs
@@ -56,10 +56,12 @@ public sealed class TaskBag
 
                     await asyncAction();
                 }
-                catch ( OperationCanceledException )
+                catch ( OperationCanceledException ) when ( cancellationToken.IsCancellationRequested )
                 {
-                    // Cancellation is the normal way for the caller to abandon work that a newer request has
-                    // superseded, therefore it is not reported as an exception.
+                    // Cancellation of the token given to this method is the normal way for the caller to abandon work
+                    // that a newer request has superseded, therefore it is not reported as an exception. The filter
+                    // restricts this to that token: an operation cancelled for any other reason, such as an inner
+                    // operation using a token of its own, still reaches the handler below.
                 }
                 catch ( Exception e )
                 {

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/TaskBag.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Utilities/TaskBag.cs
@@ -28,6 +28,19 @@ public sealed class TaskBag
         this._exceptionHandler = exceptionHandler.GetRequiredService<DesignTimeExceptionHandler>();
     }
 
+    /// <summary>
+    /// Runs an asynchronous action in the background and keeps track of it until it has completed.
+    /// </summary>
+    /// <remarks>
+    /// The cancellation token is not passed to <see cref="Task.Run(Func{Task})"/> and is observed from inside the
+    /// delegate instead. When a token is given to <see cref="Task.Run(Func{Task},CancellationToken)"/> and is
+    /// signalled before the thread pool invokes the delegate, the task goes directly to the canceled state and the
+    /// delegate never runs at all. The <c>finally</c> block below, which is what removes the entry from
+    /// <see cref="_pendingTasks"/>, is part of that delegate, so the entry would stay in the dictionary forever
+    /// together with the closure that produced it, and therefore with everything that closure captured. The callers
+    /// of this class enqueue one delegate per version of a compilation and cancel the previous one, so such an entry
+    /// retains a whole Roslyn compilation. See issue #1793.
+    /// </remarks>
     internal void Enqueue( Func<Task> asyncAction, CancellationToken cancellationToken = default )
     {
         var taskId = Interlocked.Increment( ref this._nextId );
@@ -39,7 +52,14 @@ public sealed class TaskBag
             {
                 try
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     await asyncAction();
+                }
+                catch ( OperationCanceledException )
+                {
+                    // Cancellation is the normal way for the caller to abandon work that a newer request has
+                    // superseded, therefore it is not reported as an exception.
                 }
                 catch ( Exception e )
                 {
@@ -53,8 +73,7 @@ public sealed class TaskBag
                         this._pendingTasks.TryRemove( taskId, out _ );
                     }
                 }
-            },
-            cancellationToken );
+            } );
 
         lock ( sync )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/InheritableAspectInstance.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/InheritableAspectInstance.cs
@@ -4,6 +4,7 @@
 
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
+using Metalama.Framework.Engine.CodeModel.References;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Immutable;
@@ -37,10 +38,23 @@ public sealed partial class InheritableAspectInstance : IAspectInstance, IAspect
 
     public int PredecessorDegree { get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="InheritableAspectInstance"/> class from an aspect instance of the
+    /// current compilation.
+    /// </summary>
+    /// <remarks>
+    /// The target declaration is converted to a durable reference. A reference obtained from the code model is bound
+    /// to the compilation it came from, through the symbol it holds and through its reference factory, and this class
+    /// is stored in the design-time results of a syntax tree, which the pipeline carries forward from one version of
+    /// the project to the next without re-analysing the file. A compilation-bound reference here therefore keeps the
+    /// compilation in which the aspect was found alive for as long as the project stays open. See issue #1793. The
+    /// reference is serialized as a declaration identifier in any case, so this only makes the in-memory form agree
+    /// with the serialized one.
+    /// </remarks>
     public InheritableAspectInstance( IAspectInstance aspectInstance )
     {
         var asPredecessor = (IAspectPredecessorImpl) aspectInstance;
-        this.TargetDeclaration = asPredecessor.TargetDeclaration;
+        this.TargetDeclaration = asPredecessor.TargetDeclaration.ToDurable();
         this.TargetDeclarationDepth = asPredecessor.TargetDeclarationDepth;
         this.Aspect = aspectInstance.Aspect;
         this._aspectClass = aspectInstance.AspectClass;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/DesignTimeEditingSimulator.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/DesignTimeEditingSimulator.cs
@@ -1,0 +1,173 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Pipeline;
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Simulates a design-time editing session: an initial compilation followed by an arbitrary number of edits, each of
+/// which produces a new <see cref="Compilation"/> that is then submitted to the design-time pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An edit is applied with <see cref="Compilation.ReplaceSyntaxTree"/> rather than by building a new compilation from
+/// the complete source, because that is what Roslyn does when the user types in the editor. The syntax trees of the
+/// files that were not edited therefore remain the same instances across versions, and only the edited tree and the
+/// <see cref="Compilation"/> itself are new. A test that rebuilt the whole compilation on each iteration would
+/// exaggerate the amount of garbage produced and would not reproduce the situation in which the leak is reported.
+/// </para>
+/// <para>
+/// The metadata references of the initial compilation are preserved for the same reason: Roslyn reuses reference
+/// objects across edits, and creating new ones would make every version differ in its references, which is a
+/// different scenario from the one under test.
+/// </para>
+/// </remarks>
+internal sealed class DesignTimeEditingSimulator
+{
+    private readonly TestContext _testContext;
+    private readonly TestDesignTimeAspectPipelineFactory _factory;
+    private readonly CSharpParseOptions _parseOptions;
+
+    /// <summary>
+    /// Gets the compilation that represents the current state of the simulated editor.
+    /// </summary>
+    /// <remarks>
+    /// The property is private for the same reason as <see cref="Edit"/>: a test that read it into a local variable
+    /// would keep that version of the compilation alive for the rest of its own method.
+    /// </remarks>
+    private Compilation CurrentCompilation { get; set; }
+
+    /// <summary>
+    /// Gets the number of edits applied since the session was created.
+    /// </summary>
+    public int EditCount { get; private set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DesignTimeEditingSimulator"/> class.
+    /// </summary>
+    /// <param name="testContext">The test context used to create compilations.</param>
+    /// <param name="factory">The pipeline factory that plays the role of the design-time host.</param>
+    /// <param name="assemblyName">The assembly name, which must be stable across edits so that every version maps to the same project.</param>
+    /// <param name="code">The initial content of the project, indexed by file name.</param>
+    public DesignTimeEditingSimulator(
+        TestContext testContext,
+        TestDesignTimeAspectPipelineFactory factory,
+        string assemblyName,
+        IReadOnlyDictionary<string, string> code )
+    {
+        this._testContext = testContext;
+        this._factory = factory;
+        this.CurrentCompilation = testContext.CreateCSharpCompilation( code, assemblyName: assemblyName );
+        this._parseOptions = (CSharpParseOptions) this.CurrentCompilation.SyntaxTrees.First().Options;
+    }
+
+    /// <summary>
+    /// Replaces the content of a single file, producing a new <see cref="Compilation"/> in the same way as Roslyn does
+    /// when the user types.
+    /// </summary>
+    /// <param name="fileName">The path of the file to replace, as given to the constructor.</param>
+    /// <param name="newContent">The new content of the file.</param>
+    /// <returns>The new compilation, which also becomes <see cref="CurrentCompilation"/>.</returns>
+    /// <remarks>
+    /// The method is private because a caller that stores the returned compilation in a local variable keeps that
+    /// version alive for the rest of its own method, which is precisely what these tests must avoid. Callers use
+    /// <see cref="ApplyEdit"/> or <see cref="EditAndExecute"/> instead.
+    /// </remarks>
+    private Compilation Edit( string fileName, string newContent )
+    {
+        var oldTree = this.CurrentCompilation.SyntaxTrees.Single(
+            t => string.Equals( t.FilePath, fileName, StringComparison.OrdinalIgnoreCase ) );
+
+        var newTree = CSharpSyntaxTree.ParseText( newContent, this._parseOptions, fileName, encoding: oldTree.Encoding );
+
+        this.CurrentCompilation = this.CurrentCompilation.ReplaceSyntaxTree( oldTree, newTree );
+        this.EditCount++;
+
+        return this.CurrentCompilation;
+    }
+
+    /// <summary>
+    /// Runs the design-time pipeline on <see cref="CurrentCompilation"/>, in the same way as the diagnostic analyzer
+    /// and the source generator do when Roslyn reports a new compilation.
+    /// </summary>
+    /// <remarks>
+    /// The result is intentionally not returned. Holding a result on the caller stack would keep the corresponding
+    /// compilation alive and would mask the very retention that the tests are looking for.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public void Execute()
+    {
+        if ( !this._factory.TryExecute( this._testContext.ProjectOptions, this.CurrentCompilation, default, out _ ) )
+        {
+            throw new InvalidOperationException(
+                $"The design-time pipeline failed on edit {this.EditCount}. A memory test requires a pipeline that runs successfully." );
+        }
+    }
+
+    /// <summary>
+    /// Applies an edit and runs the pipeline, without exposing the resulting compilation to the caller.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public void ApplyEdit( string fileName, string newContent )
+    {
+        this.Edit( fileName, newContent );
+        this.Execute();
+    }
+
+    /// <summary>
+    /// Applies an edit and runs the pipeline, returning a weak reference to the compilation that was analyzed.
+    /// </summary>
+    /// <remarks>
+    /// The compilation is never returned by a strong reference, so that the caller cannot accidentally keep it alive.
+    /// The method is not inlinable, so that the local variable holding the compilation belongs to a stack frame that
+    /// no longer exists when the caller resumes. This matters because a debug build keeps every local alive until the
+    /// end of the method that declares it.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public WeakReference EditAndExecute( string fileName, string newContent )
+    {
+        var compilation = this.Edit( fileName, newContent );
+        this.Execute();
+
+        return new WeakReference( compilation );
+    }
+
+    /// <summary>
+    /// Returns a weak reference to <see cref="CurrentCompilation"/>, without exposing a strong reference to it.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public WeakReference GetWeakReferenceToCurrentCompilation() => new( this.CurrentCompilation );
+
+    /// <summary>
+    /// Returns weak references to the syntax trees of <see cref="CurrentCompilation"/>, without exposing strong
+    /// references to them.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public WeakReference[] GetWeakReferencesToCurrentSyntaxTrees()
+        => this.CurrentCompilation.SyntaxTrees.Select( t => new WeakReference( t ) ).ToArray();
+
+    /// <summary>
+    /// Returns a weak reference to the syntax tree of a given file in <see cref="CurrentCompilation"/>, without
+    /// exposing a strong reference to it.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public WeakReference GetWeakReferenceToSyntaxTree( string fileName )
+        => new(
+            this.CurrentCompilation.SyntaxTrees.Single(
+                t => string.Equals( t.FilePath, fileName, StringComparison.OrdinalIgnoreCase ) ) );
+
+    /// <summary>
+    /// Gets the pipeline that the factory has created for the current compilation.
+    /// </summary>
+    public DesignTimeAspectPipeline GetPipeline() => this._factory.CreatePipeline( this.CurrentCompilation );
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/DesignTimePipelineMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/DesignTimePipelineMemoryLeakTests.cs
@@ -1,0 +1,561 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that a design-time editing session does not retain the Roslyn objects of the versions of the project that
+/// the user has already replaced.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Roslyn produces a new <see cref="Microsoft.CodeAnalysis.Compilation"/> and a new
+/// <see cref="Microsoft.CodeAnalysis.SyntaxTree"/> for the edited file on every keystroke, and it releases the
+/// previous ones as soon as the analysers it hosts do. A single retained compilation pins the syntax trees of the
+/// whole project and the symbol tables of every referenced assembly, therefore a component that retains one
+/// compilation per edit consumes memory in proportion to the length of the editing session. That is the shape of the
+/// reported growth of the Roslyn analysis process to several gigabytes over several hours.
+/// </para>
+/// <para>
+/// These tests deliberately restrict themselves to edits of run-time code. Editing the code of an aspect is known to
+/// accumulate the compiled compile-time assemblies, which is an accepted cost, and a test that edited aspect code
+/// could not distinguish that accepted cost from a genuine defect. The single exception is
+/// <see cref="AspectEdits_CompilationsAreCollected"/>, which exists precisely to establish whether the accepted cost
+/// is limited to the compile-time assemblies or whether it also retains compilations.
+/// </para>
+/// </remarks>
+public sealed class DesignTimePipelineMemoryLeakTests : DesignTimeTestBase
+{
+    /// <summary>
+    /// The number of surviving versions of the project that the design-time host is allowed to retain.
+    /// </summary>
+    /// <remarks>
+    /// The host legitimately retains the version it has most recently analysed, because that is the version whose
+    /// results it serves. One additional version is tolerated to account for a version that is still referenced by a
+    /// diff that has not yet been superseded. Anything beyond that grows with the length of the session.
+    /// </remarks>
+    private const int _allowedSurvivingVersions = 2;
+
+    /// <summary>
+    /// The name of the file that contains the aspect, that is, the compile-time code.
+    /// </summary>
+    private const string _aspectFileName = "Aspect.cs";
+
+    /// <summary>
+    /// The name of the run-time file that the tests edit.
+    /// </summary>
+    private const string _targetFileName = "Target.cs";
+
+    private const string _aspectCode = """
+                                       using Metalama.Framework.Aspects;
+
+                                       public class LogAttribute : OverrideMethodAspect
+                                       {
+                                           public override dynamic? OverrideMethod()
+                                           {
+                                               return meta.Proceed();
+                                           }
+                                       }
+                                       """;
+
+    public DesignTimePipelineMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// Returns the content of the run-time file that the tests edit, for a given version.
+    /// </summary>
+    /// <remarks>
+    /// Only the body of a method changes from one version to the next. This is the cheapest possible edit and the one
+    /// a user performs most often, therefore it is the one for which retention matters most.
+    /// </remarks>
+    private static string GetTargetCode( int version )
+        => $$"""
+             public class Target
+             {
+                 [Log]
+                 public int Method()
+                 {
+                     var x = {{version}};
+                     return x;
+                 }
+
+                 [Log]
+                 public string OtherMethod() => "{{version}}";
+             }
+             """;
+
+    /// <summary>
+    /// Returns the content of a run-time file that the tests never edit, so that the compilation has a realistic size.
+    /// </summary>
+    private static string GetFillerCode( int index )
+        => $$"""
+             public class Filler{{index}}
+             {
+                 [Log]
+                 public int Compute( int a, int b ) => a + b + {{index}};
+
+                 public int Property { get; set; }
+             }
+             """;
+
+    /// <summary>
+    /// Returns the version of the aspect file for a given version, so that a test can edit compile-time code.
+    /// </summary>
+    private static string GetAspectCode( int version )
+        => $$"""
+             using Metalama.Framework.Aspects;
+
+             public class LogAttribute : OverrideMethodAspect
+             {
+                 public override dynamic? OverrideMethod()
+                 {
+                     var version = {{version}};
+                     return meta.Proceed();
+                 }
+             }
+             """;
+
+    /// <summary>
+    /// Builds the initial content of the simulated project.
+    /// </summary>
+    private static Dictionary<string, string> CreateInitialCode( int fillerCount = 4 )
+    {
+        var code = new Dictionary<string, string> { [_aspectFileName] = _aspectCode, [_targetFileName] = GetTargetCode( 0 ) };
+
+        for ( var i = 0; i < fillerCount; i++ )
+        {
+            code[$"Filler{i}.cs"] = GetFillerCode( i );
+        }
+
+        return code;
+    }
+
+    /// <summary>
+    /// Verifies that the compilation of the first version of the project is released once the user has made further
+    /// edits to run-time code.
+    /// </summary>
+    [Fact]
+    public void RuntimeEdits_InitialCompilationIsCollected()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.RuntimeEdits_InitialCompilationIsCollected),
+            CreateInitialCode() );
+
+        var initialCompilation = simulator.GetWeakReferenceToCurrentCompilation();
+        simulator.Execute();
+
+        var firstEditCompilation = simulator.EditAndExecute( _targetFileName, GetTargetCode( 1 ) );
+
+        const int editCount = 10;
+
+        for ( var version = 2; version <= editCount; version++ )
+        {
+            simulator.ApplyEdit( _targetFileName, GetTargetCode( version ) );
+        }
+
+        this.AssertPipelineDidWork( simulator, editCount );
+
+        MemoryLeakAssert.Collected( initialCompilation, "The initial compilation", ("pipelineFactory", factory) );
+        MemoryLeakAssert.Collected( firstEditCompilation, "The compilation of the first edit", ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that the number of compilations that survive an editing session does not grow with the number of
+    /// edits.
+    /// </summary>
+    /// <remarks>
+    /// The same assertion is made for three session lengths. A component that retains one compilation per edit fails
+    /// the longest session while possibly passing the shortest one, and the comparison between the three cases
+    /// distinguishes a bounded cache from unbounded growth.
+    /// </remarks>
+    [Theory]
+    [InlineData( 5 )]
+    [InlineData( 15 )]
+    [InlineData( 40 )]
+    public void RuntimeEdits_SurvivingCompilationCountDoesNotGrow( int editCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.RuntimeEdits_SurvivingCompilationCountDoesNotGrow),
+            CreateInitialCode() );
+
+        simulator.Execute();
+
+        var compilations = new WeakReference[editCount];
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            compilations[version - 1] = simulator.EditAndExecute( _targetFileName, GetTargetCode( version ) );
+        }
+
+        this.AssertPipelineDidWork( simulator, editCount );
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            _allowedSurvivingVersions,
+            $"compilations of an editing session of {editCount} edits",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Asserts that the pipeline actually analysed every version submitted to it.
+    /// </summary>
+    /// <remarks>
+    /// Without this check, a test in which the pipeline silently declined to run every version would report that
+    /// nothing is retained, which is true but meaningless. The expected count is one execution for the initial
+    /// version plus one per edit.
+    /// </remarks>
+    private void AssertPipelineDidWork( DesignTimeEditingSimulator simulator, int editCount )
+    {
+        var executionCount = simulator.GetPipeline().PipelineExecutionCount;
+
+        this.TestOutput.WriteLine( $"The pipeline was executed {executionCount} times for {editCount} edits." );
+
+        Assert.True(
+            executionCount >= editCount,
+            $"The pipeline was executed only {executionCount} times for {editCount} edits, therefore the test did not "
+            + "exercise the retention of the versions it was supposed to exercise." );
+    }
+
+    /// <summary>
+    /// Verifies that the syntax trees of the versions of the edited file that the user has replaced are released.
+    /// </summary>
+    /// <remarks>
+    /// A syntax tree can be retained independently of its compilation, for example by a
+    /// <see cref="Microsoft.CodeAnalysis.Diagnostic"/> that a result cache keeps, because a diagnostic holds a
+    /// location and a location holds its source tree. This test therefore complements
+    /// <see cref="RuntimeEdits_SurvivingCompilationCountDoesNotGrow"/> instead of duplicating it.
+    /// </remarks>
+    [Fact]
+    public void RuntimeEdits_ReplacedSyntaxTreesAreCollected()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.RuntimeEdits_ReplacedSyntaxTreesAreCollected),
+            CreateInitialCode() );
+
+        simulator.Execute();
+
+        const int editCount = 12;
+        var syntaxTrees = new WeakReference[editCount];
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            syntaxTrees[version - 1] = EditAndGetWeakReferenceToEditedTree( simulator, version );
+        }
+
+        MemoryLeakAssert.AtMostAlive(
+            syntaxTrees,
+            _allowedSurvivingVersions,
+            $"syntax trees of '{_targetFileName}'",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Applies one edit and returns a weak reference to the syntax tree that the edit produced.
+    /// </summary>
+    private static WeakReference EditAndGetWeakReferenceToEditedTree( DesignTimeEditingSimulator simulator, int version )
+    {
+        simulator.ApplyEdit( _targetFileName, GetTargetCode( version ) );
+
+        return simulator.GetWeakReferenceToSyntaxTree( _targetFileName );
+    }
+
+    /// <summary>
+    /// Verifies that run-time edits performed while the pipeline is paused do not retain the compilations they
+    /// produce.
+    /// </summary>
+    /// <remarks>
+    /// Editing compile-time code pauses the pipeline until the next external build. A user who has just edited an
+    /// aspect and then continues to work on run-time code therefore keeps the pipeline paused for a long time, and
+    /// every compilation produced during that period follows the code path that computes a difference from the last
+    /// analysed version rather than from the immediately preceding one. This is the path most likely to accumulate
+    /// versions, and it is common in practice.
+    /// </remarks>
+    [Fact]
+    public void RuntimeEditsWhilePipelineIsPaused_CompilationsAreCollected()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.RuntimeEditsWhilePipelineIsPaused_CompilationsAreCollected),
+            CreateInitialCode() );
+
+        simulator.Execute();
+
+        // Edit the aspect, which pauses the pipeline.
+        simulator.ApplyEdit( _aspectFileName, GetAspectCode( 1 ) );
+
+        const int editCount = 20;
+        var compilations = new WeakReference[editCount];
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            compilations[version - 1] = simulator.EditAndExecute( _targetFileName, GetTargetCode( version ) );
+        }
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            _allowedSurvivingVersions,
+            $"compilations produced while the pipeline was paused ({editCount} edits)",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that editing the code of an aspect does not retain the compilations of the versions that the user has
+    /// replaced.
+    /// </summary>
+    /// <remarks>
+    /// The accumulation of the compiled compile-time assemblies that results from editing an aspect is an accepted
+    /// cost, because each version of the aspect must remain loadable. Retaining the Roslyn compilations of those
+    /// versions is a different matter: it multiplies that accepted cost by the size of the whole project. This test
+    /// therefore asserts the second property only, and a failure identifies an amplification of the accepted cost
+    /// rather than the accepted cost itself.
+    /// </remarks>
+    [Fact]
+    public void AspectEdits_CompilationsAreCollected()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.AspectEdits_CompilationsAreCollected),
+            CreateInitialCode() );
+
+        simulator.Execute();
+
+        const int editCount = 8;
+        var compilations = new WeakReference[editCount];
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            compilations[version - 1] = simulator.EditAndExecute( _aspectFileName, GetAspectCode( version ) );
+        }
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            _allowedSurvivingVersions,
+            $"compilations of an aspect-editing session of {editCount} edits",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// The name of the file that declares a type carrying an inheritable aspect. The tests never edit it.
+    /// </summary>
+    private const string _inheritanceRootFileName = "InheritanceRoot.cs";
+
+    private const string _aspectCodeWithInheritableAspect = """
+                                                            using Metalama.Framework.Advising;
+                                                            using Metalama.Framework.Aspects;
+
+                                                            public class LogAttribute : OverrideMethodAspect
+                                                            {
+                                                                public override dynamic? OverrideMethod()
+                                                                {
+                                                                    return meta.Proceed();
+                                                                }
+                                                            }
+
+                                                            [Inheritable]
+                                                            public class InheritedAspect : TypeAspect { }
+                                                            """;
+
+    private const string _inheritanceRootCode = """
+                                                [InheritedAspect]
+                                                public interface IInheritanceRoot { }
+                                                """;
+
+    /// <summary>
+    /// Builds a project that produces an inheritable aspect instance in a file that the tests never edit.
+    /// </summary>
+    private static Dictionary<string, string> CreateCodeWithInheritableAspect()
+        => new()
+        {
+            [_aspectFileName] = _aspectCodeWithInheritableAspect,
+            [_inheritanceRootFileName] = _inheritanceRootCode,
+            [_targetFileName] = GetTargetCode( 0 ),
+            ["Filler0.cs"] = GetFillerCode( 0 )
+        };
+
+    /// <summary>
+    /// Verifies that the results of the files that the pipeline did not re-analyse do not retain the compilation in
+    /// which they were computed.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The design-time pipeline analyses only the syntax trees that changed, therefore the
+    /// <c>SyntaxTreePipelineResult</c> of every other file survives, unchanged, from an earlier run. That is by
+    /// design and is sound only as long as such a result holds no reference that is bound to the compilation it was
+    /// computed from. Most of its members were reduced to serialisable identifiers for exactly that reason, but
+    /// <c>InheritableAspects</c> holds an <c>InheritableAspectInstance</c> whose target declaration is a reference
+    /// obtained from the code model.
+    /// </para>
+    /// <para>
+    /// The file that carries the inheritable aspect is never edited here, so its result is produced once, during the
+    /// first run, and is then carried forward through every subsequent version. If that result reaches the
+    /// compilation of the first run, the first compilation stays alive for the whole session, and, because the
+    /// pipeline also caches its results in a table keyed by compilation, each surviving version can in turn keep the
+    /// previous one alive.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void InheritableAspectInAnUneditedFile_DoesNotRetainTheFirstCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.InheritableAspectInAnUneditedFile_DoesNotRetainTheFirstCompilation),
+            CreateCodeWithInheritableAspect() );
+
+        var initialCompilation = simulator.GetWeakReferenceToCurrentCompilation();
+        simulator.Execute();
+
+        const int editCount = 12;
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            simulator.ApplyEdit( _targetFileName, GetTargetCode( version ) );
+        }
+
+        this.AssertPipelineDidWork( simulator, editCount );
+
+        var pipeline = simulator.GetPipeline();
+
+        var inheritableAspectTypes = pipeline.AspectPipelineResult.InheritableAspectTypes.ToList();
+
+        this.TestOutput.WriteLine(
+            $"The pipeline holds {inheritableAspectTypes.Count} inheritable aspect type(s): {string.Join( ", ", inheritableAspectTypes )}." );
+
+        // The test is meaningless if the project produced no inheritable aspect, because the retention path under
+        // examination starts at the collection of inheritable aspects.
+        Assert.NotEmpty( inheritableAspectTypes );
+
+        MemoryLeakAssert.Collected(
+            initialCompilation,
+            "The compilation in which the inheritable aspect of the unedited file was computed",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that the number of versions retained during a session that produces inheritable aspects does not grow
+    /// with the number of edits.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The previous test states whether the first version survives. This one states whether the whole history
+    /// survives, which is the difference between a constant overhead and growth proportional to the length of the
+    /// session.
+    /// </para>
+    /// <para>
+    /// This test passes while <see cref="InheritableAspectInAnUneditedFile_DoesNotRetainTheFirstCompilation"/> fails,
+    /// and the combination is the informative result. The pipeline caches its results in a table keyed by
+    /// compilation, so a reference from the result of one version to an older version could have kept the whole
+    /// history alive. It does not: exactly one stale version survives, whatever the length of the session. The cost
+    /// of the defect is therefore one retained compilation per project, which is a constant overhead on a large
+    /// solution rather than growth over the length of an editing session.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData( 5 )]
+    [InlineData( 25 )]
+    public void InheritableAspects_SurvivingCompilationCountDoesNotGrow( int editCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.InheritableAspects_SurvivingCompilationCountDoesNotGrow),
+            CreateCodeWithInheritableAspect() );
+
+        simulator.Execute();
+
+        var compilations = new WeakReference[editCount];
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            compilations[version - 1] = simulator.EditAndExecute( _targetFileName, GetTargetCode( version ) );
+        }
+
+        this.AssertPipelineDidWork( simulator, editCount );
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            _allowedSurvivingVersions,
+            $"compilations of a session of {editCount} edits in a project that produces inheritable aspects",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that the design-time host does not retain the results it computed for versions that have been
+    /// superseded.
+    /// </summary>
+    /// <remarks>
+    /// The results of the pipeline are keyed by the path of a syntax tree, so their number is bounded by the number
+    /// of files. This test guards that property, which is the reason why the results are keyed by path rather than by
+    /// syntax tree instance, and which a future change could silently break.
+    /// </remarks>
+    [Fact]
+    public void RuntimeEdits_ResultCountIsBoundedByFileCount()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var code = CreateInitialCode();
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.RuntimeEdits_ResultCountIsBoundedByFileCount),
+            code );
+
+        simulator.Execute();
+
+        for ( var version = 1; version <= 15; version++ )
+        {
+            simulator.ApplyEdit( _targetFileName, GetTargetCode( version ) );
+        }
+
+        var pipeline = simulator.GetPipeline();
+        var resultCount = pipeline.AspectPipelineResult.SyntaxTreeResults.Count;
+
+        this.TestOutput.WriteLine( $"The pipeline holds {resultCount} syntax tree results for {code.Count} files." );
+
+        // One additional result is allowed, because diagnostics that have no source location are grouped under an
+        // entry whose key is the empty string.
+        Assert.True(
+            resultCount <= code.Count + 1,
+            $"The pipeline holds {resultCount} syntax tree results, but the project has only {code.Count} files. "
+            + "The results are therefore not keyed by file path, and their number grows with the number of edits." );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/GarbageCollectionHelper.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/GarbageCollectionHelper.cs
@@ -1,0 +1,73 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Runtime.CompilerServices;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Forces the garbage collector to run to completion, so that a test can assert that an object is no longer reachable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A single call to <see cref="GC.Collect()"/> is not sufficient for this kind of assertion. An object that has a
+/// finalizer is promoted to the finalization queue by the first collection and is only reclaimed by a subsequent one,
+/// therefore at least two rounds of collection and finalization are required. Roslyn objects reachable from a
+/// <see cref="ConditionalWeakTable{TKey,TValue}"/> add a second reason: the entries of such a table are resolved
+/// during the mark phase, and a value that has itself become unreachable may only be observed as such once the key
+/// has been collected in an earlier round.
+/// </para>
+/// <para>
+/// The collection is requested as blocking and compacting on the maximum generation, because the default
+/// non-blocking background collection may return before the large object heap, where syntax trees and compilations
+/// typically reside, has been swept.
+/// </para>
+/// </remarks>
+internal static class GarbageCollectionHelper
+{
+    /// <summary>
+    /// The number of collection rounds performed by <see cref="Collect"/>.
+    /// </summary>
+    private const int _collectionRounds = 4;
+
+    /// <summary>
+    /// Performs several rounds of blocking, compacting garbage collection, waiting for finalizers between rounds.
+    /// </summary>
+    public static void Collect()
+    {
+        for ( var i = 0; i < _collectionRounds; i++ )
+        {
+            GC.Collect( GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true );
+            GC.WaitForPendingFinalizers();
+        }
+
+        GC.Collect( GC.MaxGeneration, GCCollectionMode.Forced, blocking: true, compacting: true );
+    }
+
+    /// <summary>
+    /// Returns the number of live objects among the given weak references, after forcing a full collection.
+    /// </summary>
+    /// <remarks>
+    /// The method is marked as not inlinable so that the caller cannot keep a temporary of the enumeration alive on
+    /// its stack frame, which would defeat the purpose of the measurement.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public static int CountAlive( params WeakReference[] weakReferences )
+    {
+        Collect();
+
+        var count = 0;
+
+        foreach ( var weakReference in weakReferences )
+        {
+            if ( weakReference.IsAlive )
+            {
+                count++;
+            }
+        }
+
+        return count;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/MemoryLeakAssert.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/MemoryLeakAssert.cs
@@ -1,0 +1,117 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Text;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Assertions on the reachability of objects that a design-time editing session was expected to release.
+/// </summary>
+/// <remarks>
+/// A failure reported by these assertions includes the chain of references that retains the object, computed by
+/// <see cref="RetentionPathFinder"/>. Without that chain, the only information a failure conveys is that something,
+/// somewhere, retains a compilation, which is not enough to act upon.
+/// </remarks>
+internal static class MemoryLeakAssert
+{
+    /// <summary>
+    /// Asserts that the target of a weak reference has been collected, and explains the retention if it has not.
+    /// </summary>
+    /// <param name="weakReference">A weak reference to the object that was expected to be collected.</param>
+    /// <param name="description">A description of the object, used in the failure message.</param>
+    /// <param name="roots">The objects that play the role of garbage-collection roots in the failure analysis.</param>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public static void Collected( WeakReference weakReference, string description, params (string Name, object Root)[] roots )
+    {
+        GarbageCollectionHelper.Collect();
+
+        var target = weakReference.Target;
+
+        if ( target == null )
+        {
+            return;
+        }
+
+        Assert.Fail( BuildFailureMessage( target, description, roots ) );
+    }
+
+    /// <summary>
+    /// Asserts that at most <paramref name="expectedMaximum"/> of the given weak references are still alive.
+    /// </summary>
+    /// <remarks>
+    /// The design-time host legitimately retains the most recent version of a project, therefore an assertion that
+    /// nothing at all survives an editing session would be wrong. This overload expresses the correct expectation:
+    /// the number of surviving versions must be bounded by a constant, and in particular must not grow with the
+    /// number of edits.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public static void AtMostAlive(
+        IReadOnlyList<WeakReference> weakReferences,
+        int expectedMaximum,
+        string description,
+        params (string Name, object Root)[] roots )
+    {
+        GarbageCollectionHelper.Collect();
+
+        List<int> aliveIndices = new();
+
+        for ( var i = 0; i < weakReferences.Count; i++ )
+        {
+            if ( weakReferences[i].IsAlive )
+            {
+                aliveIndices.Add( i );
+            }
+        }
+
+        if ( aliveIndices.Count <= expectedMaximum )
+        {
+            return;
+        }
+
+        var stringBuilder = new StringBuilder();
+
+        stringBuilder.AppendLine(
+            $"{aliveIndices.Count} of {weakReferences.Count} {description} are still alive, but at most {expectedMaximum} were expected." );
+
+        stringBuilder.AppendLine( $"Alive indices: {string.Join( ", ", aliveIndices )}." );
+
+        // Explain the retention of the oldest survivor, which is the most informative one: the most recent versions
+        // are expected to be alive, whereas the oldest one should have been released first.
+        var oldestSurvivor = weakReferences[aliveIndices[0]].Target;
+
+        if ( oldestSurvivor != null )
+        {
+            stringBuilder.AppendLine();
+            stringBuilder.AppendLine( BuildFailureMessage( oldestSurvivor, $"The oldest survivor (index {aliveIndices[0]})", roots ) );
+        }
+
+        Assert.Fail( stringBuilder.ToString() );
+    }
+
+    /// <summary>
+    /// Builds a failure message that includes the retention chain of <paramref name="target"/>, when one can be found.
+    /// </summary>
+    private static string BuildFailureMessage( object target, string description, (string Name, object Root)[] roots )
+    {
+        var finder = new RetentionPathFinder();
+
+        if ( finder.TryFindPath( target, out var path, roots ) )
+        {
+            return $"{description} is still reachable. Retention path:{Environment.NewLine}{path}";
+        }
+
+        var reason = finder.IsExhausted
+            ? "the search was exhausted before completing, therefore the absence of a path is not conclusive"
+            : "no path exists from the given roots, therefore the object is retained by a root that was not supplied, "
+              + "such as a static field, a running task, or a local variable of the test itself";
+
+        return $"{description} is still reachable, but no retention path was found: {reason}. "
+               + $"The search visited {finder.VisitedObjectCount} objects.";
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/MemoryLeakAssertSelfTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/MemoryLeakAssertSelfTests.cs
@@ -1,0 +1,193 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests the memory-leak test infrastructure itself.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A suite of leak tests that all pass proves nothing unless the assertions it uses are known to fail when a leak is
+/// present. The tests in this class supply that proof: they introduce a retention path deliberately and require the
+/// assertions to detect it, to name the retaining field, and to distinguish a strong reference from a reference held
+/// through a <see cref="ConditionalWeakTable{TKey,TValue}"/>.
+/// </para>
+/// <para>
+/// The objects retained on purpose here are real <see cref="Compilation"/> instances, so that the size and shape of
+/// the graph that the search has to traverse are representative of the graph in the tests that matter.
+/// </para>
+/// </remarks>
+public sealed class MemoryLeakAssertSelfTests : DesignTimeTestBase
+{
+    public MemoryLeakAssertSelfTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// A component that retains every compilation it is given, standing in for a defective cache.
+    /// </summary>
+    private sealed class LeakingCache
+    {
+        /// <summary>
+        /// Gets the list that retains the compilations. Its name appears in the retention path that the assertion
+        /// reports, which is what the tests verify.
+        /// </summary>
+        public List<Compilation> RetainedCompilations { get; } = new();
+    }
+
+    /// <summary>
+    /// A component that stores compilations in a <see cref="ConditionalWeakTable{TKey,TValue}"/> keyed by the
+    /// compilation itself, which does not retain them.
+    /// </summary>
+    private sealed class ConditionalCache
+    {
+        public ConditionalWeakTable<Compilation, object> Entries { get; } = new();
+    }
+
+    /// <summary>
+    /// Creates a compilation, adds it to a cache that retains it, and returns only a weak reference to it.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static WeakReference CreateAndRetain( TestContext testContext, LeakingCache cache, string assemblyName )
+    {
+        var compilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["Code.cs"] = "public class C { }" },
+            assemblyName: assemblyName );
+
+        cache.RetainedCompilations.Add( compilation );
+
+        return new WeakReference( compilation );
+    }
+
+    /// <summary>
+    /// Creates a compilation and returns only a weak reference to it, retaining nothing.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static WeakReference CreateWithoutRetaining( TestContext testContext, string assemblyName )
+    {
+        var compilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["Code.cs"] = "public class C { }" },
+            assemblyName: assemblyName );
+
+        return new WeakReference( compilation );
+    }
+
+    /// <summary>
+    /// Creates a compilation, registers it in a conditional weak table keyed by itself, and returns only a weak
+    /// reference to it.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static WeakReference CreateAndRegisterConditionally( TestContext testContext, ConditionalCache cache, string assemblyName )
+    {
+        var compilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["Code.cs"] = "public class C { }" },
+            assemblyName: assemblyName );
+
+        cache.Entries.Add( compilation, new object() );
+
+        return new WeakReference( compilation );
+    }
+
+    /// <summary>
+    /// Verifies that a compilation which nothing retains is reported as collected.
+    /// </summary>
+    /// <remarks>
+    /// This is the negative control. If it failed, every other test in the suite would fail for a reason unrelated to
+    /// the code under test, such as a local variable of the test harness keeping the compilation alive.
+    /// </remarks>
+    [Fact]
+    public void UnretainedCompilationIsReportedAsCollected()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var weakReference = CreateWithoutRetaining( testContext, nameof(this.UnretainedCompilationIsReportedAsCollected) );
+
+        MemoryLeakAssert.Collected( weakReference, "An unretained compilation", ("testContext", testContext) );
+    }
+
+    /// <summary>
+    /// Verifies that a compilation retained by a strong reference is detected, and that the failure message names the
+    /// field that retains it.
+    /// </summary>
+    /// <remarks>
+    /// This is the positive control, and it is the test that gives the rest of the suite its value. Without it, a
+    /// suite in which every test passes would be indistinguishable from a suite whose assertions never fail.
+    /// </remarks>
+    [Fact]
+    public void RetainedCompilationIsDetectedAndTheRetainingFieldIsNamed()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var cache = new LeakingCache();
+        var weakReference = CreateAndRetain( testContext, cache, nameof(this.RetainedCompilationIsDetectedAndTheRetainingFieldIsNamed) );
+
+        var exception = Assert.Throws<FailException>(
+            () => MemoryLeakAssert.Collected( weakReference, "A deliberately retained compilation", ("leakingCache", cache) ) );
+
+        this.TestOutput.WriteLine( exception.Message );
+
+        Assert.Contains( "still reachable", exception.Message, StringComparison.Ordinal );
+        Assert.Contains( "leakingCache", exception.Message, StringComparison.Ordinal );
+        Assert.Contains( nameof(LeakingCache.RetainedCompilations), exception.Message, StringComparison.Ordinal );
+    }
+
+    /// <summary>
+    /// Verifies that the growth assertion detects the case in which every version is retained.
+    /// </summary>
+    [Fact]
+    public void RetainedCompilationsAreDetectedByTheGrowthAssertion()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var cache = new LeakingCache();
+        var weakReferences = new WeakReference[5];
+
+        for ( var i = 0; i < weakReferences.Length; i++ )
+        {
+            weakReferences[i] = CreateAndRetain(
+                testContext,
+                cache,
+                $"{nameof(this.RetainedCompilationsAreDetectedByTheGrowthAssertion)}{i}" );
+        }
+
+        var exception = Assert.Throws<FailException>(
+            () => MemoryLeakAssert.AtMostAlive( weakReferences, 1, "deliberately retained compilations", ("leakingCache", cache) ) );
+
+        this.TestOutput.WriteLine( exception.Message );
+
+        Assert.Contains( "5 of 5", exception.Message, StringComparison.Ordinal );
+        Assert.Contains( nameof(LeakingCache.RetainedCompilations), exception.Message, StringComparison.Ordinal );
+    }
+
+    /// <summary>
+    /// Verifies that a compilation registered as the key of a conditional weak table is not considered retained.
+    /// </summary>
+    /// <remarks>
+    /// The design-time code relies on this property throughout, therefore a test suite that reported such an entry as
+    /// a leak would produce a stream of false failures. This test pins the semantics that the other tests assume.
+    /// </remarks>
+    [Fact]
+    public void ConditionallyRegisteredCompilationIsReportedAsCollected()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var cache = new ConditionalCache();
+
+        var weakReference = CreateAndRegisterConditionally(
+            testContext,
+            cache,
+            nameof(this.ConditionallyRegisteredCompilationIsReportedAsCollected) );
+
+        MemoryLeakAssert.Collected( weakReference, "A compilation used as a conditional weak table key", ("conditionalCache", cache) );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/PendingTasksHelper.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/PendingTasksHelper.cs
@@ -1,0 +1,45 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Utilities;
+using Metalama.Testing.UnitTesting;
+using System;
+using System.Threading.Tasks;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Waits for the background tasks of a <see cref="TaskBag"/> before a test asserts on what is still reachable.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A task of a bag removes its own entry when it runs, and it runs on the thread pool. An assertion made before the
+/// task has run therefore observes a bag that is merely still busy, and its result depends on how loaded the thread
+/// pool happens to be. That dependency is invisible when a test runs on its own and appears when the whole suite runs
+/// in parallel, which is the worst way for it to appear.
+/// </para>
+/// <para>
+/// A bag that strands a task leaves it in the canceled state, and <see cref="TaskBag.WaitAllAsync"/> surfaces that as
+/// an exception. That exception is swallowed here, because it is the very defect that the assertions of the caller
+/// diagnose, and their failure message names the field that retains the object. The cancellation of the test context
+/// is not swallowed, so a bag that never completes fails the test rather than hanging it.
+/// </para>
+/// </remarks>
+internal static class PendingTasksHelper
+{
+    /// <summary>
+    /// Waits until every task of <paramref name="taskBag"/> has run.
+    /// </summary>
+    public static async Task WaitForPendingTasksAsync( TaskBag taskBag, TestContext testContext )
+    {
+        try
+        {
+            await taskBag.WaitAllAsync( testContext.CancellationToken );
+        }
+        catch ( OperationCanceledException ) when ( !testContext.CancellationToken.IsCancellationRequested )
+        {
+            // See the remarks on the class.
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/PipelineFactoryMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/PipelineFactoryMemoryLeakTests.cs
@@ -1,0 +1,159 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Pipeline;
+using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.Utilities.Threading;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that <see cref="DesignTimeAspectPipelineFactory"/> releases the compilations of the callers that waited for
+/// a pipeline that was never created.
+/// </summary>
+/// <remarks>
+/// <para>
+/// When a caller asks for the pipeline of a project that has not been registered yet,
+/// <c>GetPipelineAndWaitAsync</c> enqueues a <see cref="TaskCompletionSource{TResult}"/> in a queue of listeners and
+/// awaits it. The listeners of that queue are completed by iterating over it, but they are never dequeued, so the
+/// queue only grows. A listener that is never completed keeps the continuation of its awaiter, and that continuation
+/// is the suspended state machine of <c>GetPipelineAndWaitAsync</c>, which holds the <see cref="Compilation"/> that
+/// the caller passed.
+/// </para>
+/// <para>
+/// The cancellation token is registered only for the duration of the statement that enqueues the listener, not for
+/// the duration of the wait, therefore cancelling the token does not release the caller. In the analysis process this
+/// situation arises whenever a project is queried before its pipeline exists and the pipeline is then never created,
+/// for example because the project is unloaded, is renamed, or fails to be classified as a Metalama project.
+/// </para>
+/// </remarks>
+public sealed class PipelineFactoryMemoryLeakTests : DesignTimeTestBase
+{
+    public PipelineFactoryMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// Creates the real pipeline factory, rather than the test subclass, because the test subclass overrides the
+    /// method under test.
+    /// </summary>
+    private static DesignTimeAspectPipelineFactory CreateFactory( TestContext testContext )
+    {
+        GlobalServiceProvider serviceProvider = testContext.ServiceProvider;
+
+        if ( serviceProvider.GetService<AnalysisProcessEventHub>() == null )
+        {
+            serviceProvider = serviceProvider.Underlying.WithService( new AnalysisProcessEventHub( serviceProvider ) );
+        }
+
+        return new DesignTimeAspectPipelineFactory( serviceProvider );
+    }
+
+    /// <summary>
+    /// Starts a wait for a pipeline that does not exist, cancels it, and returns only a weak reference to the
+    /// compilation that was passed to the factory.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The wait is awaited before returning, which is what makes the assertion of the caller deterministic: the
+    /// continuation of the wait is what releases the objects it captured, and asserting before that continuation has
+    /// run would observe a retention that is merely in flight.
+    /// </para>
+    /// <para>
+    /// The wait is awaited under the cancellation token of the test context, so that a regression in which the wait
+    /// never ends fails the test rather than hanging it. Because that guard would itself raise an operation-cancelled
+    /// exception, the caller also verifies that the wait really did complete.
+    /// </para>
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static async Task<WeakReference> StartAndCancelWaitAsync(
+        TestContext testContext,
+        DesignTimeAspectPipelineFactory factory,
+        string assemblyName )
+    {
+        var compilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["Code.cs"] = "public class C { }" },
+            assemblyName: assemblyName );
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        // No pipeline is ever created for this project, so only the cancellation token can end this wait.
+        var waitTask = factory.GetPipelineAndWaitAsync( compilation, cancellationTokenSource.Token ).AsTask();
+
+        cancellationTokenSource.Cancel();
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>( () => waitTask.WithCancellation( testContext.CancellationToken ) );
+
+        Assert.True(
+            waitTask.IsCompleted,
+            "The wait for the pipeline did not end when its cancellation token was signalled. The exception above came "
+            + "from the timeout of the test context, not from the wait itself." );
+
+        return new WeakReference( compilation );
+    }
+
+    /// <summary>
+    /// Verifies that cancelling a wait for a pipeline releases the compilation that the caller supplied.
+    /// </summary>
+    [Fact]
+    public async Task CancelledWaitForPipeline_ReleasesTheCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = CreateFactory( testContext );
+
+        var compilation = await StartAndCancelWaitAsync( testContext, factory, nameof(this.CancelledWaitForPipeline_ReleasesTheCompilation) );
+
+        MemoryLeakAssert.Collected( compilation, "The compilation of a cancelled wait for a pipeline", ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that a sequence of cancelled waits does not accumulate compilations.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <see cref="CancelledWaitForPipeline_ReleasesTheCompilation"/> states the defect on a single wait. This test
+    /// states its consequence: the collection of listeners belongs to the factory, which lives as long as the
+    /// analysis process, so anything it retains is retained until the process exits.
+    /// </para>
+    /// <para>
+    /// One survivor is tolerated, and the assertion is made for two different numbers of waits so that the claim
+    /// being tested is the absence of accumulation rather than the absence of any survivor. The asynchronous state of
+    /// the most recent iteration, including the exception that carries the cancelled task, is still in flight when
+    /// the assertion runs, and it belongs to the test rather than to the code under test. The defect this test guards
+    /// against would retain every iteration, not one.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData( 10 )]
+    [InlineData( 30 )]
+    public async Task RepeatedCancelledWaitsForPipeline_DoNotAccumulateCompilations( int waitCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = CreateFactory( testContext );
+
+        var compilations = new WeakReference[waitCount];
+
+        for ( var i = 0; i < waitCount; i++ )
+        {
+            compilations[i] = await StartAndCancelWaitAsync(
+                testContext,
+                factory,
+                $"{nameof(this.RepeatedCancelledWaitsForPipeline_DoNotAccumulateCompilations)}{i}" );
+        }
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            1,
+            $"compilations of {waitCount} cancelled waits for a pipeline",
+            ("pipelineFactory", factory) );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/PipelineFactoryMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/PipelineFactoryMemoryLeakTests.cs
@@ -2,6 +2,9 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - acceptable in test code
+#pragma warning disable VSTHRD103 // Cancel synchronously blocks - CancelAsync not available on all target frameworks
+
 using Metalama.Framework.DesignTime.Pipeline;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities.Threading;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/ProjectVersionProviderMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/ProjectVersionProviderMemoryLeakTests.cs
@@ -1,0 +1,245 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Pipeline.Diff;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+#pragma warning disable VSTHRD200 // Async method names must have an "Async" suffix.
+
+/// <summary>
+/// Tests the retention behaviour of <see cref="ProjectVersionProvider"/> in isolation from the rest of the
+/// design-time pipeline.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="ProjectVersionProvider"/> is the component that keeps the history of the versions of a project, so it
+/// is the first place where a version can be retained for longer than intended. Its entire state is designed to be
+/// held weakly: the graph of differences is stored in a <see cref="System.Runtime.CompilerServices.ConditionalWeakTable{TKey,TValue}"/>
+/// keyed by <see cref="Compilation"/>, and the last known compilation of each project is stored in a
+/// <see cref="WeakReference{T}"/>. The tests below assert that property directly, which is the strongest statement
+/// that can be made about this component: once the caller has released a compilation, the provider must not keep it
+/// alive.
+/// </para>
+/// <para>
+/// These tests complement <see cref="DesignTimePipelineMemoryLeakTests"/>. A failure here localises the defect in the
+/// diff subsystem, whereas a failure there with no failure here localises it elsewhere in the pipeline.
+/// </para>
+/// </remarks>
+public sealed class ProjectVersionProviderMemoryLeakTests : DesignTimeTestBase
+{
+    public ProjectVersionProviderMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// Returns the source of the run-time file for a given version.
+    /// </summary>
+    private static string GetCode( int version )
+        => $$"""
+             public class C
+             {
+                 public int M() => {{version}};
+             }
+             """;
+
+    /// <summary>
+    /// Verifies that a chain of successive differences, each computed from the immediately preceding version, retains
+    /// none of the versions once the caller has released them.
+    /// </summary>
+    /// <remarks>
+    /// This is the sequence produced by an uninterrupted editing session in which the pipeline keeps up with the user.
+    /// </remarks>
+    [Fact]
+    public async Task SequentialDiffChain_NoCompilationIsRetained()
+    {
+        using var testContext = this.CreateTestContext();
+        var provider = new ProjectVersionProvider( testContext.ServiceProvider, true );
+
+        var compilations = await RunSequentialChainAsync( testContext, provider, nameof(this.SequentialDiffChain_NoCompilationIsRetained), 30 );
+
+        MemoryLeakAssert.AtMostAlive( compilations, 0, "compilations of a sequential difference chain", ("projectVersionProvider", provider) );
+    }
+
+    /// <summary>
+    /// Computes a chain of differences and returns weak references to every version, including the last one.
+    /// </summary>
+    /// <remarks>
+    /// Every strong reference to a compilation is confined to this method, so that none of them survives in the frame
+    /// of the calling test method.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static async Task<WeakReference[]> RunSequentialChainAsync(
+        TestContext testContext,
+        ProjectVersionProvider provider,
+        string assemblyName,
+        int versionCount )
+    {
+        var current = CreateInitialCompilation( testContext, assemblyName );
+        _ = await provider.GetCompilationChangesAsync( null, current );
+
+        var weakReferences = new WeakReference[versionCount];
+
+        for ( var version = 0; version < versionCount; version++ )
+        {
+            var next = ReplaceCode( current, "Code.cs", version + 1 );
+            _ = await provider.GetCompilationChangesAsync( current, next );
+            weakReferences[version] = new WeakReference( current );
+            current = next;
+        }
+
+        return weakReferences;
+    }
+
+    /// <summary>
+    /// Verifies that repeatedly computing the difference from one pinned version to each successive version does not
+    /// retain the intermediate versions.
+    /// </summary>
+    /// <remarks>
+    /// This is the sequence produced when the pipeline is paused, which happens as soon as the user edits compile-time
+    /// code and lasts until the next external build. Every compilation produced during that period is compared with
+    /// the last version that the pipeline analysed, and the provider merges the difference it already knows with the
+    /// difference from its most recent version. That merge is the code path most likely to build a chain of versions,
+    /// and a user who edits an aspect and then continues to work on run-time code stays on it for a long time.
+    /// </remarks>
+    [Fact]
+    public async Task DiffsFromPinnedVersion_IntermediateCompilationsAreNotRetained()
+    {
+        using var testContext = this.CreateTestContext();
+        var provider = new ProjectVersionProvider( testContext.ServiceProvider, true );
+
+        var pinned = CreateInitialCompilation( testContext, nameof(this.DiffsFromPinnedVersion_IntermediateCompilationsAreNotRetained) );
+        _ = await provider.GetCompilationChangesAsync( null, pinned );
+
+        var intermediateCompilations = await RunPinnedChainAsync( provider, pinned, 30 );
+
+        MemoryLeakAssert.AtMostAlive(
+            intermediateCompilations,
+            1,
+            "intermediate compilations compared against a pinned version",
+            ("projectVersionProvider", provider) );
+
+        // The pinned compilation is deliberately kept alive until the end of the test, because it plays the role of
+        // the version that the paused pipeline still serves results for.
+        GC.KeepAlive( pinned );
+    }
+
+    /// <summary>
+    /// Computes the difference from a single pinned version to each of a series of successive versions.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static async Task<WeakReference[]> RunPinnedChainAsync( ProjectVersionProvider provider, Compilation pinned, int versionCount )
+    {
+        var weakReferences = new WeakReference[versionCount];
+
+        for ( var version = 0; version < versionCount; version++ )
+        {
+            var next = ReplaceCode( pinned, "Code.cs", version + 1 );
+            _ = await provider.GetCompilationChangesAsync( pinned, next );
+            weakReferences[version] = new WeakReference( next );
+        }
+
+        return weakReferences;
+    }
+
+    /// <summary>
+    /// Verifies that the versions of a referenced project are not retained when the referencing project is
+    /// re-analysed.
+    /// </summary>
+    /// <remarks>
+    /// A solution is a graph of projects, and a version of a project holds a version of each project it references.
+    /// Editing a project that is low in the reference graph therefore produces a new version of every project above
+    /// it. If any of those versions is retained, the amount of memory involved is a multiple of the size of the
+    /// solution rather than of the size of a single project, which matches the order of magnitude in the reports.
+    /// </remarks>
+    [Fact]
+    public async Task ReferencedProjectVersions_AreNotRetained()
+    {
+        using var testContext = this.CreateTestContext();
+        var provider = new ProjectVersionProvider( testContext.ServiceProvider, true );
+
+        var compilations = await RunReferenceChainAsync( testContext, provider, nameof(this.ReferencedProjectVersions_AreNotRetained), 15 );
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            0,
+            "compilations of a referenced project and of its dependent project",
+            ("projectVersionProvider", provider) );
+    }
+
+    /// <summary>
+    /// Edits a referenced project repeatedly and computes, for every version, the difference of the dependent project.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static async Task<WeakReference[]> RunReferenceChainAsync(
+        TestContext testContext,
+        ProjectVersionProvider provider,
+        string assemblyName,
+        int versionCount )
+    {
+        var masterCode = new Dictionary<string, string> { ["Master.cs"] = GetCode( 0 ) };
+        Compilation currentMaster = testContext.CreateCSharpCompilation( masterCode, assemblyName: assemblyName + ".Master" );
+
+        var dependentCode = new Dictionary<string, string> { ["Dependent.cs"] = "public class D { }" };
+
+        Compilation currentDependent = testContext.CreateCSharpCompilation(
+            dependentCode,
+            assemblyName: assemblyName + ".Dependent",
+            additionalReferences: new[] { currentMaster.ToMetadataReference() } );
+
+        _ = await provider.GetCompilationChangesAsync( null, currentDependent );
+
+        // Two weak references per iteration: one for the version of the referenced project and one for the version of
+        // the dependent project.
+        var weakReferences = new WeakReference[versionCount * 2];
+
+        for ( var version = 0; version < versionCount; version++ )
+        {
+            var nextMaster = ReplaceCode( currentMaster, "Master.cs", version + 1 );
+
+            var oldReference = currentDependent.References
+                .OfType<CompilationReference>()
+                .Single( r => ReferenceEquals( r.Compilation, currentMaster ) );
+
+            var nextDependent = currentDependent.ReplaceReference( oldReference, nextMaster.ToMetadataReference() );
+
+            _ = await provider.GetCompilationChangesAsync( currentDependent, nextDependent );
+
+            weakReferences[( version * 2 ) + 0] = new WeakReference( currentMaster );
+            weakReferences[( version * 2 ) + 1] = new WeakReference( currentDependent );
+
+            currentMaster = nextMaster;
+            currentDependent = nextDependent;
+        }
+
+        return weakReferences;
+    }
+
+    /// <summary>
+    /// Creates the first version of the simulated project.
+    /// </summary>
+    private static Compilation CreateInitialCompilation( TestContext testContext, string assemblyName )
+        => testContext.CreateCSharpCompilation( new Dictionary<string, string> { ["Code.cs"] = GetCode( 0 ) }, assemblyName: assemblyName );
+
+    /// <summary>
+    /// Produces the next version of a compilation by replacing the syntax tree of one source file, in the same way as
+    /// Roslyn does when the user types.
+    /// </summary>
+    private static Compilation ReplaceCode( Compilation compilation, string fileName, int version )
+    {
+        var oldTree = compilation.SyntaxTrees.Single( t => string.Equals( t.FilePath, fileName, StringComparison.OrdinalIgnoreCase ) );
+        var newTree = CSharpSyntaxTree.ParseText( GetCode( version ), (CSharpParseOptions) oldTree.Options, fileName, oldTree.Encoding );
+
+        return compilation.ReplaceSyntaxTree( oldTree, newTree );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/RetentionPathFinder.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/RetentionPathFinder.cs
@@ -1,0 +1,592 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Finds the shortest chain of object references from a set of roots to a target object, by walking the object graph
+/// with reflection.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A test that asserts that a <see cref="Compilation"/> has been collected reports a failure that is difficult to act
+/// upon: the assertion says that something retains the compilation, but not what. This class answers that question.
+/// The roots given to <see cref="TryFindPath"/> are the objects that a design-time host keeps alive for the lifetime
+/// of a project, typically the pipeline factory and the services it owns, and the target is the object that the test
+/// expected to be collected.
+/// </para>
+/// <para>
+/// The walk is deliberately not a heap walk. It only follows fields that are reachable from the given roots, which is
+/// exactly the set of paths that Metalama is responsible for. A reference held through a
+/// <see cref="WeakReference"/> or a <see cref="WeakReference{T}"/> is invisible to reflection, because the target is
+/// stored in a native handle, therefore weak references are naturally excluded. A
+/// <see cref="ConditionalWeakTable{TKey,TValue}"/> is equally invisible, so it is enumerated explicitly and its edges
+/// are reported as conditional, because such an edge only keeps the value alive while the key is alive.
+/// </para>
+/// <para>
+/// The walk stops at objects that are themselves candidate targets, such as a <see cref="Compilation"/> or a
+/// <see cref="SyntaxTree"/>, because the internal graph of those objects is large and is not the responsibility of
+/// this codebase.
+/// </para>
+/// </remarks>
+internal sealed class RetentionPathFinder
+{
+    /// <summary>
+    /// The maximum number of distinct objects visited before the search gives up.
+    /// </summary>
+    private const int _defaultMaxObjects = 400_000;
+
+    /// <summary>
+    /// The maximum number of elements inspected in a single array.
+    /// </summary>
+    private const int _maxArrayElements = 100_000;
+
+    /// <summary>
+    /// The maximum nesting depth when recursing into the fields of a value type.
+    /// </summary>
+    private const int _maxStructDepth = 6;
+
+    private readonly int _maxObjects;
+    private readonly TimeSpan _timeout;
+    private readonly Dictionary<object, Edge> _parents = new( ReferenceEqualityComparer.Instance );
+    private readonly HashSet<object> _visited = new( ReferenceEqualityComparer.Instance );
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="RetentionPathFinder"/> class.
+    /// </summary>
+    /// <param name="maxObjects">The maximum number of distinct objects to visit. The search reports failure when the budget is exhausted.</param>
+    /// <param name="timeout">The maximum duration of the search. A <c>null</c> value means one minute.</param>
+    public RetentionPathFinder( int maxObjects = _defaultMaxObjects, TimeSpan? timeout = null )
+    {
+        this._maxObjects = maxObjects;
+        this._timeout = timeout ?? TimeSpan.FromMinutes( 1 );
+    }
+
+    /// <summary>
+    /// Gets the number of distinct objects visited by the last call to <see cref="TryFindPath"/>.
+    /// </summary>
+    public int VisitedObjectCount => this._visited.Count;
+
+    /// <summary>
+    /// Gets a value indicating whether the last call to <see cref="TryFindPath"/> stopped because it exhausted its
+    /// budget of objects or its timeout, in which case a negative result is inconclusive.
+    /// </summary>
+    public bool IsExhausted { get; private set; }
+
+    /// <summary>
+    /// Attempts to find the shortest chain of strong or conditional references from one of <paramref name="roots"/>
+    /// to <paramref name="target"/>.
+    /// </summary>
+    /// <param name="target">The object whose retention must be explained.</param>
+    /// <param name="path">On success, a human-readable description of the chain, one hop per line.</param>
+    /// <param name="roots">The objects from which the search starts, each paired with the name to display for it.</param>
+    /// <returns><c>true</c> if a chain was found.</returns>
+    public bool TryFindPath( object target, out string? path, params (string Name, object Root)[] roots )
+    {
+        this._parents.Clear();
+        this._visited.Clear();
+        this.IsExhausted = false;
+
+        var stopwatch = Stopwatch.StartNew();
+        var queue = new Queue<object>();
+
+        foreach ( var (name, root) in roots )
+        {
+            if ( root == null! )
+            {
+                continue;
+            }
+
+            if ( ReferenceEquals( root, target ) )
+            {
+                path = $"{name} ({FormatType( root.GetType() )}) is the target itself.";
+
+                return true;
+            }
+
+            if ( this._visited.Add( root ) )
+            {
+                this._parents[root] = new Edge( null, name, false );
+                queue.Enqueue( root );
+            }
+        }
+
+        // Conditional weak tables are set aside during the strong pass and revisited afterwards, because the value of
+        // an entry is only reachable while its key is, and the key may only be proven reachable later.
+        List<object> conditionalTables = new();
+
+        while ( true )
+        {
+            // Strong pass: follow ordinary references until nothing new is discovered.
+            while ( queue.Count > 0 )
+            {
+                if ( this._visited.Count > this._maxObjects || stopwatch.Elapsed > this._timeout )
+                {
+                    this.IsExhausted = true;
+                    path = null;
+
+                    return false;
+                }
+
+                var current = queue.Dequeue();
+
+                if ( IsConditionalWeakTable( current.GetType() ) )
+                {
+                    conditionalTables.Add( current );
+
+                    continue;
+                }
+
+                foreach ( var reference in EnumerateReferences( current ) )
+                {
+                    if ( this.Visit( current, reference, target, queue, out path ) )
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // Conditional pass: follow the value of every entry whose key has been proven reachable by the strong
+            // pass. A key that is not reachable cannot keep its value alive, therefore such a value explains nothing.
+            // This is the marking rule the garbage collector itself applies to ephemerons, and applying it here is
+            // what prevents the search from reporting that an object is retained by a table entry that the object
+            // itself keys.
+            foreach ( var table in conditionalTables.ToArray() )
+            {
+                foreach ( var reference in this.EnumerateReachableConditionalValues( table ) )
+                {
+                    if ( this.Visit( table, reference, target, queue, out path ) )
+                    {
+                        return true;
+                    }
+                }
+            }
+
+            // The conditional pass may have made new objects reachable, which may in turn make more keys reachable.
+            // The search therefore alternates between the two passes until it reaches a fixed point.
+            if ( queue.Count == 0 )
+            {
+                break;
+            }
+        }
+
+        path = null;
+
+        return false;
+    }
+
+    /// <summary>
+    /// Records the discovery of one reference, and reports whether it reaches the target.
+    /// </summary>
+    private bool Visit( object parent, Reference reference, object target, Queue<object> queue, out string? path )
+    {
+        var child = reference.Target;
+
+        if ( ReferenceEquals( child, target ) )
+        {
+            this._parents[child] = new Edge( parent, reference.Label, reference.IsConditional );
+            path = this.FormatPath( child );
+
+            return true;
+        }
+
+        path = null;
+
+        if ( !this._visited.Add( child ) )
+        {
+            return false;
+        }
+
+        this._parents[child] = new Edge( parent, reference.Label, reference.IsConditional );
+
+        if ( ShouldTraverse( child ) )
+        {
+            queue.Enqueue( child );
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Builds the human-readable description of the chain that leads to <paramref name="target"/>.
+    /// </summary>
+    private string FormatPath( object target )
+    {
+        var hops = new List<Edge>();
+        var hopTargets = new List<object>();
+        var current = target;
+
+        while ( this._parents.TryGetValue( current, out var edge ) )
+        {
+            hops.Add( edge );
+            hopTargets.Add( current );
+
+            if ( edge.Parent == null )
+            {
+                break;
+            }
+
+            current = edge.Parent;
+        }
+
+        hops.Reverse();
+        hopTargets.Reverse();
+
+        var stringBuilder = new StringBuilder();
+
+        for ( var i = 0; i < hops.Count; i++ )
+        {
+            var indent = new string( ' ', i * 2 );
+            var kind = hops[i].IsConditional ? " [conditional]" : "";
+            stringBuilder.AppendLine( $"{indent}{hops[i].Label} : {FormatType( hopTargets[i].GetType() )}{kind}" );
+        }
+
+        return stringBuilder.ToString().TrimEnd();
+    }
+
+    /// <summary>
+    /// Determines whether the object graph should be explored through the given object.
+    /// </summary>
+    /// <remarks>
+    /// Objects that are themselves plausible targets of a retention assertion, and objects belonging to the reflection
+    /// or threading infrastructure, are not traversed. Traversing them would multiply the cost of the search without
+    /// producing a chain that this codebase could act upon.
+    /// </remarks>
+    private static bool ShouldTraverse( object obj )
+    {
+        switch ( obj )
+        {
+            case Compilation:
+            case SyntaxTree:
+            case SemanticModel:
+            case ISymbol:
+            case string:
+            case Type:
+            case Assembly:
+            case Module:
+            case MemberInfo:
+            case ParameterInfo:
+            case Thread:
+            case AppDomain:
+                return false;
+
+            default:
+                return true;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates the outgoing strong and conditional references of an object.
+    /// </summary>
+    private static IEnumerable<Reference> EnumerateReferences( object obj )
+    {
+        var type = obj.GetType();
+
+        if ( obj is Array array )
+        {
+            foreach ( var reference in EnumerateArray( array ) )
+            {
+                yield return reference;
+            }
+
+            yield break;
+        }
+
+        foreach ( var reference in EnumerateFields( obj, type, "", 0 ) )
+        {
+            yield return reference;
+        }
+    }
+
+    /// <summary>
+    /// Enumerates the elements of a single-dimensional array.
+    /// </summary>
+    private static IEnumerable<Reference> EnumerateArray( Array array )
+    {
+        if ( array.Rank != 1 )
+        {
+            yield break;
+        }
+
+        var elementType = array.GetType().GetElementType()!;
+
+        if ( elementType.IsPrimitive || elementType.IsEnum || elementType == typeof(decimal) )
+        {
+            yield break;
+        }
+
+        var length = Math.Min( array.Length, _maxArrayElements );
+
+        for ( var i = 0; i < length; i++ )
+        {
+            object? value;
+
+            try
+            {
+                value = array.GetValue( i );
+            }
+            catch ( Exception )
+            {
+                continue;
+            }
+
+            if ( value == null )
+            {
+                continue;
+            }
+
+            if ( elementType.IsValueType )
+            {
+                foreach ( var reference in EnumerateFields( value, elementType, $"[{i}]", 1 ) )
+                {
+                    yield return reference;
+                }
+            }
+            else
+            {
+                yield return new Reference( $"[{i}]", value, false );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Enumerates the instance fields of an object or of a boxed value, including the fields declared by base types.
+    /// </summary>
+    /// <param name="obj">The object or boxed value whose fields are read.</param>
+    /// <param name="type">The type whose fields are enumerated. For a boxed value this is the declared type of the value.</param>
+    /// <param name="prefix">The label prefix, used when recursing into the fields of a value type.</param>
+    /// <param name="structDepth">The current nesting depth inside value types.</param>
+    private static IEnumerable<Reference> EnumerateFields( object obj, Type type, string prefix, int structDepth )
+    {
+        for ( var currentType = type; currentType != null && currentType != typeof(object); currentType = currentType.BaseType )
+        {
+            FieldInfo[] fields;
+
+            try
+            {
+                fields = currentType.GetFields( BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.DeclaredOnly );
+            }
+            catch ( Exception )
+            {
+                yield break;
+            }
+
+            foreach ( var field in fields )
+            {
+                var fieldType = field.FieldType;
+
+                if ( fieldType.IsPrimitive || fieldType.IsEnum || fieldType.IsPointer || fieldType == typeof(IntPtr) || fieldType == typeof(UIntPtr) )
+                {
+                    continue;
+                }
+
+                object? value;
+
+                try
+                {
+                    value = field.GetValue( obj );
+                }
+                catch ( Exception )
+                {
+                    // Fields of by-reference-like types cannot be read by reflection, and some runtime types refuse
+                    // access. Such a field cannot be the cause of a managed retention that this test could fix.
+                    continue;
+                }
+
+                if ( value == null )
+                {
+                    continue;
+                }
+
+                var label = prefix.Length == 0 ? field.Name : $"{prefix}.{field.Name}";
+
+                if ( fieldType.IsValueType )
+                {
+                    if ( structDepth >= _maxStructDepth )
+                    {
+                        continue;
+                    }
+
+                    foreach ( var reference in EnumerateFields( value, fieldType, label, structDepth + 1 ) )
+                    {
+                        yield return reference;
+                    }
+                }
+                else
+                {
+                    yield return new Reference( label, value, false );
+                }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Determines whether a type is a <see cref="ConditionalWeakTable{TKey,TValue}"/>.
+    /// </summary>
+    private static bool IsConditionalWeakTable( Type type )
+        => type.IsGenericType && type.GetGenericTypeDefinition() == typeof(ConditionalWeakTable<,>);
+
+    /// <summary>
+    /// Enumerates the values of the entries of a <see cref="ConditionalWeakTable{TKey,TValue}"/> whose key has
+    /// already been proven reachable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The entries are held through dependent handles, which reflection cannot read, therefore the table is
+    /// enumerated through its <see cref="IEnumerable"/> implementation.
+    /// </para>
+    /// <para>
+    /// Keys are never reported as reachable through the table, because a table does not keep its keys alive. An edge
+    /// that arrived at an object because that object is a key would name a path along which the garbage collector is
+    /// free to reclaim the object, would attribute to the table a retention it does not cause, and would hide the
+    /// reference that is genuinely responsible.
+    /// </para>
+    /// <para>
+    /// A value is reported only when its key is already known to be reachable, because that is the condition under
+    /// which the entry keeps the value alive. Without this restriction the search would report that an object is
+    /// retained by an entry that the object itself keys, which is circular.
+    /// </para>
+    /// </remarks>
+    private IEnumerable<Reference> EnumerateReachableConditionalValues( object table )
+    {
+        List<Reference> references = new();
+
+        try
+        {
+            var index = 0;
+
+            foreach ( var entry in (IEnumerable) table )
+            {
+                index++;
+
+                if ( entry == null )
+                {
+                    continue;
+                }
+
+                var entryType = entry.GetType();
+                var key = entryType.GetProperty( "Key" )?.GetValue( entry );
+
+                if ( key == null || !this._visited.Contains( key ) )
+                {
+                    continue;
+                }
+
+                var value = entryType.GetProperty( "Value" )?.GetValue( entry );
+
+                if ( value != null )
+                {
+                    references.Add( new Reference( $"[key #{index}: {FormatType( key.GetType() )}].Value", value, true ) );
+                }
+            }
+        }
+        catch ( Exception )
+        {
+            // The table cannot be enumerated on this runtime. The absence of these edges only makes the search less
+            // informative, never incorrect.
+        }
+
+        return references;
+    }
+
+    /// <summary>
+    /// Formats a type name in a form that is short enough to read in a test failure message.
+    /// </summary>
+    private static string FormatType( Type type )
+    {
+        if ( !type.IsGenericType )
+        {
+            return type.Name;
+        }
+
+        var name = type.Name;
+        var backTick = name.IndexOf( '`' );
+
+        if ( backTick > 0 )
+        {
+            name = name.Substring( 0, backTick );
+        }
+
+        var arguments = type.GetGenericArguments();
+        var formattedArguments = new string[arguments.Length];
+
+        for ( var i = 0; i < arguments.Length; i++ )
+        {
+            formattedArguments[i] = FormatType( arguments[i] );
+        }
+
+        return $"{name}<{string.Join( ",", formattedArguments )}>";
+    }
+
+    /// <summary>
+    /// An outgoing reference from an object, as discovered by <see cref="EnumerateReferences"/>.
+    /// </summary>
+    private readonly struct Reference
+    {
+        public string Label { get; }
+
+        public object Target { get; }
+
+        /// <summary>
+        /// Gets a value indicating whether the reference is held through a
+        /// <see cref="ConditionalWeakTable{TKey,TValue}"/>, in which case it only extends the lifetime of the target
+        /// while the corresponding key is alive.
+        /// </summary>
+        public bool IsConditional { get; }
+
+        public Reference( string label, object target, bool isConditional )
+        {
+            this.Label = label;
+            this.Target = target;
+            this.IsConditional = isConditional;
+        }
+    }
+
+    /// <summary>
+    /// The incoming edge of a visited object, used to reconstruct the chain once the target has been found.
+    /// </summary>
+    private readonly struct Edge
+    {
+        public object? Parent { get; }
+
+        public string Label { get; }
+
+        public bool IsConditional { get; }
+
+        public Edge( object? parent, string label, bool isConditional )
+        {
+            this.Parent = parent;
+            this.Label = label;
+            this.IsConditional = isConditional;
+        }
+    }
+
+    /// <summary>
+    /// Compares objects by reference, so that the search is not affected by user-defined equality.
+    /// </summary>
+    /// <remarks>
+    /// The framework type of the same name is not available on all target frameworks of this test project, therefore
+    /// it is defined here.
+    /// </remarks>
+    private sealed class ReferenceEqualityComparer : IEqualityComparer<object>
+    {
+        public static ReferenceEqualityComparer Instance { get; } = new();
+
+        private ReferenceEqualityComparer() { }
+
+        public new bool Equals( object? x, object? y ) => ReferenceEquals( x, y );
+
+        public int GetHashCode( object obj ) => RuntimeHelpers.GetHashCode( obj );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/SourceGeneratorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/SourceGeneratorMemoryLeakTests.cs
@@ -115,6 +115,8 @@ public sealed class SourceGeneratorMemoryLeakTests : DesignTimeTestBase
             testContext.ProjectOptions,
             projectKey );
 
+        Exception? disposeException = null;
+
         try
         {
             const int editCount = 15;
@@ -130,16 +132,27 @@ public sealed class SourceGeneratorMemoryLeakTests : DesignTimeTestBase
         finally
         {
             // The source generator is not disposed by a using statement, because disposing it waits for the pending
-            // tasks and therefore throws when one of them was cancelled. An exception raised while the stack is
-            // unwinding replaces the exception that the assertion raised, and would hide the result of the test.
+            // tasks and therefore throws when one of them was stranded in the canceled state. An exception raised
+            // while the stack is unwinding replaces the exception that the assertion raised, and would hide the
+            // result of the test. The failure is recorded instead and reported below.
             try
             {
                 sourceGenerator.Dispose();
             }
             catch ( Exception e )
             {
-                this.TestOutput.WriteLine( $"Disposing the source generator failed, which is a second symptom of the same defect: {e.Message}" );
+                disposeException = e;
             }
+        }
+
+        // This is only reached when the assertion above succeeded, because an assertion failure propagates through
+        // the finally block. A disposal that fails at this point is the second symptom of the same defect, so it
+        // fails the test rather than being merely logged.
+        if ( disposeException != null )
+        {
+            Assert.Fail(
+                "The compilations were released, but disposing the source generator failed. Disposal waits for the "
+                + $"pending tasks, so this means one of them was left in the canceled state: {disposeException}" );
         }
     }
 

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/SourceGeneratorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/SourceGeneratorMemoryLeakTests.cs
@@ -16,6 +16,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
 using Xunit;
 using Xunit.Abstractions;
 
@@ -95,7 +96,7 @@ public sealed class SourceGeneratorMemoryLeakTests : DesignTimeTestBase
     /// generator.
     /// </summary>
     [Fact]
-    public void CancelledAnalyses_DoNotRetainTheirCompilations()
+    public async Task CancelledAnalyses_DoNotRetainTheirCompilations()
     {
         using var testContext = this.CreateTestContext( new TestContextOptions { HasSourceGeneratorTouchFile = true } );
 
@@ -121,6 +122,11 @@ public sealed class SourceGeneratorMemoryLeakTests : DesignTimeTestBase
         {
             const int editCount = 15;
             var compilations = RunEditingSession( testContext, sourceGenerator, editCount );
+
+            // The scheduled analyses remove their own entry from the bag when they run, and they run on the thread
+            // pool. Asserting before they have run would observe a generator that is merely still busy, and the
+            // result would depend on how loaded the thread pool happens to be.
+            await PendingTasksHelper.WaitForPendingTasksAsync( sourceGenerator.PendingTasks, testContext );
 
             MemoryLeakAssert.AtMostAlive(
                 compilations,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/SourceGeneratorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/SourceGeneratorMemoryLeakTests.cs
@@ -1,0 +1,181 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime;
+using Metalama.Framework.DesignTime.Pipeline;
+using Metalama.Framework.DesignTime.SourceGeneration;
+using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.Utilities.Threading;
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that the source generator of the analysis process does not retain the compilations whose analysis was
+/// abandoned because a newer version arrived.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Roslyn calls the source generator once per version of the compilation, that is, once per keystroke.
+/// <c>AnalysisProcessProjectSourceGenerator.GenerateSources</c> serves the previous result immediately, cancels the
+/// analysis of the previous version, and schedules the analysis of the new one on a background task whose delegate
+/// closes over the new compilation. A user typing continuously therefore produces a long sequence of scheduled
+/// analyses of which only the last one is useful.
+/// </para>
+/// <para>
+/// These tests make the cancellation deterministic by supplying a factory that returns cancellation sources which are
+/// already signalled. That is not an artificial situation: it is the limit case of the race that occurs whenever the
+/// next keystroke arrives before the thread pool has started the task scheduled for the previous one, which is the
+/// normal situation when a project is large enough for the analysis to take longer than the interval between two
+/// keystrokes.
+/// </para>
+/// </remarks>
+public sealed class SourceGeneratorMemoryLeakTests : DesignTimeTestBase
+{
+    public SourceGeneratorMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    private const string _aspectFileName = "Aspect.cs";
+    private const string _targetFileName = "Target.cs";
+
+    private const string _aspectCode = """
+                                       using Metalama.Framework.Aspects;
+
+                                       public class LogAttribute : OverrideMethodAspect
+                                       {
+                                           public override dynamic? OverrideMethod()
+                                           {
+                                               return meta.Proceed();
+                                           }
+                                       }
+                                       """;
+
+    /// <summary>
+    /// A factory of cancellation sources that are signalled from the moment they are created.
+    /// </summary>
+    /// <remarks>
+    /// It reproduces, deterministically, the outcome of the race in which a scheduled analysis is cancelled by the
+    /// arrival of the next version before the thread pool has started it.
+    /// </remarks>
+    private sealed class AlreadyCancelledTokenSourceFactory : ITestableCancellationTokenSourceFactory
+    {
+        public TestableCancellationTokenSource Create()
+        {
+            var source = new TestableCancellationTokenSource();
+            source.CancellationTokenSource.Cancel();
+
+            return source;
+        }
+    }
+
+    /// <summary>
+    /// Returns the content of the run-time file for a given version.
+    /// </summary>
+    private static string GetTargetCode( int version )
+        => $$"""
+             public class Target
+             {
+                 [Log]
+                 public int Method() => {{version}};
+             }
+             """;
+
+    /// <summary>
+    /// Verifies that the versions whose analysis was cancelled before it started are not retained by the source
+    /// generator.
+    /// </summary>
+    [Fact]
+    public void CancelledAnalyses_DoNotRetainTheirCompilations()
+    {
+        using var testContext = this.CreateTestContext( new TestContextOptions { HasSourceGeneratorTouchFile = true } );
+
+        GlobalServiceProvider serviceProvider = testContext.ServiceProvider;
+        serviceProvider = serviceProvider.Underlying.WithService( new AnalysisProcessEventHub( serviceProvider ) );
+
+        using var pipelineFactory = new TestDesignTimeAspectPipelineFactory( testContext, serviceProvider );
+
+        var generatorServiceProvider = serviceProvider.Underlying
+            .WithService( pipelineFactory )
+            .WithService( new AlreadyCancelledTokenSourceFactory(), allowOverride: true );
+
+        var projectKey = ProjectKeyFactory.CreateTest( nameof(this.CancelledAnalyses_DoNotRetainTheirCompilations) );
+
+        var sourceGenerator = new AnalysisProcessProjectSourceGenerator(
+            generatorServiceProvider,
+            testContext.ProjectOptions,
+            projectKey );
+
+        try
+        {
+            const int editCount = 15;
+            var compilations = RunEditingSession( testContext, sourceGenerator, editCount );
+
+            MemoryLeakAssert.AtMostAlive(
+                compilations,
+                2,
+                $"compilations submitted to the source generator during {editCount} edits",
+                ("sourceGenerator", sourceGenerator),
+                ("pipelineFactory", pipelineFactory) );
+        }
+        finally
+        {
+            // The source generator is not disposed by a using statement, because disposing it waits for the pending
+            // tasks and therefore throws when one of them was cancelled. An exception raised while the stack is
+            // unwinding replaces the exception that the assertion raised, and would hide the result of the test.
+            try
+            {
+                sourceGenerator.Dispose();
+            }
+            catch ( Exception e )
+            {
+                this.TestOutput.WriteLine( $"Disposing the source generator failed, which is a second symptom of the same defect: {e.Message}" );
+            }
+        }
+    }
+
+    /// <summary>
+    /// Submits a sequence of versions to the source generator and returns weak references to all of them.
+    /// </summary>
+    /// <remarks>
+    /// Every strong reference to a compilation is confined to this method, so that none of them survives in the frame
+    /// of the calling test method.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static WeakReference[] RunEditingSession( TestContext testContext, ProjectSourceGenerator sourceGenerator, int editCount )
+    {
+        var code = new Dictionary<string, string> { [_aspectFileName] = _aspectCode, [_targetFileName] = GetTargetCode( 0 ) };
+
+        Compilation current = testContext.CreateCSharpCompilation( code, assemblyName: "SourceGeneratorMemoryLeakTest" );
+        var parseOptions = (CSharpParseOptions) current.SyntaxTrees.First().Options;
+
+        // The first call is synchronous and populates the cache of the generator, which is the precondition for the
+        // asynchronous path taken by all the subsequent calls.
+        _ = sourceGenerator.GenerateSources( current, default );
+
+        var weakReferences = new WeakReference[editCount];
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            var oldTree = current.SyntaxTrees.Single( t => t.FilePath == _targetFileName );
+            var newTree = CSharpSyntaxTree.ParseText( GetTargetCode( version ), parseOptions, _targetFileName, oldTree.Encoding );
+
+            current = current.ReplaceSyntaxTree( oldTree, newTree );
+
+            _ = sourceGenerator.GenerateSources( current, default );
+
+            weakReferences[version - 1] = new WeakReference( current );
+        }
+
+        return weakReferences;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
@@ -2,6 +2,8 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+#pragma warning disable VSTHRD103 // Cancel synchronously blocks - CancelAsync not available on all target frameworks
+
 using Metalama.Framework.DesignTime.Utilities;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
@@ -86,6 +86,30 @@ public sealed class TaskBagMemoryLeakTests : DesignTimeTestBase
     }
 
     /// <summary>
+    /// Waits until every task of the bag has run, so that the assertions that follow do not depend on the scheduling
+    /// of the thread pool.
+    /// </summary>
+    /// <remarks>
+    /// The entry of a task is removed by the task itself, therefore an assertion made before the task has run would
+    /// observe a bag that is merely still busy. A bag that strands a task leaves it in the canceled state, which
+    /// <see cref="TaskBag.WaitAllAsync"/> surfaces as an exception. That exception is swallowed here, because it is
+    /// the very defect that the assertions of the caller are there to diagnose, and their failure message names the
+    /// field that retains the compilation. The cancellation of the test context is not swallowed, so a bag that never
+    /// completes fails the test rather than hanging it.
+    /// </remarks>
+    private static async Task WaitForPendingTasksAsync( TaskBag taskBag, TestContext testContext )
+    {
+        try
+        {
+            await taskBag.WaitAllAsync( testContext.CancellationToken );
+        }
+        catch ( OperationCanceledException ) when ( !testContext.CancellationToken.IsCancellationRequested )
+        {
+            // See the remarks above.
+        }
+    }
+
+    /// <summary>
     /// Verifies that a task that completes normally is removed from the bag and does not retain what it captured.
     /// </summary>
     /// <remarks>
@@ -123,7 +147,7 @@ public sealed class TaskBagMemoryLeakTests : DesignTimeTestBase
     /// with the closure that produced it.
     /// </remarks>
     [Fact]
-    public void CancelledBeforeStart_TaskIsRemovedFromTheBag()
+    public async Task CancelledBeforeStart_TaskIsRemovedFromTheBag()
     {
         using var testContext = this.CreateTestContext();
         var taskBag = CreateTaskBag( testContext );
@@ -136,6 +160,8 @@ public sealed class TaskBagMemoryLeakTests : DesignTimeTestBase
             taskBag,
             nameof(this.CancelledBeforeStart_TaskIsRemovedFromTheBag),
             cancellationTokenSource.Token );
+
+        await WaitForPendingTasksAsync( taskBag, testContext );
 
         // The memory consequence is asserted first, because its failure message contains the chain of references that
         // retains the compilation, which is the information needed to act on the defect.
@@ -155,7 +181,7 @@ public sealed class TaskBagMemoryLeakTests : DesignTimeTestBase
     /// grows with the number of keystrokes, which is the shape of the growth that has been reported.
     /// </remarks>
     [Fact]
-    public void RepeatedCancellationBeforeStart_DoesNotAccumulate()
+    public async Task RepeatedCancellationBeforeStart_DoesNotAccumulate()
     {
         using var testContext = this.CreateTestContext();
         var taskBag = CreateTaskBag( testContext );
@@ -174,6 +200,8 @@ public sealed class TaskBagMemoryLeakTests : DesignTimeTestBase
                 $"{nameof(this.RepeatedCancellationBeforeStart_DoesNotAccumulate)}{i}",
                 cancellationTokenSource.Token );
         }
+
+        await WaitForPendingTasksAsync( taskBag, testContext );
 
         MemoryLeakAssert.AtMostAlive(
             compilations,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
@@ -89,25 +89,8 @@ public sealed class TaskBagMemoryLeakTests : DesignTimeTestBase
     /// Waits until every task of the bag has run, so that the assertions that follow do not depend on the scheduling
     /// of the thread pool.
     /// </summary>
-    /// <remarks>
-    /// The entry of a task is removed by the task itself, therefore an assertion made before the task has run would
-    /// observe a bag that is merely still busy. A bag that strands a task leaves it in the canceled state, which
-    /// <see cref="TaskBag.WaitAllAsync"/> surfaces as an exception. That exception is swallowed here, because it is
-    /// the very defect that the assertions of the caller are there to diagnose, and their failure message names the
-    /// field that retains the compilation. The cancellation of the test context is not swallowed, so a bag that never
-    /// completes fails the test rather than hanging it.
-    /// </remarks>
-    private static async Task WaitForPendingTasksAsync( TaskBag taskBag, TestContext testContext )
-    {
-        try
-        {
-            await taskBag.WaitAllAsync( testContext.CancellationToken );
-        }
-        catch ( OperationCanceledException ) when ( !testContext.CancellationToken.IsCancellationRequested )
-        {
-            // See the remarks above.
-        }
-    }
+    private static Task WaitForPendingTasksAsync( TaskBag taskBag, TestContext testContext )
+        => PendingTasksHelper.WaitForPendingTasksAsync( taskBag, testContext );
 
     /// <summary>
     /// Verifies that a task that completes normally is removed from the bag and does not retain what it captured.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TaskBagMemoryLeakTests.cs
@@ -1,0 +1,186 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Utilities;
+using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that <see cref="TaskBag"/> does not retain the tasks it was given once they can no longer run.
+/// </summary>
+/// <remarks>
+/// <para>
+/// <see cref="TaskBag"/> holds, for every pending task, both the <see cref="Task"/> and the
+/// <see cref="Func{TResult}"/> that produced it, and removes the entry from a <c>finally</c> block that runs at the
+/// end of the delegate. The source generator of the analysis process enqueues one such task per call to
+/// <c>GenerateSources</c>, that is, once per keystroke, and the delegate it enqueues is a closure over the
+/// <see cref="Compilation"/> that Roslyn has just produced. An entry that is never removed therefore retains a whole
+/// version of the project.
+/// </para>
+/// <para>
+/// The same source generator cancels the token of the previous call before enqueuing the next one, so that only the
+/// most recent version is computed. A user who types faster than the pipeline runs produces a long sequence of tasks
+/// that are cancelled before they start. This is the situation these tests reproduce, and it is the reason why the
+/// growth is difficult to observe in a laboratory: a scenario that submits one version at a time, and waits for each
+/// of them, never cancels anything.
+/// </para>
+/// </remarks>
+public sealed class TaskBagMemoryLeakTests : DesignTimeTestBase
+{
+    public TaskBagMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// Creates a <see cref="TaskBag"/> that uses the services of a test context.
+    /// </summary>
+    private static TaskBag CreateTaskBag( TestContext testContext )
+    {
+        GlobalServiceProvider serviceProvider = testContext.ServiceProvider;
+
+        return new TaskBag( serviceProvider.GetLoggerFactory().GetLogger( nameof(TaskBagMemoryLeakTests) ), serviceProvider );
+    }
+
+    /// <summary>
+    /// Enqueues one task whose delegate captures a compilation, and returns only a weak reference to that
+    /// compilation.
+    /// </summary>
+    /// <remarks>
+    /// The delegate is deliberately shaped like the one that the source generator of the analysis process enqueues:
+    /// it closes over the compilation that is being analysed.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static WeakReference EnqueueTaskCapturingACompilation(
+        TestContext testContext,
+        TaskBag taskBag,
+        string assemblyName,
+        CancellationToken cancellationToken )
+    {
+        var compilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["Code.cs"] = "public class C { }" },
+            assemblyName: assemblyName );
+
+        taskBag.Enqueue( () => ObserveAsync( compilation ), cancellationToken );
+
+        return new WeakReference( compilation );
+    }
+
+    /// <summary>
+    /// The body of the enqueued task. It exists only so that the delegate has a reason to capture the compilation.
+    /// </summary>
+    private static Task ObserveAsync( Compilation compilation )
+    {
+        _ = compilation.AssemblyName;
+
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// Verifies that a task that completes normally is removed from the bag and does not retain what it captured.
+    /// </summary>
+    /// <remarks>
+    /// This is the control for <see cref="CancelledBeforeStart_TaskIsRemovedFromTheBag"/>. It establishes that the
+    /// removal mechanism works on the ordinary path, so that a failure of the other test is attributable to
+    /// cancellation rather than to the test method itself.
+    /// </remarks>
+    [Fact]
+    public async Task CompletedTask_IsRemovedFromTheBag()
+    {
+        using var testContext = this.CreateTestContext();
+        var taskBag = CreateTaskBag( testContext );
+
+        var compilation = EnqueueTaskCapturingACompilation(
+            testContext,
+            taskBag,
+            nameof(this.CompletedTask_IsRemovedFromTheBag),
+            CancellationToken.None );
+
+        await taskBag.WaitAllAsync();
+
+        Assert.True( taskBag.IsEmpty, "The bag still holds an entry for a task that has completed." );
+
+        MemoryLeakAssert.Collected( compilation, "The compilation captured by a completed task", ("taskBag", taskBag) );
+    }
+
+    /// <summary>
+    /// Verifies that a task whose cancellation token is already signalled when it is enqueued does not stay in the
+    /// bag.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Task.Run(Func{Task},CancellationToken)"/> does not invoke the delegate at all when the token is
+    /// already signalled: the task goes directly to the canceled state. The <c>finally</c> block that removes the
+    /// entry from the bag is part of that delegate, therefore it never runs, and the entry stays in the bag together
+    /// with the closure that produced it.
+    /// </remarks>
+    [Fact]
+    public void CancelledBeforeStart_TaskIsRemovedFromTheBag()
+    {
+        using var testContext = this.CreateTestContext();
+        var taskBag = CreateTaskBag( testContext );
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+        cancellationTokenSource.Cancel();
+
+        var compilation = EnqueueTaskCapturingACompilation(
+            testContext,
+            taskBag,
+            nameof(this.CancelledBeforeStart_TaskIsRemovedFromTheBag),
+            cancellationTokenSource.Token );
+
+        // The memory consequence is asserted first, because its failure message contains the chain of references that
+        // retains the compilation, which is the information needed to act on the defect.
+        MemoryLeakAssert.Collected( compilation, "The compilation captured by a task cancelled before it started", ("taskBag", taskBag) );
+
+        Assert.True(
+            taskBag.IsEmpty,
+            "The bag holds an entry for a task that was cancelled before it started, and nothing will ever remove it." );
+    }
+
+    /// <summary>
+    /// Verifies that a sequence of tasks cancelled before they start, which is what fast typing produces, does not
+    /// accumulate in the bag.
+    /// </summary>
+    /// <remarks>
+    /// The single-task case states the defect, and this one states its consequence: the number of retained versions
+    /// grows with the number of keystrokes, which is the shape of the growth that has been reported.
+    /// </remarks>
+    [Fact]
+    public void RepeatedCancellationBeforeStart_DoesNotAccumulate()
+    {
+        using var testContext = this.CreateTestContext();
+        var taskBag = CreateTaskBag( testContext );
+
+        const int taskCount = 20;
+        var compilations = new WeakReference[taskCount];
+
+        for ( var i = 0; i < taskCount; i++ )
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+            cancellationTokenSource.Cancel();
+
+            compilations[i] = EnqueueTaskCapturingACompilation(
+                testContext,
+                taskBag,
+                $"{nameof(this.RepeatedCancellationBeforeStart_DoesNotAccumulate)}{i}",
+                cancellationTokenSource.Token );
+        }
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            0,
+            "compilations captured by tasks cancelled before they started",
+            ("taskBag", taskBag) );
+
+        Assert.True( taskBag.IsEmpty, $"The bag holds entries for {taskCount} tasks that were cancelled before they started." );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the three paths by which the design-time code retained a Roslyn `Compilation` after the user had replaced it,
and adds a test suite that reproduces each of them.

- **`TaskBag.Enqueue` no longer strands a task that was cancelled before it started.** The token was passed to
  `Task.Run`, which does not invoke the delegate at all when the token is already signalled, so the `finally` block
  that removes the entry from `_pendingTasks` never ran and the entry kept the closure, and everything the closure
  captured, for the lifetime of the process. `AnalysisProcessProjectSourceGenerator.GenerateSources` enqueues one
  closure over the current `Compilation` per version, that is, once per keystroke, and cancels the token of the
  previous one, so every keystroke superseded before the thread pool started its analysis retained a whole
  compilation. The token is now observed from inside the delegate. This also fixes `ProjectSourceGenerator.Dispose`,
  which failed with `TaskCanceledException` because `WaitAllAsync` awaited a stranded canceled task.

- **`DesignTimeAspectPipelineFactory` releases a caller whose wait for a pipeline is cancelled.** The listeners were
  completed by enumerating a queue that was never dequeued, so it grew for the lifetime of the process, and the
  cancellation registration covered only the statement that enqueued the listener rather than the `await` that
  followed it, so a cancelled token never ended the wait. An uncompleted listener kept the suspended state machine of
  `GetPipelineAndWaitAsync`, and therefore the caller's compilation. The listeners are now held in a dictionary from
  which each waiter removes its own entry in a `finally`, the registration covers the wait, `TrySetCanceled` replaces
  `SetCanceled` because the listener may already have been completed by the creation of a pipeline, and the
  continuations run asynchronously so that they no longer execute under the lock on the pipeline dictionary.

- **`InheritableAspectInstance` stores a durable target reference.** The instance kept the reference it was given,
  which at design time is bound to a compilation through its symbol and its reference factory. It is stored in the
  `SyntaxTreePipelineResult` of a file, which the pipeline carries forward from one version of the project to the
  next without re-analysing that file, so a file declaring the target of an inheritable aspect pinned the compilation
  it had been analysed in for as long as the project stayed open. This contradicted the documented contract of
  `SyntaxTreePipelineResult`, which states that the class is compilation-independent and cacheable. The reference is
  now converted with `ToDurable()`, which is what serialization already did to it, and what `FabricDriver` already
  does for the same reason.

Only the first of the three grows with the number of keystrokes and it is the likely cause of the reported growth to
several gigabytes. The second is unbounded in count but reached only when a pipeline is awaited and never created.
The third was measured to be bounded at one stale compilation per project, which is a constant overhead proportional
to the size of the solution rather than growth over time.

## Test suite

`Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/`, 25 tests, on `net8.0` and `net48`. Every one of
them failed before the corresponding fix and passes after it. It contains:

- `RetentionPathFinder`, which walks the object graph from the objects a design-time host keeps alive and reports the
  chain of fields that retains a given object, so that a failure names the responsible field instead of merely
  asserting that something is retained. It applies ephemeron marking: it follows the value of a
  `ConditionalWeakTable` entry only once the key of that entry has been proven reachable by strong references, and it
  never reports a key as retained through the table.
- `MemoryLeakAssertSelfTests`, a positive control that plants a retention deliberately and requires the assertions to
  detect it and to name the retaining field.
- `DesignTimeEditingSimulator`, which reproduces an editing session the way Roslyn does, with
  `Compilation.ReplaceSyntaxTree`, and never hands a strong reference to a compilation back to the test method.

The suite also guards the paths that were examined and found sound, so that a future change cannot silently break
them: the whole diff subsystem, the pipeline under an uninterrupted editing session, and the fact that editing aspect
code retains no compilation.

## Documentation

Adds `Metalama.Framework/docs/design-time-memory.md`, which states the concept the three fixes are instances of, so
that the next addition to the design-time code does not have to rediscover it. It gives the rule, classifies every
field by the lifetime of its declaring object, and describes the mechanisms the codebase already provides: keying
results by file path rather than by instance, durable references, the ephemeron semantics that the diff subsystem
relies on, the `Dangerous` suffix that marks a weakly held previous version, and the rules for background tasks and
event subscriptions. It also records why a passing test proves less than it appears to, since both of the largest
defects required cancellation to trigger.

Linked from `CLAUDE.md` and from `docs/testing.md`.

## Verification

- The new suite: 25 passed, on `net8.0` and `net48`, stable across repeated runs.
- `Metalama.Framework.Tests.UnitTests`: 2253 passed, 0 failed, 5 skipped.
- `Metalama.Framework.Tests.AspectTests`: full run, including the 53 inheritance tests that exercise the
  `InheritableAspectInstance` change.

## Issues Fixed

Fixes #1793 - Design-time: the analysis process retains old Roslyn compilations (three distinct defects)

The fourth finding reported in that issue, the unbounded `externalExtensions` accumulation in
`DesignTimeAspectPipelineResult.Update`, is deliberately **not** addressed here and has been split off as #1796. It
needs a cross-project validator fixture that the unit test project does not have, and each accumulated entry holds a
declaration identifier rather than a compilation, so its cost is a few hundred bytes per run rather than tens of
megabytes. Its more noticeable effect is the duplicated validation work, since the same validator is returned once
per run.
