### PR TITLE
Design-time: stop accumulating contributors, and stop pinning compilations (#1796, #1799, part of #1797)

### DIFF
--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -86,6 +86,18 @@ When adding a member to a type that is stored in a `SyntaxTreePipelineResult`, t
 convenient to keep" but "does this reach a `Compilation`". Note that a `Microsoft.CodeAnalysis.Diagnostic` does: it
 holds a `Location`, which holds its source tree.
 
+**A type is not a declaration, and `ToDurable()` treats it as one.** `ToDurable()` is backed by a
+`SerializableDeclarationId`, which names a *declaration*, so converting `Base<int>` yields a reference that resolves
+to `Base<T>`: the type arguments are lost, silently, and the result is a usable type rather than an error. Where the
+value is an `IType` rather than a declaration, and above all where it comes from user code and its shape is therefore
+not known, use `DurableRefFactory.FromTypeId( type.GetSerializableTypeId() )` instead.
+`Query.CreateBaseTypeResolver` does, and `RefTests.DurableRefToConstructedGenericTypeLosesTheTypeArguments` records
+the difference.
+
+Neither identifier can denote a type an aspect introduced, because resolving one goes through the symbol table. Where
+such a type can reach the conversion, verify it rather than assume it: converting unconditionally replaces a query
+that works with one that throws `SymbolNotFoundException` when it runs, far from the call site.
+
 ### Understand `ConditionalWeakTable` before relying on it
 
 `WeakCache<TKey, TValue>` wraps a `ConditionalWeakTable`, and the diff subsystem is built on it. The semantics are
@@ -170,6 +182,13 @@ aspect builder, may return the context it holds, rebound through
 `UserCodeExecutionContext.WithCompilationAndDiagnosticAdder`. And a query builder that is handed a declaration converts
 it to a durable reference before capturing it in the adder closure, because the closure lives as long as the query.
 
+Building a context on demand has a consequence that is easy to miss, because it is not about memory. The ordinary
+constructor fills in the target declaration, the meta API and the syntax builder from the context that happens to be
+current, which is right for a context created while its own user code is running and wrong for one created on demand:
+what it would inherit is then whatever the calling thread was doing. `IQuery.ToCollection` is public, so a fabric query
+can be executed from inside an aspect. Use `UserCodeExecutionContext.CreateWithoutInheritance` in that shape;
+`UserCodeExecutionContextTests` holds the distinction.
+
 **The per-file results.** `SyntaxTreePipelineResult` describes itself as compilation-independent and cacheable, and
 the pipeline relies on that: `DesignTimeAspectPipelineResult.Update` carries forward the entry of every file the run
 did not analyse, and `SplitResultsByTree` goes further, discarding a freshly produced item whose file is not dirty so
@@ -216,6 +235,12 @@ Three parts of the harness matter more than the tests themselves.
   field. A suite of liveness tests that all pass is indistinguishable from a suite whose assertions never fire, so
   this positive control is what gives the rest of the suite its value.
 
+**Recording a retention that is known but not yet fixed** is done with `MemoryLeakAssert.RetainedThrough`, which names
+the route as well as asserting that the object is alive. Asserting liveness alone would hold whether the documented
+route retains the object or something else does, and would go on holding after the documented route was removed. Naming
+the route makes the record fail in both of the directions that matter: when the defect is fixed, which is the signal to
+replace the call with `Collected`, and when the object is retained for a different reason than the one written down.
+
 Two practical points when writing such a test.
 
 **Never let a compilation reach a local variable of the test method.** A debug build keeps every local alive until the
@@ -237,8 +262,8 @@ superseded work, the test must cancel too.
 
 Recorded here rather than in a pull request, because this is the document the next person to work on design-time memory
 reads. Strike an entry when it is closed, and add one rather than leaving a repair half-applied. State for each whether
-it was **measured** or **reasoned**, and phrase a reasoned one as a question: an entry that has not been measured is
-about as often wrong as right.
+it was **measured** or **reasoned**, and phrase a reasoned one as a question, so that a reader can tell an observation
+from a hypothesis without re-deriving it.
 
 ### A transitive aspect instance retains one compilation
 

--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -245,14 +245,25 @@ This is worth re-checking after any change on that surface, because the mistake 
 grep -rn "Task\.WarnIfLongAsync" --include=*.cs . | grep -v WithCancellation
 ```
 
-### `WithCancellation` leaves a small object behind per cancelled wait
+### `WithCancellation` does not leave anything behind: measured, contrary to a claim made here earlier
 
-The fix above releases the awaiting frame, which is what matters, because that frame is what holds the Roslyn objects.
-It does not detach the `Task.WhenAny` continuation from the source that is never completed, so a cancelled wait leaves
-a promise of about a hundred bytes attached to it. That is unbounded over a session in which no client ever connects,
-though it holds nothing bound to a compilation. The shape that avoids it is a collection of waiters an entry can be
-removed from, as in the `DesignTimeAspectPipelineFactory` fix for
-[#1793](https://github.com/metalama/Metalama/issues/1793). This was reasoned about rather than measured.
+An earlier revision of this section stated that a cancelled `WithCancellation` leaves a `Task.WhenAny` continuation on
+the task it waited for, and that this accumulates on a task that never completes. **That is false, and it was asserted
+from reading the code rather than from measuring it.**
+
+`Task.WhenAny` removes its continuation from the task that did not win. Measured on a task that is never completed, the
+number of continuations left after 10, 100 and 1000 cancelled waits is the same small constant, for both
+implementations in use: `TaskExtensions.WithCancellation` of this codebase, and
+`Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation`, which the two waits in
+`Metalama.Framework.DesignTime.Rpc` resolve to because that project does not reference the engine.
+
+`WithCancellationMemoryLeakTests` holds the property, since it belongs to the runtime and to a third-party library
+rather than to this codebase, and nothing else here would notice its loss. It counts continuations by reflection over
+a private field of `Task`, which is the only way to observe something that no public API exposes and that no weak
+reference can track.
+
+The lesson is the one this section exists to enforce: an entry here has to say whether it was measured or reasoned
+about, and a reasoned one is a question rather than a finding.
 
 ### `TransitiveAspectInstance` retains the compilation it was produced in
 

--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -229,24 +229,17 @@ What follows is deliberately not fixed, or not fixed everywhere. It is recorded 
 request description, because the next person to work on design-time memory will read this document and not that.
 Please keep the list honest: strike an entry when it is closed, and add one rather than leaving a repair half-applied.
 
-### Two remaining uncancellable waits on a task completion source
+### Uncancellable waits on a task completion source
 
-`RpcService.WaitUntilInitializedAsync` was fixed for [#1799](https://github.com/metalama/Metalama/issues/1799), but the
-same pattern survives in two places:
+Closed. All three call sites now compose the token with `WithCancellation` before `WarnIfLongAsync`, which is the
+defect: that method uses the token for its own delay and returns the original task untouched when warning logging is
+disabled, so passing it there alone leaves the wait uncancellable by either path. `RpcServiceProviderServerEndpoint`
+also completes `_hubRegistrationTask` when the service hub endpoint cannot be obtained, because registration is
+attempted once and nothing else would ever complete it. The awaiters of `ClientEndpoint` are deliberately left waiting
+in that situation, because a later connection attempt can legitimately complete them; making the wait cancellable is
+the whole of what was needed there.
 
-- `Metalama.Framework.DesignTime/VisualStudio/ServiceProvider/RpcServiceProviderServerEndpoint.cs:133`, on
-  `_hubRegistrationTask`, which `OnServerPipeCreatedAsync` leaves uncompleted when the Visual Studio extension is
-  absent.
-- `Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs:140`, on an entry of `_clientAwaiters`, which is not completed
-  when a connection attempt fails: the catch path calls `RpcClient.SetFailure`, which completes the client's own
-  source and not the awaiter.
-
-Both pass the cancellation token to `WarnIfLongAsync` alone, which is the defect: that method uses the token for its
-own delay and returns the original task untouched when warning logging is disabled. The fix is the one already applied
-to `RpcService`, namely to compose with `WithCancellation` first. Tracked by
-[#1800](https://github.com/metalama/Metalama/issues/1800).
-
-To find any recurrence:
+This is worth re-checking after any change on that surface, because the mistake is easy to repeat and invisible:
 
 ```bash
 grep -rn "Task\.WarnIfLongAsync" --include=*.cs . | grep -v WithCancellation

--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -41,6 +41,9 @@ It is useful to classify every field by the lifetime of the object that declares
 | A single request (locals, parameters, a `PartialCompilation` being processed) | Yes, freely. |
 | The current version of a project (`PipelineState.ProjectVersion`) | Yes, exactly one version. |
 | A project (`DesignTimeAspectPipeline`, a `ProjectSourceGenerator`) | No. |
+| The pipeline configuration (`AspectPipelineConfiguration` and everything it reaches) | No: it is long-lived by design, reused across keystrokes. |
+| An ambient `UserCodeExecutionContext` | Yes: it is scoped to one execution of user code. |
+| A per-file result (`SyntaxTreePipelineResult` and everything it holds) | No: it survives every run in which its file is not dirty. |
 | The process (a static field, an `IGlobalService`, an analyzer or generator instance) | No. |
 
 The last row deserves emphasis: Roslyn keeps **one instance** of a `DiagnosticAnalyzer` or an `IIncrementalGenerator`
@@ -130,6 +133,57 @@ An event handler holds its target. `AnalysisProcessEventHub` exposes its high-tr
 `WeakEvent<T>` and `AsyncWeakEvent<T>`, which hold subscribers weakly and compact their list. Where a plain event is
 used instead, the subscriber must unsubscribe in `Dispose`, and the event must carry only values, such as a
 `ProjectKey`, rather than compilation-bound objects.
+
+## What the pipeline stores for longer than one request
+
+Three collections outlive a request without being obviously long-lived, because they belong to objects a reader
+naturally takes to be per-run. Each of them is a place where the rule has been broken.
+
+**The pipeline configuration.** `AspectPipelineConfiguration` is built once, from whichever version of the project was
+current at the time, and `PipelineState` then reuses it for every subsequent version, discarding it only when the
+compile-time code changes. **That long life is deliberate and is not the defect.** Rebuilding the configuration on
+every keystroke would mean recompiling the compile-time assemblies each time, which is far too slow to be done between
+one keystroke and the next; the reuse is what makes the design-time pipeline viable and it must stay.
+
+What follows from it is a constraint, not a licence: because the configuration is long-lived, **it must not pin a
+compilation**. For a session in which the user edits run-time code alone, anything it holds that is bound to a
+compilation retains the *first* version of the session, the oldest rather than the most recent, and holds it in
+addition to the current one. The exception in the rule above does not cover that. Everything reachable from the
+configuration is therefore subject to the rule, including `FabricsContributors`, which reaches the amender of every
+static fabric and, through the amender, the queries it owns. `FabricMemoryLeakTests` guards this.
+
+The corollary is worth stating separately, because it is where the rule is easiest to break by accident.
+`UserCodeExecutionContext` is ambient and scoped to one execution of user code, so it is entitled to hold a
+compilation, a declaration and a syntax builder: that is its purpose. **The objects created from a context and outliving
+it are the ones that must not.** An amender stored a whole context, and a query built by `SelectTypesDerivedFrom`
+captured the `INamedType` it was given. Both are durable, both are reachable from the configuration, and both were
+fixed by keeping a durable reference and resolving it against the compilation of each run, which
+`UserCodeExecutionContext.WithCompilationAndDiagnosticAdder` was already doing for everything else.
+
+**The per-file results.** `SyntaxTreePipelineResult` describes itself as compilation-independent and cacheable, and
+the pipeline relies on that: `DesignTimeAspectPipelineResult.Update` carries forward the entry of every file the run
+did not analyse, and `SplitResultsByTree` goes further, discarding a freshly produced item whose file is not dirty so
+that the item produced earlier survives. A file the user never edits therefore keeps, for the whole session, whatever
+its first analysis produced. Two kinds of member of that result reach the code model and must be checked:
+
+- the extensions, which are opaque to the engine: an extension chooses what its contributor carries, and nothing in
+  `IDesignTimePipelineResultExtension` or `ITransitivePipelineContributor.ToDesignTime` says that it must be durable.
+  It must. `ExtensionContributorMemoryLeakTests` states this as a matched pair, one contributor holding a durable
+  reference and one holding the reference the code model returns.
+- the diagnostics. A `DiagnosticDefinition` formats lazily, so the arguments passed to `WithArguments` are stored in
+  the descriptor of the diagnostic and are held for as long as the diagnostic is. An argument that is an
+  `IDeclaration` reaches its `CompilationModel`. Passing the declaration is the natural way to write the message, and
+  it is what a validator does on every reference it rejects; passing `declaration.Name`, or another value, is what
+  keeps the diagnostic durable. `DiagnosticArgumentMemoryLeakTests` states this, also as a matched pair.
+
+**A `TaskCompletionSource` that no path completes.** Awaiting one retains the awaiting frame, and with it every
+argument and local the frame captured. On the design-time RPC surface those captures are Roslyn objects: a service is
+initialized only when a client attaches to its endpoint, and every method of every server-side service awaits that
+initialization before doing anything, including before checking whether there is any client to serve. When no client
+ever attaches, which is the ordinary state of the analysis process when the Visual Studio extension is absent, each
+such call parks forever. Passing a cancellation token is not by itself enough: it has to be *observed*, which means
+composing it with `WithCancellation` rather than handing it to a helper that only uses it for a timeout.
+`RpcServiceCancellationTests` states the property for the wait itself, and separately for what the parked frame holds.
 
 ## Testing it
 

--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -70,6 +70,13 @@ request, and is a retention as soon as it is stored.
 `SerializableTypeId`, which reaches nothing. Resolve it later with `GetTarget( compilation )` against whichever
 compilation is current.
 
+**Declare the requirement in the type, do not leave it to the caller.** A field, property or constructor parameter that
+must hold a durable reference is typed `IDurableRef<T>`, not `IRef<T>`. The conversion then cannot be forgotten,
+because the compiler asks for it at every call site, and a reader of the type learns the constraint from its signature
+rather than from a comment. `TransitiveAspectInstance.TargetDeclaration` is the model. Where such a reference crosses a
+serializer, keep `IRef<T>` as the wire shape, which is what the serialization framework resolves, and convert on that
+boundary.
+
 This is why `SyntaxTreePipelineResult` documents itself as *compilation-independent and cacheable*: the pipeline
 re-analyses only the syntax trees that changed and carries the results of every other file forward from an earlier
 run, so a compilation-bound reference in one of them pins the version it was computed in for as long as the project
@@ -137,7 +144,7 @@ used instead, the subscriber must unsubscribe in `Dispose`, and the event must c
 ## What the pipeline stores for longer than one request
 
 Three collections outlive a request without being obviously long-lived, because they belong to objects a reader
-naturally takes to be per-run. Each of them is a place where the rule has been broken.
+naturally takes to be per-run. Each is a place to check before storing anything in it.
 
 **The pipeline configuration.** `AspectPipelineConfiguration` is built once, from whichever version of the project was
 current at the time, and `PipelineState` then reuses it for every subsequent version, discarding it only when the
@@ -152,13 +159,16 @@ addition to the current one. The exception in the rule above does not cover that
 configuration is therefore subject to the rule, including `FabricsContributors`, which reaches the amender of every
 static fabric and, through the amender, the queries it owns. `FabricMemoryLeakTests` guards this.
 
-The corollary is worth stating separately, because it is where the rule is easiest to break by accident.
+The corollary is where this rule is easiest to break by accident, and is worth stating separately.
 `UserCodeExecutionContext` is ambient and scoped to one execution of user code, so it is entitled to hold a
-compilation, a declaration and a syntax builder: that is its purpose. **The objects created from a context and outliving
-it are the ones that must not.** An amender stored a whole context, and a query built by `SelectTypesDerivedFrom`
-captured the `INamedType` it was given. Both are durable, both are reachable from the configuration, and both were
-fixed by keeping a durable reference and resolving it against the compilation of each run, which
-`UserCodeExecutionContext.WithCompilationAndDiagnosticAdder` was already doing for everything else.
+compilation, a declaration and a syntax builder: that is its purpose. **The objects created from a context and
+outliving it are the ones that must not.** A fabric amender and the queries it owns are such objects.
+
+Two shapes follow. An owner that outlives a request does not store a context but produces one per compilation, which is
+what `IQueryOwner.GetUserCodeExecutionContext` exists for; an owner whose own lifetime is a single run, such as an
+aspect builder, may return the context it holds, rebound through
+`UserCodeExecutionContext.WithCompilationAndDiagnosticAdder`. And a query builder that is handed a declaration converts
+it to a durable reference before capturing it in the adder closure, because the closure lives as long as the query.
 
 **The per-file results.** `SyntaxTreePipelineResult` describes itself as compilation-independent and cacheable, and
 the pipeline relies on that: `DesignTimeAspectPipelineResult.Update` carries forward the entry of every file the run
@@ -223,114 +233,100 @@ one version at a time and waits for each to be analysed never cancels anything a
 why the growth was so hard to reproduce outside a real editing session. When testing a component that cancels
 superseded work, the test must cancel too.
 
-## Known residuals
+## Open items
 
-What follows is deliberately not fixed, or not fixed everywhere. It is recorded here rather than left in a pull
-request description, because the next person to work on design-time memory will read this document and not that.
-Please keep the list honest: strike an entry when it is closed, and add one rather than leaving a repair half-applied.
+Recorded here rather than in a pull request, because this is the document the next person to work on design-time memory
+reads. Strike an entry when it is closed, and add one rather than leaving a repair half-applied. State for each whether
+it was **measured** or **reasoned**, and phrase a reasoned one as a question: an entry that has not been measured is
+about as often wrong as right.
 
-### Uncancellable waits on a task completion source
+### A transitive aspect instance retains one compilation
 
-Closed. All three call sites now compose the token with `WithCancellation` before `WarnIfLongAsync`, which is the
-defect: that method uses the token for its own delay and returns the original task untouched when warning logging is
-disabled, so passing it there alone leaves the wait uncancellable by either path. `RpcServiceProviderServerEndpoint`
-also completes `_hubRegistrationTask` when the service hub endpoint cannot be obtained, because registration is
-attempted once and nothing else would ever complete it. The awaiters of `ClientEndpoint` are deliberately left waiting
-in that situation, because a later connection attempt can legitimately complete them; making the wait cancellable is
-the whole of what was needed there.
+Measured. Tracked by [#1797](https://github.com/metalama/Metalama/issues/1797). The remaining route is:
 
-This is worth re-checking after any change on that surface, because the mistake is easy to repeat and invisible:
-
-```bash
-grep -rn "Task\.WarnIfLongAsync" --include=*.cs . | grep -v WithCancellation
+```
+TransitiveAspectInstance.Aspect
+  -> PullConstructorParameterTransitiveAspect._parameter : IntroducedRef<IParameter>
+    -> RefFactory -> CompilationContext -> Compilation
 ```
 
-### `WithCancellation` does not leave anything behind: measured, contrary to a claim made here earlier
+The target declarations on that path are durable and typed `IDurableRef<IDeclaration>`, so only the aspect object
+remains. Why the parameter reference is not also durable is specific, and worth knowing before trying it again:
 
-An earlier revision of this section stated that a cancelled `WithCancellation` leaves a `Task.WhenAny` continuation on
-the task it waited for, and that this accumulates on a task that never completes. **That is false, and it was asserted
-from reading the code rather than from measuring it.**
+- an `IntroducedRef` **is** serializable. It overrides `ToSerializableId`, `FullRef.ToDurable` is built on that, and
+  the identifier of a pulled parameter names the constructor signature and the ordinal, which the resolution path
+  handles explicitly and `ConstructorParameterIdResolutionTests` covers;
+- calling `ToDurable()` on it therefore compiles, and does close this retention;
+- but it breaks the cross-project case. `PullParameterTests.CrossProjectIntegration` then fails: the consuming project
+  resolves nothing and the transitive aspect silently does not apply. That test runs on `net48` only, so a `net8.0` run
+  stays green and hides it.
 
-`Task.WhenAny` removes its continuation from the task that did not win. Measured on a task that is never completed, the
-number of continuations left after 10, 100 and 1000 cancelled waits is the same small constant, for both
-implementations in use: `TaskExtensions.WithCancellation` of this codebase, and
-`Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation`, which the two waits in
-`Metalama.Framework.DesignTime.Rpc` resolve to because that project does not reference the engine.
+The identity of an introduced declaration is not settled at the moment the advice runs. Making the reference durable
+has to happen later in the pipeline, which is a change of design rather than a change of call.
 
-`WithCancellationMemoryLeakTests` holds the property, since it belongs to the runtime and to a third-party library
-rather than to this codebase, and nothing else here would notice its loss. It counts continuations by reflection over
-a private field of `Task`, which is the only way to observe something that no public API exposes and that no weak
-reference can track.
+`TransitiveContributorMemoryLeakTests` holds a control that asserts the compilation is *still* retained. It fails when
+this is fixed, which is the signal to replace it with the ordinary assertion.
 
-The lesson is the one this section exists to enforce: an entry here has to say whether it was measured or reasoned
-about, and a reasoned one is a question rather than a finding.
+### Two requirements the framework cannot check
 
-### `TransitiveAspectInstance` retains the compilation it was produced in
+Structural, and open by nature. Both are contracts stated in documentation, because what is stored is opaque to the
+code that stores it:
 
-Bounded to one version, and tracked by [#1797](https://github.com/metalama/Metalama/issues/1797). Its target
-declaration closes with `ToDurable()` exactly as the inheritable aspect instances did. The aspect object is the harder
-half: it carries an `IntroducedRef` to a declaration the pipeline introduced, which has no source identity to be
-durable against, so it needs a design change rather than a repair.
+- what an extension puts in an `IDesignTimePipelineResultExtension`;
+- what a user lambda captures. `Select`, `SelectMany`, `Where` and `Tag` take delegates written by the user, and the
+  query holding them is as durable as its owner. Only the framework's own captures can be fixed.
 
-### `TransitiveManifestDeserializationCache` is invalidated, contrary to a second claim made here earlier
+A DEBUG invariant in `DesignTimeAspectPipelineResult.Update`, walking a stored extension for a non-durable `IFullRef`,
+would make the first of these detectable. It has not been written.
 
-An earlier revision of this section listed this cache as having no eviction and being "reset only wholesale". That
-reading was wrong, and it inverted the design: the wholesale replacement in `EnsureBoundTo` is not a substitute for
-missing eviction, it *is* the invalidation.
+## Established as clean
 
-Both dictionaries are dropped whenever the consuming project's `CompileTimeProject` is not the one they were filled
-for. That scope is the point. A manifest is deserialized with the *consuming* project's service provider so that it
-binds to that project's compile-time copy of each type ([#1710](https://github.com/metalama/Metalama/issues/1710)), so
-an entry made against a superseded projection must not be reused, and a consumer whose compile-time project is unknown
-is not cached at all rather than risk a wrong binding. `TransitiveManifestDeserializationCacheTests` covers this,
-`ReprojectedConsumer_DropsTheCache` by name.
+Recorded so that the same suspicions are not re-investigated from the same reading of the same code. Each of these
+looks like a leak and is not.
 
-The path is also narrower than the entry implied: the hash-keyed overload is reached only when `CanReuseLiveManifest`
-is false, which is a cross-version reference or one whose compile-time copies differ. A same-version reference reads
-the producer's live result instead and never touches the cache.
+**`WithCancellation` does not accumulate on the task it waits for.** `Task.WhenAny` removes its continuation from the
+task that did not win. Measured on a task that is never completed, the number of continuations left is the same small
+constant after 10, 100 and 1000 cancelled waits, for both implementations in use: `TaskExtensions.WithCancellation` of
+this codebase, and `Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation`, which
+`Metalama.Framework.DesignTime.Rpc` resolves to because that project does not reference the engine.
+`WithCancellationMemoryLeakTests` holds the property, which belongs to the runtime and to a third-party library rather
+than to this codebase and would otherwise go unnoticed if lost.
 
-What remains is a question rather than a finding, and is recorded as one because it has *not* been measured. Within one
-`CompileTimeProject` lifetime, an entry is added per distinct manifest content of a referenced project. A referenced
-project's manifest content can change without its compile-time code changing, by an edit to run-time code that carries
-an inheritable aspect, and such a change does not re-project the consumer. Whether that is reachable often enough to
-matter, given the narrow reference configuration required, is unknown. The values are compilation-neutral, so it would
-be managed memory rather than a retained compilation.
+**`TransitiveManifestDeserializationCache` is invalidated.** The wholesale replacement of its dictionaries in
+`EnsureBoundTo` is not a substitute for missing eviction, it *is* the invalidation, keyed on the identity of the
+consuming project's `CompileTimeProject`. That scope is load-bearing: a manifest is deserialized with the consuming
+project's service provider so that it binds to that project's compile-time copy of each type
+([#1710](https://github.com/metalama/Metalama/issues/1710)), so an entry made against a superseded projection must not
+be reused, and a consumer whose compile-time project is unknown is not cached at all.
+`TransitiveManifestDeserializationCacheTests` covers this, `ReprojectedConsumer_DropsTheCache` by name. The hash-keyed
+overload is also reached only when `CanReuseLiveManifest` is false; a same-version reference reads the producer's live
+result and never touches the cache.
 
-### Requirements that cannot be enforced
+**Waits on a task completion source observe their token.** Every call site composes the token with `WithCancellation`
+before `WarnIfLongAsync`. Passing the token to that method alone is not enough, and is the mistake to watch for: it
+uses the token for its own delay, and returns the original task untouched when warning logging is disabled. Worth
+re-checking after any change on that surface, because it is invisible until an analysis process runs for hours with no
+client attached:
 
-Two of the rules in this document are contracts that the framework states and cannot check, because what is stored is
-opaque to it.
+```bash
+grep -rn "Task[.]WarnIfLongAsync" --include=*.cs . | grep -v WithCancellation
+```
 
-- What an extension puts in an `IDesignTimePipelineResultExtension`. The one violation known at the time of writing,
-  `TypeEqualityPredicate` in Metalama.Premium, is fixed; another extension can break it silently.
-- What a user lambda captures. `Select`, `SelectMany`, `Where` and `Tag` take delegates written by the user, and the
-  query that holds them is as durable as the amender that owns it. Only the framework's own captures, such as the one
-  in `SelectTypesDerivedFrom`, could be fixed.
+## What has not been examined
 
-An assertion in `DesignTimeAspectPipelineResult.Update`, in DEBUG only, walking a stored extension for a non-durable
-`IFullRef`, would turn the first of these into something detectable. It has not been written.
+The rules and entries above came from an audit of the extension, fabric, query, RPC and design-time-result surfaces.
+The linker, the code-model caches, and the source-generator pipeline beyond what the RPC surface touches were not
+examined. Treat the absence of an entry as "not looked at" rather than "clean"; the section above lists what was
+positively established.
 
-### What the audit did not cover
+Two habits are worth keeping, because the defects that escaped this audit escaped it for the same two reasons.
 
-The sweep behind [#1799](https://github.com/metalama/Metalama/issues/1799) examined the extension, fabric, query, RPC
-and design-time-result surfaces. It did not examine the linker, the code-model caches, or the source-generator pipeline
-beyond what the RPC surface touched. Treat the absence of an entry as "not looked at" rather than "clean", except for
-the list under **Checked and clean** in that issue.
+**Measure before recording.** A retention that is easy to reason about is not thereby real. Entries have stood in the
+list of open items and been struck once somebody measured them.
 
-Calibrate the entries above by how they were established, because the record is not good:
-
-- The audit **missed** the diagnostic-argument defect entirely, which was found by accident when it broke an unrelated
-  control test, and which was probably the most consequential of the set.
-- It **missed** the third route by which the pipeline configuration pinned a compilation, the capture in
-  `SelectTypesDerivedFrom`, which was found only after the rule was restated as belonging to the durable objects
-  created from a context rather than to the context.
-- Two entries it produced, on `WithCancellation` and on this cache, were **wrong**, and both were wrong in the same
-  way: asserted from reading the code, never measured, and disproved the moment someone measured or read more
-  carefully.
-
-The rule that follows is the one this section is written to enforce. An entry must say whether it was measured. One
-that was not is a question, and should be phrased as a question, because on this evidence roughly half of them are
-false.
+**Make a test prove its scenario happened.** A control that passes for the wrong reason proves nothing. Assert that the
+run produced what it was supposed to produce, a contributor, a diagnostic, a validator, before asserting anything about
+what is retained.
 
 ## Related documents
 

--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -272,13 +272,29 @@ declaration closes with `ToDurable()` exactly as the inheritable aspect instance
 half: it carries an `IntroducedRef` to a declaration the pipeline introduced, which has no source identity to be
 durable against, so it needs a design change rather than a repair.
 
-### `TransitiveManifestDeserializationCache` has no eviction
+### `TransitiveManifestDeserializationCache` is invalidated, contrary to a second claim made here earlier
 
-`_manifests` and `_manifestsByHash` (`Metalama.Framework.Engine/Aspects/TransitiveManifestDeserializationCache.cs:42`
-and `:43`) grow without bound and are reset only wholesale, in `EnsureBoundTo`. The values are compilation-neutral
-deserialized manifests, so this is uncapped managed memory rather than a retained compilation, which is why it is not
-treated as a leak by the rules above. It is reached only on a minority reference configuration, namely a cross-version
-reference or one whose live manifest cannot be reused.
+An earlier revision of this section listed this cache as having no eviction and being "reset only wholesale". That
+reading was wrong, and it inverted the design: the wholesale replacement in `EnsureBoundTo` is not a substitute for
+missing eviction, it *is* the invalidation.
+
+Both dictionaries are dropped whenever the consuming project's `CompileTimeProject` is not the one they were filled
+for. That scope is the point. A manifest is deserialized with the *consuming* project's service provider so that it
+binds to that project's compile-time copy of each type ([#1710](https://github.com/metalama/Metalama/issues/1710)), so
+an entry made against a superseded projection must not be reused, and a consumer whose compile-time project is unknown
+is not cached at all rather than risk a wrong binding. `TransitiveManifestDeserializationCacheTests` covers this,
+`ReprojectedConsumer_DropsTheCache` by name.
+
+The path is also narrower than the entry implied: the hash-keyed overload is reached only when `CanReuseLiveManifest`
+is false, which is a cross-version reference or one whose compile-time copies differ. A same-version reference reads
+the producer's live result instead and never touches the cache.
+
+What remains is a question rather than a finding, and is recorded as one because it has *not* been measured. Within one
+`CompileTimeProject` lifetime, an entry is added per distinct manifest content of a referenced project. A referenced
+project's manifest content can change without its compile-time code changing, by an edit to run-time code that carries
+an inheritable aspect, and such a change does not re-project the consumer. Whether that is reachable often enough to
+matter, given the narrow reference configuration required, is unknown. The values are compilation-neutral, so it would
+be managed memory rather than a retained compilation.
 
 ### Requirements that cannot be enforced
 
@@ -298,10 +314,23 @@ An assertion in `DesignTimeAspectPipelineResult.Update`, in DEBUG only, walking 
 
 The sweep behind [#1799](https://github.com/metalama/Metalama/issues/1799) examined the extension, fabric, query, RPC
 and design-time-result surfaces. It did not examine the linker, the code-model caches, or the source-generator pipeline
-beyond what the RPC surface touched. It also missed the diagnostic-argument defect that the same issue fixes, which was
-found by accident when it broke an unrelated control test, and which was probably the most consequential of the set.
-Treat the absence of an entry here as "not looked at" rather than "clean", except for the list under **Checked and
-clean** in the issue.
+beyond what the RPC surface touched. Treat the absence of an entry as "not looked at" rather than "clean", except for
+the list under **Checked and clean** in that issue.
+
+Calibrate the entries above by how they were established, because the record is not good:
+
+- The audit **missed** the diagnostic-argument defect entirely, which was found by accident when it broke an unrelated
+  control test, and which was probably the most consequential of the set.
+- It **missed** the third route by which the pipeline configuration pinned a compilation, the capture in
+  `SelectTypesDerivedFrom`, which was found only after the rule was restated as belonging to the durable objects
+  created from a context rather than to the context.
+- Two entries it produced, on `WithCancellation` and on this cache, were **wrong**, and both were wrong in the same
+  way: asserted from reading the code, never measured, and disproved the moment someone measured or read more
+  carefully.
+
+The rule that follows is the one this section is written to enforce. An entry must say whether it was measured. One
+that was not is a question, and should be phrased as a question, because on this evidence roughly half of them are
+false.
 
 ## Related documents
 

--- a/Metalama.Framework/docs/design-time-memory.md
+++ b/Metalama.Framework/docs/design-time-memory.md
@@ -223,6 +223,82 @@ one version at a time and waits for each to be analysed never cancels anything a
 why the growth was so hard to reproduce outside a real editing session. When testing a component that cancels
 superseded work, the test must cancel too.
 
+## Known residuals
+
+What follows is deliberately not fixed, or not fixed everywhere. It is recorded here rather than left in a pull
+request description, because the next person to work on design-time memory will read this document and not that.
+Please keep the list honest: strike an entry when it is closed, and add one rather than leaving a repair half-applied.
+
+### Two remaining uncancellable waits on a task completion source
+
+`RpcService.WaitUntilInitializedAsync` was fixed for [#1799](https://github.com/metalama/Metalama/issues/1799), but the
+same pattern survives in two places:
+
+- `Metalama.Framework.DesignTime/VisualStudio/ServiceProvider/RpcServiceProviderServerEndpoint.cs:133`, on
+  `_hubRegistrationTask`, which `OnServerPipeCreatedAsync` leaves uncompleted when the Visual Studio extension is
+  absent.
+- `Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs:140`, on an entry of `_clientAwaiters`, which is not completed
+  when a connection attempt fails: the catch path calls `RpcClient.SetFailure`, which completes the client's own
+  source and not the awaiter.
+
+Both pass the cancellation token to `WarnIfLongAsync` alone, which is the defect: that method uses the token for its
+own delay and returns the original task untouched when warning logging is disabled. The fix is the one already applied
+to `RpcService`, namely to compose with `WithCancellation` first. Tracked by
+[#1800](https://github.com/metalama/Metalama/issues/1800).
+
+To find any recurrence:
+
+```bash
+grep -rn "Task\.WarnIfLongAsync" --include=*.cs . | grep -v WithCancellation
+```
+
+### `WithCancellation` leaves a small object behind per cancelled wait
+
+The fix above releases the awaiting frame, which is what matters, because that frame is what holds the Roslyn objects.
+It does not detach the `Task.WhenAny` continuation from the source that is never completed, so a cancelled wait leaves
+a promise of about a hundred bytes attached to it. That is unbounded over a session in which no client ever connects,
+though it holds nothing bound to a compilation. The shape that avoids it is a collection of waiters an entry can be
+removed from, as in the `DesignTimeAspectPipelineFactory` fix for
+[#1793](https://github.com/metalama/Metalama/issues/1793). This was reasoned about rather than measured.
+
+### `TransitiveAspectInstance` retains the compilation it was produced in
+
+Bounded to one version, and tracked by [#1797](https://github.com/metalama/Metalama/issues/1797). Its target
+declaration closes with `ToDurable()` exactly as the inheritable aspect instances did. The aspect object is the harder
+half: it carries an `IntroducedRef` to a declaration the pipeline introduced, which has no source identity to be
+durable against, so it needs a design change rather than a repair.
+
+### `TransitiveManifestDeserializationCache` has no eviction
+
+`_manifests` and `_manifestsByHash` (`Metalama.Framework.Engine/Aspects/TransitiveManifestDeserializationCache.cs:42`
+and `:43`) grow without bound and are reset only wholesale, in `EnsureBoundTo`. The values are compilation-neutral
+deserialized manifests, so this is uncapped managed memory rather than a retained compilation, which is why it is not
+treated as a leak by the rules above. It is reached only on a minority reference configuration, namely a cross-version
+reference or one whose live manifest cannot be reused.
+
+### Requirements that cannot be enforced
+
+Two of the rules in this document are contracts that the framework states and cannot check, because what is stored is
+opaque to it.
+
+- What an extension puts in an `IDesignTimePipelineResultExtension`. The one violation known at the time of writing,
+  `TypeEqualityPredicate` in Metalama.Premium, is fixed; another extension can break it silently.
+- What a user lambda captures. `Select`, `SelectMany`, `Where` and `Tag` take delegates written by the user, and the
+  query that holds them is as durable as the amender that owns it. Only the framework's own captures, such as the one
+  in `SelectTypesDerivedFrom`, could be fixed.
+
+An assertion in `DesignTimeAspectPipelineResult.Update`, in DEBUG only, walking a stored extension for a non-durable
+`IFullRef`, would turn the first of these into something detectable. It has not been written.
+
+### What the audit did not cover
+
+The sweep behind [#1799](https://github.com/metalama/Metalama/issues/1799) examined the extension, fabric, query, RPC
+and design-time-result surfaces. It did not examine the linker, the code-model caches, or the source-generator pipeline
+beyond what the RPC surface touched. It also missed the diagnostic-argument defect that the same issue fixes, which was
+found by accident when it broke an unrelated control test, and which was probably the most consequential of the set.
+Treat the absence of an entry here as "not looked at" rather than "clean", except for the list under **Checked and
+clean** in the issue.
+
 ## Related documents
 
 - `pipeline.md` for the structure of the pipeline whose state these rules constrain.

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/ClientEndpoint.cs
@@ -1,9 +1,10 @@
-// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
 using JetBrains.Annotations;
 using Metalama.Backstage.Diagnostics;
+using Microsoft.VisualStudio.Threading;
 using StreamJsonRpc;
 using System.Collections.Concurrent;
 using System.Collections.Immutable;
@@ -137,7 +138,13 @@ public abstract partial class ClientEndpoint : BaseEndpoint
 
         await this.EnsureInitialServicesRetrievedAsync( cancellationToken );
 
-        return (TClient) await awaiter.Task.WarnIfLongAsync( this.Logger, $"waiting for client '{typeof(TClient)}'", cancellationToken );
+        // WithCancellation first: WarnIfLongAsync uses the token for its own delay only, and returns the original
+        // task untouched when warning logging is disabled, so passing the token to it alone leaves the wait
+        // uncancellable by either path. A suspended caller retains its frame and everything it captured. See
+        // issue #1799, which fixed the same defect in RpcService.
+        return (TClient) await awaiter.Task
+            .WithCancellation( cancellationToken )
+            .WarnIfLongAsync( this.Logger, $"waiting for client '{typeof(TClient)}'", cancellationToken );
     }
 
     /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcService.cs
@@ -33,9 +33,9 @@ public abstract class RpcService
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The token is composed with <see cref="TplExtensions.WithCancellation{T}(Task{T},CancellationToken)"/>, as it is
-    /// in the client-side counterpart <c>RpcClient.WaitUntilInitializedAsync</c>. Passing it to
-    /// <see cref="LongTaskHelper.WarnIfLongAsync{T}"/> alone is not enough, and was the defect reported by issue
+    /// The token is composed with <c>WithCancellation</c>, as it is in the client-side counterpart
+    /// <c>RpcClient.WaitUntilInitializedAsync</c>. Passing it to <c>LongTaskHelper.WarnIfLongAsync</c> alone is not
+    /// enough, and was the defect reported by issue
     /// #1799: that method uses the token for its own delay only, and returns the original task untouched when warning
     /// logging is disabled, so the wait was not cancellable by either path.
     /// </para>

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcService.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime.Rpc/RpcService.cs
@@ -28,8 +28,29 @@ public abstract class RpcService
         this.Logger.Trace?.Log( $"Instantiating." );
     }
 
+    /// <summary>
+    /// Waits until a client has attached to the endpoint, which is what makes this service usable.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The token is composed with <see cref="TplExtensions.WithCancellation{T}(Task{T},CancellationToken)"/>, as it is
+    /// in the client-side counterpart <c>RpcClient.WaitUntilInitializedAsync</c>. Passing it to
+    /// <see cref="LongTaskHelper.WarnIfLongAsync{T}"/> alone is not enough, and was the defect reported by issue
+    /// #1799: that method uses the token for its own delay only, and returns the original task untouched when warning
+    /// logging is disabled, so the wait was not cancellable by either path.
+    /// </para>
+    /// <para>
+    /// It has to be cancellable because <see cref="_initialized"/> is completed only by
+    /// <see cref="OnRpcConnected"/>, so a caller that reaches this method while no client is attached waits until one
+    /// is, and waits forever in the configuration where none ever attaches. A suspended asynchronous method retains
+    /// its own frame, and the callers on this surface hold Roslyn objects: the source generator waits here while
+    /// holding the compilation whose generated sources it is publishing.
+    /// </para>
+    /// </remarks>
     protected Task WaitUntilInitializedAsync( CancellationToken cancellationToken = default )
-        => this._initialized.Task.WarnIfLongAsync( this.Logger, nameof(this.WaitUntilInitializedAsync), cancellationToken );
+        => this._initialized.Task
+            .WithCancellation( cancellationToken )
+            .WarnIfLongAsync( this.Logger, nameof(this.WaitUntilInitializedAsync), cancellationToken );
 
     internal abstract void ConfigureRpc( JsonRpc rpc );
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/CompilationPipelineResult.Invalidator.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/CompilationPipelineResult.Invalidator.cs
@@ -45,7 +45,8 @@ public sealed partial class DesignTimeAspectPipelineResult
                 this._parent.Extensions,
                 this._parent.InheritableOptions,
                 this._parent.Annotations,
-                this._parent.AspectInstancesHashCode );
+                this._parent.AspectInstancesHashCode,
+                this._parent._foreignExtensions );
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -312,8 +312,20 @@ public sealed partial class DesignTimeAspectPipelineResult
 
         // Replace the contributors that belong to another compilation. They cannot be indexed per tree, because no
         // result of this project is keyed by the path of such a tree, so the set of the previous run is removed and
-        // the set of this run is added. A run re-produces the complete set, therefore replacing loses nothing.
-        if ( !this._foreignExtensions.IsEmpty || !foreignExtensions.IsEmpty )
+        // the set of this run is added.
+        //
+        // Only when this run produced some. A run that produced none has not established that there are none: the
+        // design-time stage invokes the extensions only when the run yielded at least one contributor of extension
+        // kind, so a validator source registered by an aspect contributes nothing on a run in which that aspect's file
+        // is clean, and a run whose pipeline failed carries none either. Replacing unconditionally would then drop the
+        // rules of a referenced project silently, which is the regression this whole branch of the method exists to
+        // avoid. Keeping the previous set instead is symmetric with the per-tree results, which are likewise replaced
+        // when their tree is re-analysed and kept otherwise.
+        //
+        // The residual is that a rule genuinely removed survives until the next run that produces any foreign
+        // contributor. Removing a rule is an edit to compile-time code, which discards the pipeline configuration and
+        // with it this whole result, so in practice that window does not outlive the edit. See issue #1796.
+        if ( !foreignExtensions.IsEmpty )
         {
             extensionsBuilder ??= this.Extensions.ToBuilder();
 
@@ -348,7 +360,7 @@ public sealed partial class DesignTimeAspectPipelineResult
             inheritableOptions,
             annotations,
             aspectInstancesHashCode,
-            foreignExtensions );
+            foreignExtensions.IsEmpty ? this._foreignExtensions : foreignExtensions );
     }
 
     /// <summary>
@@ -528,7 +540,7 @@ public sealed partial class DesignTimeAspectPipelineResult
                     builder.Extensions ??= ImmutableArray.CreateBuilder<IDesignTimePipelineResultExtension>();
                     builder.Extensions.Add( designTimeExtension );
                 }
-                else if ( compilation.Compilation.ContainsSyntaxTree( syntaxTree! ) )
+                else if ( syntaxTree != null && compilation.Compilation.ContainsSyntaxTree( syntaxTree ) )
                 {
                     // The tree belongs to this project but is not dirty, so it is not part of the partial compilation.
                     // This is the same situation as for an inheritable aspect instance above: an aspect can export a
@@ -543,7 +555,9 @@ public sealed partial class DesignTimeAspectPipelineResult
                 }
                 else
                 {
-                    // The tree belongs to another compilation. This happens with cross-project validators: the syntax
+                    // The tree belongs to another compilation, or the contributor reports none and the result keyed by
+                    // the empty path was not created, which the branch above normally guarantees. The case that
+                    // matters is the first: with cross-project validators the syntax
                     // tree a reference validator reports is that of the validated declaration, and a fabric of this
                     // project can validate references to declarations of a referenced project. No result of this
                     // project is keyed by that path, and none ever will be, so skipping the contributor would lose it

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -122,7 +122,7 @@ public sealed partial class DesignTimeAspectPipelineResult
     {
         Logger.DesignTime.Trace?.Log( $"CompilationPipelineResult.Update( id = {this._id} )" );
 
-        var (resultsByTree, externalExtensions) = SplitResultsByTree( compilation, pipelineResults );
+        var resultsByTree = SplitResultsByTree( compilation, pipelineResults );
 
         var syntaxTreeResultBuilder = this.SyntaxTreeResults.ToBuilder();
 
@@ -300,16 +300,6 @@ public sealed partial class DesignTimeAspectPipelineResult
         var introducedTrees = introducedSyntaxTreeBuilder?.ToImmutable() ?? this.IntroducedSyntaxTrees;
         var inheritableAspects = inheritableAspectsBuilder?.ToImmutable() ?? this._inheritableAspects;
 
-        if ( externalExtensions != null )
-        {
-            extensionsBuilder ??= this.Extensions.ToBuilder();
-
-            foreach ( var externalExtension in externalExtensions )
-            {
-                extensionsBuilder.Add( externalExtension );
-            }
-        }
-
         var extensions = extensionsBuilder?.ToImmutable( projectVersion.ReferencedExtensions )
                          ?? this.Extensions.WithChildCollections( projectVersion.ReferencedExtensions );
 
@@ -332,18 +322,15 @@ public sealed partial class DesignTimeAspectPipelineResult
     /// Splits a <see cref="DesignTimePipelineExecutionResult"/>, which includes data for several syntax trees, into
     /// a list of <see cref="SyntaxTreePipelineResult"/> which each have information related to a single syntax tree.
     /// </summary>
-    private static (IEnumerable<SyntaxTreePipelineResult> Results, IReadOnlyList<IDesignTimePipelineResultExtension>? ExternalValidators)
-        SplitResultsByTree(
-            PartialCompilation compilation,
-            DesignTimePipelineExecutionResult pipelineResults )
+    private static IEnumerable<SyntaxTreePipelineResult> SplitResultsByTree(
+        PartialCompilation compilation,
+        DesignTimePipelineExecutionResult pipelineResults )
     {
         SyntaxTreePipelineResult.Builder? emptySyntaxTreeResult = null;
 
         var resultBuilders = pipelineResults
             .InputSyntaxTrees
             .ToDictionary( r => r.Key, syntaxTree => new SyntaxTreePipelineResult.Builder( syntaxTree.Value ) );
-
-        List<IDesignTimePipelineResultExtension>? externalValidators = null;
 
         // Split diagnostic by syntax tree.
         foreach ( var diagnostic in pipelineResults.Diagnostics.ReportedDiagnostics )
@@ -502,9 +489,18 @@ public sealed partial class DesignTimeAspectPipelineResult
                 }
                 else
                 {
-                    // This happens with cross-project validators
-                    externalValidators ??= new List<IDesignTimePipelineResultExtension>();
-                    externalValidators.Add( designTimeExtension );
+                    // The contributor is not bound to the trees the pipeline ran on, for the same reason as an
+                    // inheritable aspect instance above: an aspect can export one onto a declaration it did not
+                    // itself target, such as the declaring type of a base constructor, and that declaration can be in
+                    // a tree that is not dirty. The contributor is skipped instead of being filed under that tree,
+                    // because the tree keeps the result of the run that did include it, and that result already
+                    // carries this contributor. Filing it under the tree would overwrite that result and drop the
+                    // diagnostics and introductions it holds, and accumulating it outside any tree, which is what
+                    // this method used to do, gives the collection an entry per run that nothing can ever remove.
+                    // See issues #1768 and #1796.
+                    Logger.DesignTime.Trace?.Log(
+                        $"SplitResultsByTree: skipping the transitive contributor of kind '{designTimeExtension.ContributorKind}' because it belongs "
+                        + $"to syntax tree '{filePath}', which is not a part of the partial compilation." );
                 }
             }
             else
@@ -658,7 +654,7 @@ public sealed partial class DesignTimeAspectPipelineResult
             resultBuilders[""] = emptySyntaxTreeResult;
         }
 
-        return (resultBuilders.SelectAsReadOnlyCollection( b => b.Value.ToImmutable( compilation.Compilation ) ), externalValidators);
+        return resultBuilders.SelectAsReadOnlyCollection( b => b.Value.ToImmutable( compilation.Compilation ) );
     }
 
     internal Invalidator ToInvalidator() => new( this );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -579,17 +579,17 @@ public sealed partial class DesignTimeAspectPipelineResult
                     // introductions it holds. See issue #1768.
                     Logger.DesignTime.Trace?.Log(
                         $"SplitResultsByTree: skipping the transitive contributor of kind '{designTimeExtension.ContributorKind}' because it belongs "
-                        + $"to syntax tree '{filePath}' of this project, which is not a part of the partial compilation." );
+                        + $"to syntax tree '{documentKey}' of this project, which is not a part of the partial compilation." );
                 }
                 else
                 {
                     // The tree belongs to another compilation, or the contributor reports none and the result keyed by
-                    // the empty path was not created, which the branch above normally guarantees. The case that
-                    // matters is the first: with cross-project validators the syntax
-                    // tree a reference validator reports is that of the validated declaration, and a fabric of this
-                    // project can validate references to declarations of a referenced project. No result of this
-                    // project is keyed by that path, and none ever will be, so skipping the contributor would lose it
-                    // and the rules it enforces would silently stop being applied.
+                    // the default DocumentKey was not created, which the branch above normally guarantees. The case
+                    // that matters is the first: with cross-project validators the syntax tree a reference validator
+                    // reports is that of the validated declaration, and a fabric of this project can validate
+                    // references to declarations of a referenced project. No result of this project is keyed by that
+                    // document, and none ever will be, so skipping the contributor would lose it and the rules it
+                    // enforces would silently stop being applied.
                     //
                     // Such a contributor is therefore kept, in a collection that is replaced on every run rather than
                     // appended to. Replacing is correct because a run re-produces the complete set: the extension that

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/Pipeline/DesignTimeAspectPipelineResult.cs
@@ -68,6 +68,18 @@ public sealed partial class DesignTimeAspectPipelineResult
 
     private readonly ImmutableDictionaryOfHashSet<string, InheritableAspectInstance> _inheritableAspects = _emptyInheritableAspects;
 
+    /// <summary>
+    /// The contributors of the last run that belong to a syntax tree of another compilation, typically the validators
+    /// that a fabric of this project applies to declarations of a referenced project.
+    /// </summary>
+    /// <remarks>
+    /// No <see cref="SyntaxTreePipelineResult"/> of this project is keyed by the path of such a tree, so these
+    /// contributors cannot be indexed and un-indexed per tree like the others. They are kept here instead, and
+    /// <see cref="Update"/> replaces the whole set on every run rather than adding to it. See issue #1796.
+    /// </remarks>
+    private readonly ImmutableArray<IDesignTimePipelineResultExtension> _foreignExtensions =
+        ImmutableArray<IDesignTimePipelineResultExtension>.Empty;
+
     public ImmutableDictionary<HierarchicalOptionsKey, IHierarchicalOptions> InheritableOptions { get; } = _emptyInheritableOptions;
 
     public ImmutableDictionaryOfArray<SerializableDeclarationId, IAnnotation> Annotations { get; } = _emptyAnnotations;
@@ -83,8 +95,10 @@ public sealed partial class DesignTimeAspectPipelineResult
         DesignTimeAspectPipelineResultExtensionCollection extensions,
         ImmutableDictionary<HierarchicalOptionsKey, IHierarchicalOptions> inheritableOptions,
         ImmutableDictionaryOfArray<SerializableDeclarationId, IAnnotation> annotations,
-        ulong aspectInstancesHashCode )
+        ulong aspectInstancesHashCode,
+        ImmutableArray<IDesignTimePipelineResultExtension> foreignExtensions )
     {
+        this._foreignExtensions = foreignExtensions;
         this.SyntaxTreeResults = syntaxTreeResults;
         this._invalidSyntaxTreeResults = invalidSyntaxTreeResults;
         this.IntroducedSyntaxTrees = introducedSyntaxTrees;
@@ -122,7 +136,7 @@ public sealed partial class DesignTimeAspectPipelineResult
     {
         Logger.DesignTime.Trace?.Log( $"CompilationPipelineResult.Update( id = {this._id} )" );
 
-        var resultsByTree = SplitResultsByTree( compilation, pipelineResults );
+        var (resultsByTree, foreignExtensions) = SplitResultsByTree( compilation, pipelineResults );
 
         var syntaxTreeResultBuilder = this.SyntaxTreeResults.ToBuilder();
 
@@ -296,6 +310,24 @@ public sealed partial class DesignTimeAspectPipelineResult
             aspectInstancesHashCode ^= newSyntaxTreeResult.AspectInstancesHashCode;
         }
 
+        // Replace the contributors that belong to another compilation. They cannot be indexed per tree, because no
+        // result of this project is keyed by the path of such a tree, so the set of the previous run is removed and
+        // the set of this run is added. A run re-produces the complete set, therefore replacing loses nothing.
+        if ( !this._foreignExtensions.IsEmpty || !foreignExtensions.IsEmpty )
+        {
+            extensionsBuilder ??= this.Extensions.ToBuilder();
+
+            foreach ( var oldForeignExtension in this._foreignExtensions )
+            {
+                extensionsBuilder.Remove( oldForeignExtension );
+            }
+
+            foreach ( var newForeignExtension in foreignExtensions )
+            {
+                extensionsBuilder.Add( newForeignExtension );
+            }
+        }
+
         // Make immutable and return.
         var introducedTrees = introducedSyntaxTreeBuilder?.ToImmutable() ?? this.IntroducedSyntaxTrees;
         var inheritableAspects = inheritableAspectsBuilder?.ToImmutable() ?? this._inheritableAspects;
@@ -315,14 +347,21 @@ public sealed partial class DesignTimeAspectPipelineResult
             extensions,
             inheritableOptions,
             annotations,
-            aspectInstancesHashCode );
+            aspectInstancesHashCode,
+            foreignExtensions );
     }
 
     /// <summary>
     /// Splits a <see cref="DesignTimePipelineExecutionResult"/>, which includes data for several syntax trees, into
     /// a list of <see cref="SyntaxTreePipelineResult"/> which each have information related to a single syntax tree.
     /// </summary>
-    private static IEnumerable<SyntaxTreePipelineResult> SplitResultsByTree(
+    /// <param name="compilation">The partial compilation the pipeline ran on.</param>
+    /// <param name="pipelineResults">The results to split.</param>
+    /// <returns>
+    /// The results for each syntax tree of <paramref name="compilation"/>, and the contributors that belong to a
+    /// syntax tree of another compilation, which no result of this project can carry.
+    /// </returns>
+    private static (IEnumerable<SyntaxTreePipelineResult> Results, ImmutableArray<IDesignTimePipelineResultExtension> ForeignExtensions) SplitResultsByTree(
         PartialCompilation compilation,
         DesignTimePipelineExecutionResult pipelineResults )
     {
@@ -331,6 +370,8 @@ public sealed partial class DesignTimeAspectPipelineResult
         var resultBuilders = pipelineResults
             .InputSyntaxTrees
             .ToDictionary( r => r.Key, syntaxTree => new SyntaxTreePipelineResult.Builder( syntaxTree.Value ) );
+
+        ImmutableArray<IDesignTimePipelineResultExtension>.Builder? foreignExtensions = null;
 
         // Split diagnostic by syntax tree.
         foreach ( var diagnostic in pipelineResults.Diagnostics.ReportedDiagnostics )
@@ -487,20 +528,34 @@ public sealed partial class DesignTimeAspectPipelineResult
                     builder.Extensions ??= ImmutableArray.CreateBuilder<IDesignTimePipelineResultExtension>();
                     builder.Extensions.Add( designTimeExtension );
                 }
-                else
+                else if ( compilation.Compilation.ContainsSyntaxTree( syntaxTree! ) )
                 {
-                    // The contributor is not bound to the trees the pipeline ran on, for the same reason as an
-                    // inheritable aspect instance above: an aspect can export one onto a declaration it did not
-                    // itself target, such as the declaring type of a base constructor, and that declaration can be in
-                    // a tree that is not dirty. The contributor is skipped instead of being filed under that tree,
-                    // because the tree keeps the result of the run that did include it, and that result already
-                    // carries this contributor. Filing it under the tree would overwrite that result and drop the
-                    // diagnostics and introductions it holds, and accumulating it outside any tree, which is what
-                    // this method used to do, gives the collection an entry per run that nothing can ever remove.
-                    // See issues #1768 and #1796.
+                    // The tree belongs to this project but is not dirty, so it is not part of the partial compilation.
+                    // This is the same situation as for an inheritable aspect instance above: an aspect can export a
+                    // contributor onto a declaration it did not itself target, such as the declaring type of a base
+                    // constructor. The contributor is skipped rather than filed under that tree, because the tree
+                    // keeps the result of the run that did include it and that result already carries this
+                    // contributor. Filing it under the tree would overwrite that result and drop the diagnostics and
+                    // introductions it holds. See issue #1768.
                     Logger.DesignTime.Trace?.Log(
                         $"SplitResultsByTree: skipping the transitive contributor of kind '{designTimeExtension.ContributorKind}' because it belongs "
-                        + $"to syntax tree '{filePath}', which is not a part of the partial compilation." );
+                        + $"to syntax tree '{filePath}' of this project, which is not a part of the partial compilation." );
+                }
+                else
+                {
+                    // The tree belongs to another compilation. This happens with cross-project validators: the syntax
+                    // tree a reference validator reports is that of the validated declaration, and a fabric of this
+                    // project can validate references to declarations of a referenced project. No result of this
+                    // project is keyed by that path, and none ever will be, so skipping the contributor would lose it
+                    // and the rules it enforces would silently stop being applied.
+                    //
+                    // Such a contributor is therefore kept, in a collection that is replaced on every run rather than
+                    // appended to. Replacing is correct because a run re-produces the complete set: the extension that
+                    // creates reference validators runs every validator source over the whole compilation, not over
+                    // the partial one. Appending, which is what this method used to do, gave the collection an entry
+                    // per run that nothing could ever remove. See issue #1796.
+                    foreignExtensions ??= ImmutableArray.CreateBuilder<IDesignTimePipelineResultExtension>();
+                    foreignExtensions.Add( designTimeExtension );
                 }
             }
             else
@@ -654,7 +709,8 @@ public sealed partial class DesignTimeAspectPipelineResult
             resultBuilders[""] = emptySyntaxTreeResult;
         }
 
-        return resultBuilders.SelectAsReadOnlyCollection( b => b.Value.ToImmutable( compilation.Compilation ) );
+        return (resultBuilders.SelectAsReadOnlyCollection( b => b.Value.ToImmutable( compilation.Compilation ) ),
+                foreignExtensions?.ToImmutable() ?? ImmutableArray<IDesignTimePipelineResultExtension>.Empty);
     }
 
     internal Invalidator ToInvalidator() => new( this );

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/ServiceProvider/RpcServiceProviderServerEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/ServiceProvider/RpcServiceProviderServerEndpoint.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 

--- a/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/ServiceProvider/RpcServiceProviderServerEndpoint.cs
+++ b/Metalama.Framework/src/Metalama.Framework.DesignTime/VisualStudio/ServiceProvider/RpcServiceProviderServerEndpoint.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
@@ -14,6 +14,7 @@ using Metalama.Framework.DesignTime.VisualStudio.Rpc;
 using Metalama.Framework.DesignTime.VisualStudio.ServiceHub;
 using Metalama.Framework.DesignTime.VisualStudio.SourceGenerating;
 using Metalama.Framework.Engine.Services;
+using Metalama.Framework.Engine.Utilities.Threading;
 using System.Collections.Immutable;
 
 namespace Metalama.Framework.DesignTime.VisualStudio.ServiceProvider;
@@ -105,6 +106,12 @@ public sealed class RpcServiceProviderServerEndpoint : ServerEndpoint
                 {
                     this.Logger.Warning?.Log( "Cannot get the ServiceHubClientEndpoint." );
 
+                    // Completed even though the registration did not take place. Registration is attempted once, so
+                    // nothing else would ever complete this task, and every caller of RegisterProjectAsync would wait
+                    // for an event that cannot occur. That method tests the provider again and degrades gracefully,
+                    // therefore completing here loses nothing. See issue #1799.
+                    this._hubRegistrationTask.TrySetResult( false );
+
                     return;
                 }
 
@@ -118,19 +125,23 @@ public sealed class RpcServiceProviderServerEndpoint : ServerEndpoint
                 this.Logger.Warning?.Log( "ServiceHubClientEndpointProvider is not available." );
             }
 
-            this._hubRegistrationTask.SetResult( true );
+            this._hubRegistrationTask.TrySetResult( true );
         }
         catch ( Exception ex )
         {
             this.Logger.LogException( ex, $"Cannot register the endpoint '{this.PipeName}' on the hub" );
-            this._hubRegistrationTask.SetException( ex );
+            this._hubRegistrationTask.TrySetException( ex );
         }
     }
 
     [PublicAPI( "Used by Metalama.Premium tests." )]
     public async Task RegisterProjectAsync( ProjectKey projectKey, CancellationToken cancellationToken )
     {
-        await this._hubRegistrationTask.Task.WarnIfLongAsync( this.Logger, "Awaiting for _hubRegistrationTask", cancellationToken );
+        // WithCancellation first, for the reason given in ClientEndpoint.GetOrWaitForClientAsync: passing the token
+        // to WarnIfLongAsync alone does not make the wait cancellable.
+        await this._hubRegistrationTask.Task
+            .WithCancellation( cancellationToken )
+            .WarnIfLongAsync( this.Logger, "Awaiting for _hubRegistrationTask", cancellationToken );
 
         if ( this._serviceHubApiClientProvider != null )
         {

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedMethodAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedMethodAdvice.cs
@@ -1,4 +1,4 @@
-﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
@@ -169,11 +169,6 @@ internal sealed class OnConstructedMethodAdvice : Advice<AddInitializerAdviceRes
             context.AddTransitiveAspect(
                 new TransitiveAspectInstance(
                     transitiveAspect,
-
-                    // Durable: a transitive aspect instance is stored in the design-time results of the file
-                    // declaring its target, which the pipeline carries forward to every later version of the
-                    // project, so a symbol-backed reference would pin the compilation it was produced in for the
-                    // whole editing session. See issue #1797.
                     targetType.ToRef().ToDurable(),
                     targetType.Depth,
                     (IAspectClassImpl) context.AspectClassResolver.GetAspectClass( typeof(AddConstructorEpilogueTransitiveAspect) ),

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedMethodAdvice.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Initialization/OnConstructedMethodAdvice.cs
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
@@ -169,7 +169,12 @@ internal sealed class OnConstructedMethodAdvice : Advice<AddInitializerAdviceRes
             context.AddTransitiveAspect(
                 new TransitiveAspectInstance(
                     transitiveAspect,
-                    targetType.ToRef(),
+
+                    // Durable: a transitive aspect instance is stored in the design-time results of the file
+                    // declaring its target, which the pipeline carries forward to every later version of the
+                    // project, so a symbol-backed reference would pin the compilation it was produced in for the
+                    // whole editing session. See issue #1797.
+                    targetType.ToRef().ToDurable(),
                     targetType.Depth,
                     (IAspectClassImpl) context.AspectClassResolver.GetAspectClass( typeof(AddConstructorEpilogueTransitiveAspect) ),
                     this.AspectLayerInstance.AspectInstance.AspectState,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterAdviceImpl.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterAdviceImpl.cs
@@ -222,6 +222,12 @@ internal sealed class PullConstructorParameterAdviceImpl
             {
                 var transitiveAspect = new PullConstructorParameterTransitiveAspect(
                     this._pullStrategy,
+
+                    // Durable, like the target declaration below: the aspect object is carried by the transitive
+                    // aspect instance and lives exactly as long. The pulled parameter may itself have been
+                    // introduced by an earlier aspect, in which case this is an IntroducedRef, whose serializable
+                    // identifier names the constructor signature and the ordinal and therefore survives the
+                    // re-introduction that a later run performs. See issue #1797.
                     baseParameter.ToRef(),
                     this._context.AspectOrder,
                     this._forwardingHelper?.OverloadingStrategy );
@@ -229,7 +235,7 @@ internal sealed class PullConstructorParameterAdviceImpl
                 this._context.AddTransitiveAspect(
                     new TransitiveAspectInstance(
                         transitiveAspect,
-                        baseParameter.DeclaringMember.DeclaringType.ToRef(),
+                        baseParameter.DeclaringMember.DeclaringType.ToRef().ToDurable(),
                         baseParameter.DeclaringMember.DeclaringType.Depth,
                         (IAspectClassImpl) this._context.AspectClassResolver.GetAspectClass( typeof(PullConstructorParameterTransitiveAspect) ),
                         this._aspectLayerInstance.AspectInstance.AspectState,

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.Serializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.Serializer.cs
@@ -19,6 +19,10 @@ internal sealed partial class PullConstructorParameterTransitiveAspect
         public override PullConstructorParameterTransitiveAspect CreateInstance( IArgumentsReader constructorArguments )
         {
             var pullStrategy = constructorArguments.GetValue<IPullStrategy>( nameof(_pullStrategy) );
+            // Read and written as IRef, which is the shape the serialization framework knows, and converted on this
+            // boundary. A deserialized reference is already durable, since RefSerializer rebuilds it from a
+            // serializable identifier, so ToDurable is a no-op here; it is what satisfies the field type, which
+            // declares the requirement rather than trusting the caller. See issue #1797.
             var parameter = constructorArguments.GetValue<IRef<IParameter>>( nameof(_parameter) ).AssertNotNull();
             var order = constructorArguments.GetValue<int>( nameof(_order) );
             var overloadingStrategy = constructorArguments.GetValue<IConstructorOverloadingStrategy>( nameof(_overloadingStrategy) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.Serializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.Serializer.cs
@@ -19,10 +19,9 @@ internal sealed partial class PullConstructorParameterTransitiveAspect
         public override PullConstructorParameterTransitiveAspect CreateInstance( IArgumentsReader constructorArguments )
         {
             var pullStrategy = constructorArguments.GetValue<IPullStrategy>( nameof(_pullStrategy) );
-            // Read and written as IRef, which is the shape the serialization framework knows, and converted on this
-            // boundary. A deserialized reference is already durable, since RefSerializer rebuilds it from a
-            // serializable identifier, so ToDurable is a no-op here; it is what satisfies the field type, which
-            // declares the requirement rather than trusting the caller. See issue #1797.
+            // A deserialized reference is durable in practice, because RefSerializer rebuilds it from a serializable
+            // identifier. The field is nevertheless typed IRef rather than IDurableRef, because the reference the
+            // advice creates in the producing project is not. See issue #1797.
             var parameter = constructorArguments.GetValue<IRef<IParameter>>( nameof(_parameter) ).AssertNotNull();
             var order = constructorArguments.GetValue<int>( nameof(_order) );
             var overloadingStrategy = constructorArguments.GetValue<IConstructorOverloadingStrategy>( nameof(_overloadingStrategy) );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.cs
@@ -16,14 +16,21 @@ namespace Metalama.Framework.Engine.AdviceImpl.Introduction.Constructors;
 internal sealed partial class PullConstructorParameterTransitiveAspect : IAspect<INamedType>
 {
     private readonly IPullStrategy? _pullStrategy;
+
+    /// <summary>
+    /// The parameter of the base constructor whose value the derived constructor is made to pull.
+    /// </summary>
     /// <remarks>
-    /// Durable by declaration, for the reason given on <see cref="TransitiveAspectInstance.TargetDeclaration"/>: this
-    /// aspect object is carried by a transitive aspect instance and lives exactly as long as it does. The parameter
-    /// may itself have been introduced by an earlier aspect, in which case the reference is an <c>IntroducedRef</c>,
-    /// whose serializable identifier names the constructor signature and the ordinal and so survives the
-    /// re-introduction a later run performs.
+    /// This reference is deliberately not durable, unlike <see cref="TransitiveAspectInstance.TargetDeclaration"/>,
+    /// and it is the last route by which a transitive aspect instance retains the version of the project it was
+    /// produced in. Issue #1797 tracks it. Making it durable compiles and does close the retention, because an
+    /// <c>IntroducedRef</c> has a serializable identifier naming the constructor signature and the ordinal, but the
+    /// identity of an introduced declaration is not settled while the advice runs, so the identifier captured at that
+    /// moment is one the consuming project cannot resolve, and the cross-project case then fails silently. Making it
+    /// durable therefore has to happen later in the pipeline, which is a change of design.
     /// </remarks>
     private readonly IRef<IParameter> _parameter;
+
     private readonly int _order;
     private readonly IConstructorOverloadingStrategy? _overloadingStrategy;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/AdviceImpl/Introduction/Constructors/PullConstructorParameterTransitiveAspect.cs
@@ -16,6 +16,13 @@ namespace Metalama.Framework.Engine.AdviceImpl.Introduction.Constructors;
 internal sealed partial class PullConstructorParameterTransitiveAspect : IAspect<INamedType>
 {
     private readonly IPullStrategy? _pullStrategy;
+    /// <remarks>
+    /// Durable by declaration, for the reason given on <see cref="TransitiveAspectInstance.TargetDeclaration"/>: this
+    /// aspect object is carried by a transitive aspect instance and lives exactly as long as it does. The parameter
+    /// may itself have been introduced by an earlier aspect, in which case the reference is an <c>IntroducedRef</c>,
+    /// whose serializable identifier names the constructor signature and the ordinal and so survives the
+    /// re-introduction a later run performs.
+    /// </remarks>
     private readonly IRef<IParameter> _parameter;
     private readonly int _order;
     private readonly IConstructorOverloadingStrategy? _overloadingStrategy;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/AspectBuilder.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/AspectBuilder.cs
@@ -8,6 +8,7 @@ using Metalama.Framework.Code;
 using Metalama.Framework.Diagnostics;
 using Metalama.Framework.Eligibility;
 using Metalama.Framework.Engine.Advising;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Extensibility;
 using Metalama.Framework.Engine.Queries;
@@ -174,7 +175,14 @@ namespace Metalama.Framework.Engine.Aspects
 
         Type IQueryOwner.Type => this.AspectInstance.AspectClass.Type;
 
-        public UserCodeExecutionContext UserCodeExecutionContext => this._aspectBuilderState.UserCodeExecutionContext;
+        /// <inheritdoc />
+        /// <remarks>
+        /// An aspect builder lives for the duration of a single execution of the aspect, so it may return the context
+        /// it already holds, rebound to the compilation of the query. See <see cref="IQueryOwner.GetUserCodeExecutionContext"/>
+        /// for the owners that may not.
+        /// </remarks>
+        public UserCodeExecutionContext GetUserCodeExecutionContext( CompilationModel compilation, IDiagnosticAdder diagnostics )
+            => this._aspectBuilderState.UserCodeExecutionContext.WithCompilationAndDiagnosticAdder( compilation, diagnostics );
 
         UserCodeInvoker IQueryOwner.UserCodeInvoker => this._aspectBuilderState.Configuration.UserCodeInvoker;
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectInstance.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectInstance.cs
@@ -1,10 +1,11 @@
-// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Extensibility;
+using Metalama.Framework.Engine.CodeModel.References;
 using Microsoft.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.Aspects;
@@ -13,7 +14,7 @@ internal sealed class TransitiveAspectInstance : ITransitivePipelineContributor,
 {
     internal TransitiveAspectInstance(
         IAspect aspect,
-        IRef<IDeclaration> targetDeclaration,
+        IDurableRef<IDeclaration> targetDeclaration,
         int targetDeclarationDepth,
         IAspectClassImpl aspectClass,
         IAspectState? aspectState,
@@ -31,7 +32,17 @@ internal sealed class TransitiveAspectInstance : ITransitivePipelineContributor,
 
     public int PredecessorDegree { get; }
 
-    public IRef<IDeclaration> TargetDeclaration { get; }
+    /// <summary>
+    /// Gets the declaration this aspect instance applies to.
+    /// </summary>
+    /// <remarks>
+    /// Typed as <see cref="IDurableRef{T}"/> rather than <see cref="IRef{T}"/> on purpose. An instance of this class is
+    /// stored in the design-time result of the file declaring its target, and the pipeline carries that result forward
+    /// to every later version of the project, so a compilation-bound reference here would pin the version it was
+    /// produced in for the whole editing session. Declaring the requirement in the type makes it the compiler's
+    /// business rather than the caller's discipline. See issue #1797.
+    /// </remarks>
+    public IDurableRef<IDeclaration> TargetDeclaration { get; }
 
     public IAspect Aspect { get; }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectInstance.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Aspects/TransitiveAspectInstance.cs
@@ -1,11 +1,11 @@
-﻿// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
-using Metalama.Framework.Engine.Extensibility;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.Extensibility;
 using Microsoft.CodeAnalysis;
 
 namespace Metalama.Framework.Engine.Aspects;

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticDescriptorExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticDescriptorExtensions.cs
@@ -10,7 +10,6 @@ using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
-using System.Linq;
 
 namespace Metalama.Framework.Engine.Diagnostics;
 
@@ -185,6 +184,16 @@ public static class DiagnosticDescriptorExtensions
     /// formatted anyway, and it is done while the compilation is certainly available rather than at an arbitrary later
     /// point. The title and the message share the result instead of formatting the same arguments twice.
     /// </para>
+    /// <para>
+    /// The cost was measured, because it is paid on the compile-time path as well, where nothing outlives the run and
+    /// the work would be wasted for a diagnostic that is created and never displayed. Creating a diagnostic whose
+    /// argument is a declaration takes about 3.2 microseconds, of which about 2.3 are the display string; the same
+    /// diagnostic with a string argument takes about 0.25. A build that created ten thousand such diagnostics without
+    /// displaying any of them would therefore spend about twenty milliseconds more. That is small enough not to warrant
+    /// making the behaviour conditional on the execution scenario, which this method has no way of reading: it is a
+    /// static extension, reached from many call sites, and the project forbids passing a service as a parameter to
+    /// obtain one.
+    /// </para>
     /// </remarks>
     private static object?[] MaterializeCompilationBoundArguments( object?[] arguments )
     {
@@ -240,6 +249,13 @@ public static class DiagnosticDescriptorExtensions
             ISymbol => true,
             IRef => true,
 
+            // The two primitive types that do not implement IFormattable, and which the last case below would
+            // otherwise materialize. Materializing them would produce the same message, since neither reads the format
+            // specifier, so this is a matter of not doing needless work rather than of correctness, and no test can
+            // tell the two behaviours apart.
+            bool => false,
+            char => false,
+
             // Enumerations, including the ones the formatter gives a display name to, and reflection types, which are
             // either real types or the identifier-based compile-time mocks. None of them reaches a compilation.
             Enum => false,
@@ -251,7 +267,7 @@ public static class DiagnosticDescriptorExtensions
 
             // Any other array is formatted element by element with an empty specifier, so materializing the array as a
             // whole is faithful. It is worth doing only when an element requires it.
-            Array array => array.Cast<object?>().Any( IsCompilationBound ),
+            Array array => AnyElementIsCompilationBound( array ),
 
             // Numbers, dates and the like, whose format specifier must reach them. This case is deliberately after
             // IDisplayable and ISymbol, which the formatter also matches first.
@@ -259,4 +275,21 @@ public static class DiagnosticDescriptorExtensions
 
             _ => true
         };
+
+    /// <summary>
+    /// Determines whether any element of <paramref name="array"/> is compilation-bound, without the delegate and the
+    /// iterator that the equivalent query expression would allocate on a path taken for every diagnostic.
+    /// </summary>
+    private static bool AnyElementIsCompilationBound( Array array )
+    {
+        foreach ( var element in array )
+        {
+            if ( IsCompilationBound( element ) )
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticDescriptorExtensions.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Diagnostics/DiagnosticDescriptorExtensions.cs
@@ -2,12 +2,15 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Code;
 using Metalama.Framework.Diagnostics;
 using Metalama.Framework.Engine.Collections;
+using Metalama.Framework.Engine.Utilities;
 using Microsoft.CodeAnalysis;
 using System;
 using System.Collections.Generic;
 using System.Collections.Immutable;
+using System.Linq;
 
 namespace Metalama.Framework.Engine.Diagnostics;
 
@@ -138,18 +141,122 @@ public static class DiagnosticDescriptorExtensions
         var diagnosticSourceDescription = diagnosticSource == null ? null : $"Reported by {diagnosticSource.DiagnosticSourceDescription}.";
         var effectiveDescription = description ?? diagnosticSourceDescription;
 
+        var durableArguments = MaterializeCompilationBoundArguments( arguments );
+
         return Diagnostic.Create(
             definition.Id,
             definition.Category,
-            new NonLocalizedString( definition.MessageFormat, arguments ),
+            new NonLocalizedString( definition.MessageFormat, durableArguments ),
             definition.Severity.ToRoslynSeverity(),
             definition.Severity.ToRoslynSeverity(),
             true,
             definition.Severity == Severity.Error ? 0 : 1,
-            new NonLocalizedString( definition.Title, arguments ),
+            new NonLocalizedString( definition.Title, durableArguments ),
             location: location,
             additionalLocations: additionalLocations,
             properties: propertiesWithAdditions,
             description: effectiveDescription );
     }
+
+    /// <summary>
+    /// Replaces every argument that is bound to a compilation with the string it would have been formatted to,
+    /// leaving the others untouched.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A <see cref="Diagnostic"/> formats its message lazily, so the arguments are held by the
+    /// <see cref="NonLocalizedString"/> for as long as the diagnostic itself. At design time a diagnostic outlives by
+    /// far the version of the project it was reported on: it is kept in the <c>SyntaxTreePipelineResult</c> of its
+    /// file, and that result is carried forward to every subsequent version in which the file is not re-analysed. An
+    /// argument that is a declaration therefore keeps the whole compilation of the run that reported the diagnostic
+    /// alive, which is the retention described in issue #1799. Passing the declaration is the natural way to write
+    /// the message, so the fix belongs here rather than in every diagnostic definition.
+    /// </para>
+    /// <para>
+    /// Only the compilation-bound arguments are materialized, not all of them, because
+    /// <see cref="MetalamaStringFormatter"/> passes the format specifier of the composite format string to an
+    /// <see cref="IFormattable"/> argument. Materializing such an argument would apply its specifier to a string
+    /// instead, changing the result of <c>{0:N2}</c> and making <c>{0:x}</c> throw. The two sets do not overlap: every
+    /// branch of the formatter that handles a compilation-bound value formats it without regard to the specifier, so
+    /// materializing exactly those arguments cannot change any message.
+    /// </para>
+    /// <para>
+    /// Formatting here is not extra work in the ordinary case, in which the message is displayed and would have been
+    /// formatted anyway, and it is done while the compilation is certainly available rather than at an arbitrary later
+    /// point. The title and the message share the result instead of formatting the same arguments twice.
+    /// </para>
+    /// </remarks>
+    private static object?[] MaterializeCompilationBoundArguments( object?[] arguments )
+    {
+        if ( arguments.Length == 0 )
+        {
+            return arguments;
+        }
+
+        // A caller that formats ahead of time must not fail when no formatter has been registered, because leaving the
+        // arguments alone is a correct outcome: they are then formatted later, exactly as before this optimization.
+        var formatter = MetalamaStringFormatter.InstanceOrNull;
+
+        if ( formatter == null )
+        {
+            return arguments;
+        }
+
+        object?[]? materialized = null;
+
+        for ( var i = 0; i < arguments.Length; i++ )
+        {
+            if ( !IsCompilationBound( arguments[i] ) )
+            {
+                continue;
+            }
+
+            materialized ??= (object?[]) arguments.Clone();
+            materialized[i] = formatter.Format( arguments[i] );
+        }
+
+        return materialized ?? arguments;
+    }
+
+    /// <summary>
+    /// Determines whether an argument may reach a compilation, and may therefore not be stored in a diagnostic.
+    /// </summary>
+    /// <remarks>
+    /// The default is <c>true</c>, so that a type nobody considered is materialized rather than retained. The cost of
+    /// being wrong in that direction is that a message is formatted earlier than it needed to be; the cost of being
+    /// wrong in the other direction is a retained compilation, which is what this method exists to prevent. Each
+    /// <c>false</c> below therefore names a category that is either a value or a string, or whose formatting depends
+    /// on the format specifier and must stay lazy.
+    /// </remarks>
+    private static bool IsCompilationBound( object? argument )
+        => argument switch
+        {
+            null => false,
+            string => false,
+
+            // Formatted by ToDisplayString and ToDebugString respectively, neither of which reads the format
+            // specifier. These are the categories that reach a compilation, and IDeclaration is among them.
+            IDisplayable => true,
+            ISymbol => true,
+            IRef => true,
+
+            // Enumerations, including the ones the formatter gives a display name to, and reflection types, which are
+            // either real types or the identifier-based compile-time mocks. None of them reaches a compilation.
+            Enum => false,
+            Type => false,
+
+            // The formatter gives an array of strings a presentation of its own, which materializing the array as a
+            // whole would lose, and an array of strings cannot reach a compilation anyway.
+            string?[] => false,
+
+            // Any other array is formatted element by element with an empty specifier, so materializing the array as a
+            // whole is faithful. It is worth doing only when an element requires it.
+            Array array => array.Cast<object?>().Any( IsCompilationBound ),
+
+            // Numbers, dates and the like, whose format specifier must reach them. This case is deliberately after
+            // IDisplayable and ISymbol, which the formatter also matches first.
+            IFormattable => false,
+
+            _ => true
+        };
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Extensibility/IDesignTimePipelineResultExtension.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Extensibility/IDesignTimePipelineResultExtension.cs
@@ -8,6 +8,32 @@ using Metalama.Framework.Engine.Utilities.Roslyn;
 
 namespace Metalama.Framework.Engine.Extensibility;
 
+/// <summary>
+/// Represents the design-time form of a contributor produced by an extension, as returned by
+/// <see cref="ITransitivePipelineContributor.ToDesignTime"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An implementation must be durable, that is, it must hold no reference to a <c>Compilation</c>, a
+/// <c>SyntaxTree</c>, an <c>ISymbol</c>, a <c>CompilationModel</c>, a declaration of the code model, or a
+/// non-durable <see cref="Metalama.Framework.Code.IRef{T}"/>, and none to any object that reaches one. This is a
+/// requirement, not a recommendation: the design-time pipeline stores these objects for far longer than the run that
+/// produced them.
+/// </para>
+/// <para>
+/// The pipeline files each of them in the result of the syntax tree it belongs to, and it carries the result of every
+/// file that a run did not analyse forward to the next version of the project unchanged. It goes further: when a
+/// later run produces a contributor for a file that is not dirty, it discards the new instance so that the earlier one
+/// survives. An instance filed under a file the user does not edit therefore lives for the whole editing session, and
+/// anything bound to a compilation that it holds keeps that entire version of the project alive.
+/// </para>
+/// <para>
+/// Use <see cref="Metalama.Framework.Engine.Utilities.Roslyn.SymbolDictionaryKey.CreatePersistentKey"/> to refer to a
+/// symbol, and <c>IRef.ToDurable()</c> to refer to a declaration. Both keep only a serializable identifier. See
+/// <c>Metalama.Framework/docs/design-time-memory.md</c>, and issue #1799 for what the absence of this requirement
+/// cost.
+/// </para>
+/// </remarks>
 public interface IDesignTimePipelineResultExtension : IContributor
 {
     ITransitiveAspectsManifestExtension ToTransitiveAspectManifestExtension();

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Extensibility/ITransitivePipelineContributor.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Extensibility/ITransitivePipelineContributor.cs
@@ -11,7 +11,20 @@ namespace Metalama.Framework.Engine.Extensibility;
 /// </summary>
 public interface ITransitivePipelineContributor : IPipelineContributor
 {
+    /// <summary>
+    /// Gets the syntax tree that this contributor belongs to, which is the one under whose file path the design-time
+    /// pipeline files it, or <c>null</c> when it belongs to none.
+    /// </summary>
     SyntaxTree? SyntaxTree { get; }
 
+    /// <summary>
+    /// Returns the design-time form of this contributor, or <c>null</c> when it has none.
+    /// </summary>
+    /// <remarks>
+    /// The returned object is stored by the design-time pipeline for far longer than the run that produced it, and it
+    /// must therefore be durable. The contributor itself is under no such constraint, so this method is where a
+    /// compilation-bound state is converted into a serializable identifier. See
+    /// <see cref="IDesignTimePipelineResultExtension"/> for the requirement in full.
+    /// </remarks>
     IDesignTimePipelineResultExtension? ToDesignTime();
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
@@ -105,11 +105,18 @@ internal abstract partial class FabricDriver
 
         /// <inheritdoc />
         /// <remarks>
+        /// <para>
         /// Built afresh for each compilation, because a static fabric amender is durable. An amender whose own lifetime
         /// is a single run overrides this and may reuse a context it holds.
+        /// </para>
+        /// <para>
+        /// The context inherits nothing from the ambient one. This method is called on demand rather than while the
+        /// fabric is running, so an ambient context here belongs to whoever called into the query, not to the fabric.
+        /// See <see cref="UserCodeExecutionContext.CreateWithoutInheritance"/>.
+        /// </para>
         /// </remarks>
         public virtual UserCodeExecutionContext GetUserCodeExecutionContext( CompilationModel compilation, IDiagnosticAdder diagnostics )
-            => new( this._fabricManager.ServiceProvider, this._userCodeDescription, compilation, diagnostics: diagnostics );
+            => UserCodeExecutionContext.CreateWithoutInheritance( this._fabricManager.ServiceProvider, this._userCodeDescription, compilation, diagnostics );
 
         [Memo]
         public IQuery<T> Outbound

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricDriver.BaseAmender.cs
@@ -6,7 +6,9 @@ using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 using Metalama.Framework.Diagnostics;
 using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Extensibility;
 using Metalama.Framework.Engine.Queries;
 using Metalama.Framework.Engine.Services;
@@ -31,13 +33,14 @@ internal abstract partial class FabricDriver
 
         private readonly FabricManager _fabricManager;
         private readonly IProject _project;
+        private readonly UserCodeDescription _userCodeDescription;
 
         protected BaseAmender(
             IProject project,
             FabricManager fabricManager,
             FabricInstance fabricInstance,
             IRef<T> targetDeclaration,
-            UserCodeExecutionContext userCodeExecutionContext ) : base(
+            UserCodeDescription userCodeDescription ) : base(
             fabricManager.ServiceProvider,
             targetDeclaration,
             CompilationModelVersion.Final,
@@ -68,7 +71,16 @@ internal abstract partial class FabricDriver
         {
             this._project = project;
             this._fabricInstance = fabricInstance;
-            this.UserCodeExecutionContext = userCodeExecutionContext;
+
+            // Only the description of the fabric method is kept, never the execution context it belongs to. An amender
+            // belongs to the pipeline configuration, which is long-lived by design, being reused across keystrokes
+            // because rebuilding it per keystroke would be prohibitively slow; an execution context is bound to one
+            // compilation. Storing one here would therefore make the configuration pin a whole version of the project
+            // for the entire editing session, which is the defect reported by issue #1799. The context is built per
+            // run instead, by GetUserCodeExecutionContext. The description is a format string and its arguments, and
+            // is compilation-neutral.
+            this._userCodeDescription = userCodeDescription;
+
             this.TargetDeclaration = targetDeclaration.ToDurable(); // TODO PERF: ToDurable is useful only at design time.
             this._fabricManager = fabricManager;
         }
@@ -91,7 +103,13 @@ internal abstract partial class FabricDriver
 
         Type IQueryOwner.Type => this._fabricInstance.Fabric.GetType();
 
-        public UserCodeExecutionContext UserCodeExecutionContext { get; }
+        /// <inheritdoc />
+        /// <remarks>
+        /// Built afresh for each compilation, because a static fabric amender is durable. An amender whose own lifetime
+        /// is a single run overrides this and may reuse a context it holds.
+        /// </remarks>
+        public virtual UserCodeExecutionContext GetUserCodeExecutionContext( CompilationModel compilation, IDiagnosticAdder diagnostics )
+            => new( this._fabricManager.ServiceProvider, this._userCodeDescription, compilation, diagnostics: diagnostics );
 
         [Memo]
         public IQuery<T> Outbound

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricInstance.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/FabricInstance.cs
@@ -5,6 +5,7 @@
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Fabrics;
 using Microsoft.CodeAnalysis;
 using System;
@@ -29,7 +30,14 @@ namespace Metalama.Framework.Engine.Fabrics
         public FabricInstance( FabricDriver driver, IDeclaration targetDeclaration )
         {
             this.Driver = driver;
-            this.TargetDeclaration = targetDeclaration.ToRef();
+
+            // Durable, and not merely a reference, because a fabric instance belongs to the pipeline configuration
+            // through the amender of its fabric, and that configuration is long-lived by design, being reused across
+            // keystrokes. A symbol-backed reference reaches the compilation through its factory, which would make the
+            // configuration pin the version of the project it was built from for the whole editing session. See issue
+            // #1799, and the same conversion applied for the same reason in FabricDriver.BaseAmender.
+            this.TargetDeclaration = targetDeclaration.ToRef().ToDurable();
+
             this.TargetDeclarationDepth = targetDeclaration.Depth;
         }
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/NamespaceFabricDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/NamespaceFabricDriver.cs
@@ -56,9 +56,13 @@ namespace Metalama.Framework.Engine.Fabrics
                 return true;
             }
 
+            var description = UserCodeDescription.Create( "calling the AmendNamespace method for the fabric {0}", this.Fabric.GetType() );
+
+            // The context is for the immediate call to AmendNamespace below. The amender, which outlives this
+            // compilation, is given the description only. See IQueryOwner.GetUserCodeExecutionContext.
             var executionContext = UserCodeExecutionContext.CreateInstance(
                 this.FabricManager.ServiceProvider,
-                UserCodeDescription.Create( "calling the AmendNamespace method for the fabric {0}", this.Fabric.GetType() ),
+                description,
                 compilation,
                 diagnostics: diagnosticAdder );
 
@@ -67,7 +71,7 @@ namespace Metalama.Framework.Engine.Fabrics
                 this.FabricManager,
                 new FabricInstance( this, compilation.Factory.GetNamespace( namespaceSymbol ) ),
                 namespaceSymbol.GetFullName() ?? "",
-                executionContext );
+                description );
 
             if ( !this.FabricManager.UserCodeInvoker.TryInvoke( () => ((NamespaceFabric) this.Fabric).AmendNamespace( amender ), executionContext ) )
             {
@@ -90,13 +94,13 @@ namespace Metalama.Framework.Engine.Fabrics
                 FabricManager fabricManager,
                 FabricInstance fabricInstance,
                 string ns,
-                UserCodeExecutionContext userCodeExecutionContext ) : base(
+                UserCodeDescription userCodeDescription ) : base(
                 project,
                 fabricManager,
                 fabricInstance,
                 fabricInstance.TargetDeclaration.As<INamespace>(),
                 ns,
-                userCodeExecutionContext ) { }
+                userCodeDescription ) { }
 
             string INamespaceAmender.Namespace => this.Namespace.AssertNotNull();
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/ProjectFabricDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/ProjectFabricDriver.cs
@@ -103,9 +103,13 @@ namespace Metalama.Framework.Engine.Fabrics
 
             var projectFabric = (ProjectFabric) this.Fabric;
 
+            var description = UserCodeDescription.Create( "calling the AmendProject method for the fabric {0}", projectFabric.GetType() );
+
+            // The context is for the immediate call to AmendProject below. The amender, which outlives this
+            // compilation, is given the description only. See IQueryOwner.GetUserCodeExecutionContext.
             var executionContext = UserCodeExecutionContext.CreateInstance(
                 this.FabricManager.ServiceProvider.Underlying,
-                UserCodeDescription.Create( "calling the AmendProject method for the fabric {0}", projectFabric.GetType() ),
+                description,
                 compilation,
                 diagnostics: diagnosticAdder );
 
@@ -114,7 +118,7 @@ namespace Metalama.Framework.Engine.Fabrics
                 compilation,
                 this.FabricManager,
                 new FabricInstance( this, assembly ),
-                executionContext );
+                description );
 
             if ( !this.FabricManager.UserCodeInvoker.TryInvoke( () => projectFabric.AmendProject( amender ), executionContext ) )
             {
@@ -135,13 +139,13 @@ namespace Metalama.Framework.Engine.Fabrics
                 CompilationModel compilation,
                 FabricManager fabricManager,
                 FabricInstance fabricInstance,
-                UserCodeExecutionContext userCodeExecutionContext ) : base(
+                UserCodeDescription userCodeDescription ) : base(
                 project,
                 fabricManager,
                 fabricInstance,
                 compilation.RefFactory.ForCompilation(),
                 null,
-                userCodeExecutionContext ) { }
+                userCodeDescription ) { }
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/StaticFabricDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/StaticFabricDriver.cs
@@ -41,8 +41,8 @@ namespace Metalama.Framework.Engine.Fabrics
                 FabricInstance fabricInstance,
                 IRef<T> targetDeclaration,
                 string? ns,
-                UserCodeExecutionContext userCodeExecutionContext ) :
-                base( project, fabricManager, fabricInstance, targetDeclaration.ToDurable(), userCodeExecutionContext )
+                UserCodeDescription userCodeDescription ) :
+                base( project, fabricManager, fabricInstance, targetDeclaration.ToDurable(), userCodeDescription )
             {
                 this.Namespace = ns;
             }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/TypeFabricDriver.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Fabrics/TypeFabricDriver.cs
@@ -11,6 +11,7 @@ using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CompileTime;
+using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Extensibility;
 using Metalama.Framework.Engine.Utilities.Roslyn;
 using Metalama.Framework.Engine.Utilities.UserCode;
@@ -119,6 +120,7 @@ internal sealed class TypeFabricDriver : FabricDriver
     {
         private readonly IAspectBuilderInternal _aspectBuilder;
         private readonly IAdviser<INamedType> _adviser;
+        private readonly UserCodeExecutionContext _userCodeExecutionContext;
 
         public Amender(
             INamedType namedType,
@@ -131,9 +133,10 @@ internal sealed class TypeFabricDriver : FabricDriver
             fabricManager,
             fabricInstance,
             fabricInstance.TargetDeclaration.As<INamedType>(),
-            userCodeExecutionContext )
+            userCodeExecutionContext.Description )
         {
             this._aspectBuilder = aspectBuilder;
+            this._userCodeExecutionContext = userCodeExecutionContext;
             this.Type = namedType;
 
 #pragma warning disable CS0618 // ITypeAmender.Advice is obsolete
@@ -143,6 +146,16 @@ internal sealed class TypeFabricDriver : FabricDriver
         }
 
         public INamedType Type { get; }
+
+        /// <inheritdoc />
+        /// <remarks>
+        /// Unlike the amender of a static fabric, which is durable and must build a context per compilation, this one
+        /// is created for a single execution of the aspect that hosts the type fabric, and already holds a live
+        /// <see cref="INamedType"/> and the aspect builder. It may therefore reuse the context it was given, rebound to
+        /// the compilation of the query, which also preserves the aspect layer and the meta API that context carries.
+        /// </remarks>
+        public override UserCodeExecutionContext GetUserCodeExecutionContext( CompilationModel compilation, IDiagnosticAdder diagnostics )
+            => this._userCodeExecutionContext.WithCompilationAndDiagnosticAdder( compilation, diagnostics );
 
         public override void AddContributor( IPipelineContributor contributor ) => this._aspectBuilder.AddContributor( contributor );
 

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Queries/IQueryOwner.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Queries/IQueryOwner.cs
@@ -5,6 +5,8 @@
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Diagnostics;
 using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities.UserCode;
 using Metalama.Framework.Project;
@@ -28,5 +30,24 @@ public interface IQueryOwner : IPipelineContributorCollector, IDiagnosticSource
 
     Type Type { get; }
 
-    UserCodeExecutionContext UserCodeExecutionContext { get; }
+    /// <summary>
+    /// Returns the <see cref="UserCodeExecutionContext"/> under which the queries of this owner are to be executed
+    /// against a given compilation.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The owner is asked to produce a context rather than to expose one it holds, because an owner may be durable
+    /// while a context is bound to a compilation. A fabric amender is such an owner: it belongs to the
+    /// <c>AspectPipelineConfiguration</c>, which is long-lived by design, being reused across keystrokes because
+    /// rebuilding it per keystroke would be prohibitively slow. An amender that held a context would make that
+    /// configuration pin one whole version of the project for the entire editing session, which is the defect reported
+    /// by issue #1799.
+    /// </para>
+    /// <para>
+    /// Returning a context per compilation, rather than storing one and rebinding it, is what makes that impossible by
+    /// construction instead of by discipline. An owner whose own lifetime is that of a single run, such as an aspect
+    /// builder, may still return a context it holds.
+    /// </para>
+    /// </remarks>
+    UserCodeExecutionContext GetUserCodeExecutionContext( CompilationModel compilation, IDiagnosticAdder diagnostics );
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Queries/Query.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Queries/Query.cs
@@ -8,6 +8,7 @@ using Metalama.Framework.Diagnostics;
 using Metalama.Framework.Engine.Aspects;
 using Metalama.Framework.Engine.CodeModel;
 using Metalama.Framework.Engine.CodeModel.Helpers;
+using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Fabrics;
 using Metalama.Framework.Engine.Services;
@@ -87,13 +88,32 @@ namespace Metalama.Framework.Engine.Queries
         ITaggedQuery<INamedType, TTag> ITaggedQuery<TDeclaration, TTag>.SelectTypesDerivedFrom(
             INamedType baseType,
             DerivedTypesOptions options )
-            => this.SelectTypesDerivedFromCore( _ => baseType, options );
+            => this.SelectTypesDerivedFromCore( CreateBaseTypeResolver( baseType ), options );
 
         IQuery<INamedType> IQuery<TDeclaration>.SelectTypesDerivedFrom( Type baseType, DerivedTypesOptions options )
             => this.SelectTypesDerivedFromCore( c => c.Factory.GetNamedTypeByReflectionType( baseType ), options );
 
         IQuery<INamedType> IQuery<TDeclaration>.SelectTypesDerivedFrom( INamedType baseType, DerivedTypesOptions options )
-            => this.SelectTypesDerivedFromCore( _ => baseType, options );
+            => this.SelectTypesDerivedFromCore( CreateBaseTypeResolver( baseType ), options );
+
+        /// <summary>
+        /// Returns a function that resolves <paramref name="baseType"/> in the compilation of the run, given the type
+        /// as it stands in the compilation in which the query is being built.
+        /// </summary>
+        /// <remarks>
+        /// A query outlives by far the compilation it is built from: the query of a static fabric belongs to the
+        /// amender, which belongs to the pipeline configuration, which is long-lived by design and reused across
+        /// keystrokes. Capturing <paramref name="baseType"/> itself, which these overloads used to do, therefore made
+        /// the configuration pin the version of the project the fabric ran in, for the whole editing session. The
+        /// reference is made durable here, while the compilation is certainly available, and resolved again on each
+        /// run, which is what the overloads taking a <see cref="Type"/> do already. See issue #1799.
+        /// </remarks>
+        private static Func<CompilationModel, INamedType> CreateBaseTypeResolver( INamedType baseType )
+        {
+            var baseTypeRef = baseType.ToRef().ToDurable();
+
+            return c => baseTypeRef.GetTarget( c );
+        }
 
         private ITaggedQuery<INamedType, TTag> SelectTypesDerivedFromCore( Func<CompilationModel, INamedType> getBaseType, DerivedTypesOptions options )
             => this.AddChild(
@@ -188,7 +208,7 @@ namespace Metalama.Framework.Engine.Queries
                             compilationModel,
                             NullDiagnosticAdder.Instance,
                             this.Owner.UserCodeInvoker,
-                            this.Owner.UserCodeExecutionContext,
+                            this.Owner.GetUserCodeExecutionContext( compilationModel, NullDiagnosticAdder.Instance ),
                             CancellationToken.None ),
                         ( declaration, _, _ ) =>
                         {
@@ -416,7 +436,7 @@ namespace Metalama.Framework.Engine.Queries
                 compilation,
                 diagnosticAdder,
                 this.Owner.UserCodeInvoker,
-                this.Owner.UserCodeExecutionContext.WithCompilationAndDiagnosticAdder( compilation, diagnosticAdder ),
+                this.Owner.GetUserCodeExecutionContext( compilation, diagnosticAdder ),
                 cancellationToken );
 
             await this.InvokeAdderAsync( context, ProcessTarget );

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Queries/Query.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Queries/Query.cs
@@ -11,6 +11,7 @@ using Metalama.Framework.Engine.CodeModel.Helpers;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.Diagnostics;
 using Metalama.Framework.Engine.Fabrics;
+using Metalama.Framework.Engine.SerializableIds;
 using Metalama.Framework.Engine.Services;
 using Metalama.Framework.Engine.Utilities.Threading;
 using Metalama.Framework.Engine.Utilities.UserCode;
@@ -101,16 +102,40 @@ namespace Metalama.Framework.Engine.Queries
         /// as it stands in the compilation in which the query is being built.
         /// </summary>
         /// <remarks>
+        /// <para>
         /// A query outlives by far the compilation it is built from: the query of a static fabric belongs to the
         /// amender, which belongs to the pipeline configuration, which is long-lived by design and reused across
         /// keystrokes. Capturing <paramref name="baseType"/> itself, which these overloads used to do, therefore made
         /// the configuration pin the version of the project the fabric ran in, for the whole editing session. The
         /// reference is made durable here, while the compilation is certainly available, and resolved again on each
         /// run, which is what the overloads taking a <see cref="Type"/> do already. See issue #1799.
+        /// </para>
+        /// <para>
+        /// The durable form is a <see cref="SerializableTypeId"/> and not the <c>SerializableDeclarationId</c> that
+        /// <c>IRef.ToDurable</c> would produce, because these overloads accept any <see cref="INamedType"/>, including
+        /// a constructed generic type such as <c>Base&lt;int&gt;</c>. A declaration identifier names the generic
+        /// definition only, so going through it would silently widen the query to every construction of the generic
+        /// type. <c>DurableRefToConstructedGenericTypeLosesTheTypeArguments</c> holds that distinction.
+        /// </para>
+        /// <para>
+        /// A type that no identifier can denote, which in practice means a type introduced by an aspect or a type
+        /// constructed over one, is kept as it is. Resolving a type identifier goes through the symbol table, and an
+        /// introduced type has no symbol, so converting it would replace a query that works with one that throws on
+        /// the first run. Keeping the type retains the compilation, but only for as long as the query lives, and a
+        /// query over an introduced type can only be built by an aspect, whose queries do not outlive the run: a
+        /// fabric, whose queries do, runs before any aspect and therefore never sees an introduced type. The
+        /// conversion is verified here rather than predicated on the kind of reference, because a type may reach an
+        /// introduced type through its type arguments, its containing type or its element type.
+        /// </para>
         /// </remarks>
         private static Func<CompilationModel, INamedType> CreateBaseTypeResolver( INamedType baseType )
         {
-            var baseTypeRef = baseType.ToRef().ToDurable();
+            var baseTypeRef = DurableRefFactory.FromTypeId<INamedType>( baseType.GetSerializableTypeId() );
+
+            if ( baseTypeRef.GetTargetOrNull( baseType.Compilation ) == null )
+            {
+                return _ => baseType;
+            }
 
             return c => baseTypeRef.GetTarget( c );
         }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/UserCode/UserCodeExecutionContext.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Utilities/UserCode/UserCodeExecutionContext.cs
@@ -174,6 +174,51 @@ public class UserCodeExecutionContext : IExecutionContextInternal
         => new( serviceProvider, description, compilation, diagnostics: diagnostics );
 
     /// <summary>
+    /// Creates a <see cref="UserCodeExecutionContext"/> that inherits nothing from the context that happens to be
+    /// current, as opposed to <see cref="CreateInstance(ProjectServiceProvider,UserCodeDescription,CompilationModel,IDiagnosticAdder)"/>,
+    /// which fills in its target declaration, meta API and syntax builder from that context.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Inheriting is the right behaviour for a context created while the user code it belongs to is running, which is
+    /// the usual case: an aspect that reports a diagnostic without naming a declaration means the one it is being
+    /// applied to. It is the wrong behaviour for a context created on demand, from an owner that is not itself running
+    /// user code, because what it would inherit is not the owner's own state but whatever the calling thread was doing.
+    /// </para>
+    /// <para>
+    /// The owner in question is a static fabric amender, which builds a context per compilation rather than storing
+    /// one, so that the pipeline configuration does not pin a compilation (issue #1799). Its queries are executed by
+    /// the pipeline, where nothing is current, but also by <c>IQuery.ToCollection</c>, which is public and is called
+    /// from user code: were the context to inherit there, a fabric query would silently acquire the target declaration
+    /// and the meta API of the aspect that happened to call it.
+    /// </para>
+    /// </remarks>
+    internal static UserCodeExecutionContext CreateWithoutInheritance(
+        ProjectServiceProvider serviceProvider,
+        UserCodeDescription description,
+        CompilationModel compilation,
+        IDiagnosticAdder? diagnostics = null )
+    {
+        var current = MetalamaExecutionContext.CurrentOrNull;
+
+        if ( current == null )
+        {
+            return new UserCodeExecutionContext( serviceProvider, description, compilation, diagnostics: diagnostics );
+        }
+
+        MetalamaExecutionContext.CurrentOrNull = null;
+
+        try
+        {
+            return new UserCodeExecutionContext( serviceProvider, description, compilation, diagnostics: diagnostics );
+        }
+        finally
+        {
+            MetalamaExecutionContext.CurrentOrNull = current;
+        }
+    }
+
+    /// <summary>
     /// Initializes a new instance of the <see cref="UserCodeExecutionContext"/> class that can be used
     /// to invoke user code using <see cref="UserCodeInvoker.Invoke"/> but not <see cref="UserCodeInvoker.TryInvoke{T}"/>.
     /// </summary>

--- a/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/MetalamaStringFormatter.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Sdk/Utilities/MetalamaStringFormatter.cs
@@ -18,6 +18,17 @@ public abstract class MetalamaStringFormatter : CultureInfo, ICustomFormatter
     [PublicAPI]
     public static MetalamaStringFormatter Instance => _instance ?? throw new InvalidOperationException( "The class has not been initialized." );
 
+    /// <summary>
+    /// Gets the instance, or <c>null</c> when the class has not been initialized, for the callers that format
+    /// eagerly and must not turn the absence of an implementation into an exception.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="Instance"/> throws, which is right for formatting a message that is about to be displayed: there is
+    /// no message without a formatter. It is wrong for a caller that formats ahead of time as an optimization, because
+    /// such a caller has a correct fallback, namely to do nothing and let the value be formatted later.
+    /// </remarks>
+    internal static MetalamaStringFormatter? InstanceOrNull => _instance;
+
     internal static void Initialize( MetalamaStringFormatter impl ) => _instance = impl;
 
     private protected MetalamaStringFormatter() : base( InvariantCulture.Name ) { }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromIntroducedType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromIntroducedType.cs
@@ -1,0 +1,38 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.SelectTypesDerivedFromIntroducedType;
+
+// SelectTypesDerivedFrom( INamedType ) converts the type it is given to a durable reference, so that a query built by
+// a fabric does not pin the compilation (issue #1799). A type introduced by an aspect has no symbol and therefore no
+// resolvable type identifier, so that conversion has to be skipped for it, which is safe because only an aspect can
+// hold an introduced type and the queries of an aspect do not outlive the run. Converting it unconditionally makes
+// this test fail with a SymbolNotFoundException while the query is being executed.
+
+[assembly: AspectOrder( AspectOrderDirection.RunTime, typeof(Aspect2), typeof(Aspect1) )]
+
+namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.SelectTypesDerivedFromIntroducedType
+{
+    internal class Aspect1 : TypeAspect
+    {
+        public override void BuildAspect( IAspectBuilder<INamedType> builder )
+        {
+            var introducedType = builder.IntroduceClass( "IntroducedType" ).Declaration;
+
+            builder.Outbound.SelectTypesDerivedFrom( introducedType ).AddAspect<Aspect2>();
+        }
+    }
+
+    internal class Aspect2 : TypeAspect
+    {
+        [Introduce]
+        public void MethodOnIntroducedType() { }
+    }
+
+    // <target>
+    [Aspect1]
+    internal class TargetCode { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromIntroducedType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromIntroducedType.t.cs
@@ -1,0 +1,10 @@
+[Aspect1]
+internal class TargetCode
+{
+  class IntroducedType
+  {
+    public void MethodOnIntroducedType()
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromNamedType.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromNamedType.cs
@@ -1,0 +1,69 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.Fabrics;
+using System;
+
+// The overload of SelectTypesDerivedFrom that takes an INamedType, rather than a System.Type, keeps that type as a
+// durable reference, because the query belongs to the pipeline configuration and therefore outlives the compilation
+// the fabric ran in (issue #1799). The durable form is a SerializableTypeId and not the SerializableDeclarationId that
+// IRef.ToDurable produces, because a declaration identifier names the generic definition only.
+//
+// The expected output therefore has MethodOnPlain overridden and neither MethodOnInt nor MethodOnString. Going through
+// a declaration identifier resolves BaseClass<int> to BaseClass<T> and overrides both of the latter, which is how this
+// test fails if the distinction is lost.
+
+namespace Metalama.Framework.Tests.PublicPipeline.Aspects.Fabrics.SelectTypesDerivedFromNamedType
+{
+    internal class Fabric : ProjectFabric
+    {
+        public override void AmendProject( IProjectAmender amender )
+        {
+            amender
+                .SelectTypesDerivedFrom( (INamedType)TypeFactory.GetType( typeof(PlainBaseClass) ) )
+                .SelectMany( t => t.Methods )
+                .AddAspect<Aspect>();
+
+            amender
+                .SelectTypesDerivedFrom( (INamedType)TypeFactory.GetType( typeof(BaseClass<int>) ) )
+                .SelectMany( t => t.Methods )
+                .AddAspect<Aspect>();
+        }
+    }
+
+    internal class Aspect : OverrideMethodAspect
+    {
+        public override dynamic? OverrideMethod()
+        {
+            Console.WriteLine( "overridden" );
+
+            return meta.Proceed();
+        }
+    }
+
+    internal class PlainBaseClass { }
+
+    internal class BaseClass<T> { }
+
+    // <target>
+    internal class TargetCode
+    {
+        internal class DerivedFromPlain : PlainBaseClass
+        {
+            public void MethodOnPlain() { }
+        }
+
+        internal class DerivedFromInt : BaseClass<int>
+        {
+            public void MethodOnInt() { }
+        }
+
+        internal class DerivedFromString : BaseClass<string>
+        {
+            public void MethodOnString() { }
+        }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromNamedType.t.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromNamedType.t.cs
@@ -1,0 +1,23 @@
+internal class TargetCode
+{
+  internal class DerivedFromPlain : PlainBaseClass
+  {
+    public void MethodOnPlain()
+    {
+      global::System.Console.WriteLine("overridden");
+      return;
+    }
+  }
+  internal class DerivedFromInt : BaseClass<int>
+  {
+    public void MethodOnInt()
+    {
+    }
+  }
+  internal class DerivedFromString : BaseClass<string>
+  {
+    public void MethodOnString()
+    {
+    }
+  }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/RefTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/CodeModel/RefTests.cs
@@ -4,7 +4,9 @@
 
 using Metalama.Framework.Code;
 using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.AdviceImpl.Introduction;
 using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.CodeModel.Introductions.Builders;
 using Metalama.Framework.Engine.CodeModel.References;
 using Metalama.Framework.Engine.SerializableIds;
 using Metalama.Framework.Engine.Services;
@@ -102,5 +104,152 @@ public sealed class RefTests : UnitTestClass
         var durableRef = new DeclarationIdRef<INamedType>( new SerializableDeclarationId( "T:ThereIsNoSuchType" ) );
 
         Assert.Null( durableRef.GetPrimarySyntaxTree( compilation.CompilationContext ) );
+    }
+
+    private const string _genericTypesCode = """
+                                             class Plain { }
+
+                                             class Generic<T>
+                                             {
+                                                 public class Nested { }
+                                             }
+
+                                             class Container
+                                             {
+                                                 public Generic<int> ConstructedField = null!;
+                                                 public Generic<string> OtherConstructedField = null!;
+                                             }
+                                             """;
+
+    private static INamedType GetTestType( CompilationModel compilation, string kind )
+        => kind switch
+        {
+            "Plain" => compilation.Types.OfName( "Plain" ).Single(),
+            "Generic" => compilation.Types.OfName( "Generic" ).Single(),
+            "Nested" => compilation.Types.OfName( "Generic" ).Single().Types.OfName( "Nested" ).Single(),
+            "Constructed" => (INamedType) compilation.Types.OfName( "Container" ).Single().Fields.OfName( "ConstructedField" ).Single().Type,
+            "External" => compilation.Factory.GetTypeByReflectionType( typeof(string) ).AssertCast<INamedType>(),
+            _ => throw new AssertionFailedException( $"Unknown kind '{kind}'." )
+        };
+
+    /// <summary>
+    /// Verifies that converting an <see cref="INamedType"/> to a durable reference with <c>ToDurable</c> and resolving
+    /// it again yields an equivalent type, for every shape of type except a constructed generic one, which
+    /// <see cref="DurableRefToConstructedGenericTypeLosesTheTypeArguments"/> covers.
+    /// </summary>
+    [Theory]
+    [InlineData( "Plain" )]
+    [InlineData( "Generic" )]
+    [InlineData( "Nested" )]
+    [InlineData( "External" )]
+    public void DurableRefToNamedTypeResolvesToAnEquivalentType( string kind )
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( _genericTypesCode );
+
+        var type = GetTestType( compilation, kind );
+
+        var resolved = type.ToRef().ToDurable().GetTarget( compilation );
+
+        Assert.Equal( type.ToDisplayString(), resolved.ToDisplayString() );
+    }
+
+    /// <summary>
+    /// Records that <c>ToDurable</c> does not preserve the type arguments of a constructed generic type, and that a
+    /// <see cref="SerializableTypeId"/> does.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// <c>ToDurable</c> is backed by a <c>SerializableDeclarationId</c>, which names a declaration and therefore names
+    /// the generic definition. Resolving it returns <c>Generic&lt;T&gt;</c> where <c>Generic&lt;int&gt;</c> was
+    /// converted, silently and with no diagnostic. This is a trap for any caller that converts a type coming from user
+    /// code, because the result is a usable type rather than an error, and the widening only shows in what the caller
+    /// subsequently matches.
+    /// </para>
+    /// <para>
+    /// <c>Query.CreateBaseTypeResolver</c> is such a caller: <c>SelectTypesDerivedFrom( INamedType )</c> accepts a
+    /// constructed generic type, and going through a declaration identifier would have made the query match the types
+    /// derived from every construction of the generic type. It uses a <see cref="SerializableTypeId"/> for that reason.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void DurableRefToConstructedGenericTypeLosesTheTypeArguments()
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( _genericTypesCode );
+
+        var type = GetTestType( compilation, "Constructed" );
+        Assert.Equal( "Generic<int>", type.ToDisplayString() );
+
+        var throughDeclarationId = type.ToRef().ToDurable().GetTarget( compilation );
+        Assert.Equal( "Generic<T>", throughDeclarationId.ToDisplayString() );
+
+        var throughTypeId = DurableRefFactory.FromTypeId<INamedType>( type.GetSerializableTypeId() ).GetTarget( compilation );
+        Assert.Equal( "Generic<int>", throughTypeId.ToDisplayString() );
+    }
+
+    /// <summary>
+    /// Verifies that the durable form used by <c>Query.CreateBaseTypeResolver</c> round-trips every shape of type that
+    /// <c>SelectTypesDerivedFrom( INamedType )</c> accepts.
+    /// </summary>
+    /// <remarks>
+    /// That method converts the type it is given to a durable reference so that the query, which may outlive the
+    /// compilation by an entire editing session, does not pin it (issue #1799). The type comes from user code, so the
+    /// conversion has to survive every shape the signature accepts, not only the plain named type that the first
+    /// version of the change was written against.
+    /// </remarks>
+    [Theory]
+    [InlineData( "Plain" )]
+    [InlineData( "Generic" )]
+    [InlineData( "Nested" )]
+    [InlineData( "Constructed" )]
+    [InlineData( "External" )]
+    public void DurableTypeIdRefResolvesToAnEquivalentType( string kind )
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( _genericTypesCode );
+
+        var type = GetTestType( compilation, kind );
+
+        var resolved = DurableRefFactory.FromTypeId<INamedType>( type.GetSerializableTypeId() ).GetTarget( compilation );
+
+        Assert.Equal( type.ToDisplayString(), resolved.ToDisplayString() );
+    }
+
+    /// <summary>
+    /// Records that a type introduced by an aspect has a <see cref="SerializableTypeId"/> but that the identifier does
+    /// not resolve, and that the failure is a resolution failure rather than a failure to produce the identifier.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A type identifier is syntactic, so one is produced for an introduced type as readily as for any other. Resolving
+    /// it, however, goes through the symbol table of the Roslyn compilation, in which an introduced type does not
+    /// exist. The two halves failing at different moments is what matters to a caller: the conversion succeeds, and the
+    /// exception surfaces later, wherever the reference happens to be resolved.
+    /// </para>
+    /// <para>
+    /// <c>Query.CreateBaseTypeResolver</c> is such a caller, and this is why it verifies the conversion instead of
+    /// assuming it. Without that check, passing an introduced type to <c>SelectTypesDerivedFrom</c> builds a query that
+    /// throws when it is executed, which
+    /// <c>Metalama.Framework.Tests.AspectTests/Tests/Fabrics/SelectTypesDerivedFromIntroducedType.cs</c> demonstrates
+    /// end to end.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void DurableTypeIdRefToIntroducedTypeDoesNotResolve()
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( "class Outer;" ).CreateMutableClone();
+
+        var typeBuilder = new NamedTypeBuilder( null!, compilation.GlobalNamespace, "Introduced", TypeKind.Class );
+        typeBuilder.Freeze();
+        compilation.AddTransformation( typeBuilder.CreateTransformation() );
+
+        var introducedType = compilation.Types.OfName( "Introduced" ).Single();
+
+        var durableRef = DurableRefFactory.FromTypeId<INamedType>( introducedType.GetSerializableTypeId() );
+
+        Assert.Null( durableRef.GetTargetOrNull( compilation ) );
+        Assert.Throws<SymbolNotFoundException>( () => durableRef.GetTarget( compilation ) );
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/DiagnosticArgumentMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/DiagnosticArgumentMemoryLeakTests.cs
@@ -1,0 +1,284 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that a diagnostic reported on a declaration does not retain the version of the project in which it was
+/// reported.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The design-time pipeline keeps the diagnostics it produced in the <c>SyntaxTreePipelineResult</c> of the file they
+/// were reported on, so that it can serve them again without re-analysing that file. The results of the files the
+/// pipeline did not re-analyse are carried forward from one version of the project to the next, therefore a
+/// diagnostic reported on a file the user never edits survives for the whole editing session.
+/// </para>
+/// <para>
+/// A <c>DiagnosticDefinition</c> is formatted lazily: the arguments given to <c>WithArguments</c> are stored in the
+/// <see cref="Microsoft.CodeAnalysis.DiagnosticDescriptor"/> of the resulting diagnostic and are formatted only when
+/// the message is requested. An argument that is a declaration of the code model is therefore held by the stored
+/// diagnostic, and a declaration reaches its compilation.
+/// </para>
+/// <para>
+/// Reporting a diagnostic about a declaration, passing that declaration as an argument so that the message can name
+/// it, is the single most common thing that a validator does, and it is what the reference validation of
+/// Metalama.Extensions.Validation does on every reference it rejects. The first two tests below are a matched pair
+/// over the same aspect, differing only in whether the argument is the declaration or its name.
+/// </para>
+/// <para>
+/// The measured cost is one retained version per project, not growth over the length of the session; see
+/// <see cref="DiagnosticWithDeclarationArgument_RetentionDoesNotGrowWithTheNumberOfEditedFiles"/>, which passes. The
+/// retained version is nevertheless the oldest of the session and is held in addition to the current one, so on a
+/// large solution the cost is one whole stale compilation per project that reports such a diagnostic. The defect is
+/// tracked by issue #1799.
+/// </para>
+/// </remarks>
+public sealed class DiagnosticArgumentMemoryLeakTests : DesignTimeTestBase
+{
+    private const string _aspectFileName = "Aspect.cs";
+
+    /// <summary>
+    /// The name of the file the diagnostics are reported on. No test edits it, so its result, and the diagnostics it
+    /// holds, are produced during the first run and then survive the whole session.
+    /// </summary>
+    private const string _anchorFileName = "Anchor.cs";
+
+    /// <summary>
+    /// The name of the run-time file that the tests edit.
+    /// </summary>
+    private const string _targetFileName = "Target.cs";
+
+    public DiagnosticArgumentMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// Returns the aspect that reports a warning on every method of its target type.
+    /// </summary>
+    /// <param name="argumentExpression">
+    /// The expression that produces the argument of the diagnostic, which is the only difference between the two
+    /// cases.
+    /// </param>
+    /// <param name="argumentType">The type parameter of the diagnostic definition, which follows from the argument.</param>
+    private static string GetAspectCode( string argumentExpression, string argumentType )
+        => $$"""
+             using Metalama.Framework.Aspects;
+             using Metalama.Framework.Code;
+             using Metalama.Framework.Diagnostics;
+             using System.Linq;
+
+             public class ValidateAttribute : TypeAspect
+             {
+                 private static readonly DiagnosticDefinition<{{argumentType}}> _warning =
+                     new( "MY001", Severity.Warning, "Warning on {0}." );
+
+                 public override void BuildAspect( IAspectBuilder<INamedType> builder )
+                     => builder.Outbound.SelectMany( t => t.Methods ).ReportDiagnostic( m => _warning.WithArguments( {{argumentExpression}} ) );
+             }
+             """;
+
+    private const string _anchorCode = """
+                                       [Validate]
+                                       public class Anchor
+                                       {
+                                           public int Value;
+
+                                           public int GetValue() => this.Value;
+
+                                           public void SetValue( int value ) => this.Value = value;
+                                       }
+                                       """;
+
+    private static string GetTargetCode( int version )
+        => $$"""
+             public class Target
+             {
+                 public int Method() => {{version}};
+             }
+             """;
+
+    /// <summary>
+    /// Runs an editing session over a project whose aspect reports diagnostics with the given argument, and returns a
+    /// weak reference to the compilation of the first version, which is the version the diagnostics are reported in.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private WeakReference RunEditingSession(
+        TestContext testContext,
+        TestDesignTimeAspectPipelineFactory factory,
+        string sessionName,
+        string argumentExpression,
+        string argumentType )
+    {
+        var code = new Dictionary<string, string>
+        {
+            [_aspectFileName] = GetAspectCode( argumentExpression, argumentType ),
+            [_anchorFileName] = _anchorCode,
+            [_targetFileName] = GetTargetCode( 0 )
+        };
+
+        var simulator = new DesignTimeEditingSimulator( testContext, factory, sessionName, code );
+
+        var initialCompilation = simulator.GetWeakReferenceToCurrentCompilation();
+        simulator.Execute();
+
+        const int editCount = 10;
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            simulator.ApplyEdit( _targetFileName, GetTargetCode( version ) );
+        }
+
+        var pipeline = simulator.GetPipeline();
+        var diagnosticCount = 0;
+
+        foreach ( var result in pipeline.AspectPipelineResult.SyntaxTreeResults )
+        {
+            diagnosticCount += result.Value.Diagnostics.Length;
+        }
+
+        this.TestOutput.WriteLine( $"The pipeline holds {diagnosticCount} diagnostic(s) after {editCount} edits." );
+
+        // Without a diagnostic that survived the session there is nothing whose argument could retain anything, and
+        // both cases below would hold for a reason unrelated to the property under test.
+        Assert.True(
+            diagnosticCount > 0,
+            "The aspect reported no diagnostic that survived the session, therefore the test did not exercise the "
+            + "retention it was supposed to exercise." );
+
+        return initialCompilation;
+    }
+
+    /// <summary>
+    /// Verifies that a diagnostic whose argument is the name of the declaration does not retain the version of the
+    /// project it was reported in.
+    /// </summary>
+    /// <remarks>
+    /// This is the positive control of the pair. It establishes that the session releases the first version when the
+    /// diagnostic carries no code-model object, so that a failure of
+    /// <see cref="DiagnosticWithDeclarationArgument_DoesNotRetainTheCompilation"/> is attributable to the argument and
+    /// to nothing else.
+    /// </remarks>
+    [Fact]
+    public void DiagnosticWithStringArgument_DoesNotRetainTheCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var initialCompilation = this.RunEditingSession( testContext, factory, "StringArgument", "m.Name", "string" );
+
+        MemoryLeakAssert.Collected(
+            initialCompilation,
+            "The compilation in which a diagnostic with a string argument was reported",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that a diagnostic whose argument is the declaration itself does not retain the version of the project
+    /// it was reported in.
+    /// </summary>
+    [Fact]
+    public void DiagnosticWithDeclarationArgument_DoesNotRetainTheCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var initialCompilation = this.RunEditingSession( testContext, factory, "DeclarationArgument", "m", "IDeclaration" );
+
+        MemoryLeakAssert.Collected(
+            initialCompilation,
+            "The compilation in which a diagnostic with a declaration argument was reported",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that the number of versions retained by the stored diagnostics does not grow with the number of
+    /// distinct files the user edits.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This test states how much the defect costs, which the two tests above do not, and it passes while
+    /// <see cref="DiagnosticWithDeclarationArgument_DoesNotRetainTheCompilation"/> fails. The combination is the
+    /// informative result: the cost of the defect is a constant, one retained version per project, and not growth
+    /// over the length of the session. Editing a different file each time was the arrangement most likely to
+    /// accumulate versions, because the results are kept per file and each file's entry could have held the version in
+    /// which that file was last analysed, and it does not.
+    /// </para>
+    /// <para>
+    /// A failure here would be a considerably worse defect than the one the pair above reports, therefore this test is
+    /// worth keeping even though it passes today.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData( 4 )]
+    [InlineData( 10 )]
+    public void DiagnosticWithDeclarationArgument_RetentionDoesNotGrowWithTheNumberOfEditedFiles( int fileCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var compilations = RunMultiFileEditingSession( testContext, factory, fileCount );
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            _allowedSurvivingVersions,
+            $"compilations of a session in which {fileCount} different validated files were edited in turn",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// The number of versions of the project that the design-time host is allowed to retain, for the same reasons as
+    /// in <see cref="DesignTimePipelineMemoryLeakTests"/>.
+    /// </summary>
+    private const int _allowedSurvivingVersions = 2;
+
+    /// <summary>
+    /// Returns the content of one of the several validated files that
+    /// <see cref="DiagnosticWithDeclarationArgument_RetentionDoesNotGrowWithTheNumberOfEditedFiles"/> edits in turn.
+    /// </summary>
+    private static string GetValidatedCode( int index, int version )
+        => $$"""
+             [Validate]
+             public class Validated{{index}}
+             {
+                 public int Method() => {{version}};
+             }
+             """;
+
+    /// <summary>
+    /// Runs a session that edits each of several validated files once, and returns weak references to the version
+    /// produced by each edit.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static WeakReference[] RunMultiFileEditingSession( TestContext testContext, TestDesignTimeAspectPipelineFactory factory, int fileCount )
+    {
+        var code = new Dictionary<string, string> { [_aspectFileName] = GetAspectCode( "m", "IDeclaration" ) };
+
+        for ( var i = 0; i < fileCount; i++ )
+        {
+            code[$"Validated{i}.cs"] = GetValidatedCode( i, 0 );
+        }
+
+        var simulator = new DesignTimeEditingSimulator( testContext, factory, $"MultiFile{fileCount}", code );
+        simulator.Execute();
+
+        var compilations = new WeakReference[fileCount];
+
+        // Each file is edited once, in turn, so that the result of each is produced in a different version of the
+        // project. This is what an ordinary editing session looks like over a working day.
+        for ( var i = 0; i < fileCount; i++ )
+        {
+            compilations[i] = simulator.EditAndExecute( $"Validated{i}.cs", GetValidatedCode( i, 1 ) );
+        }
+
+        return compilations;
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/ExtensionContributorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/ExtensionContributorMemoryLeakTests.cs
@@ -240,13 +240,11 @@ public sealed class ExtensionContributorMemoryLeakTests : DesignTimeTestBase
 
         var initialCompilation = this.RunEditingSession( testContext, factory, "NonDurableContributor", 10 );
 
-        GarbageCollectionHelper.Collect();
-
-        Assert.True(
-            initialCompilation.IsAlive,
-            "The compilation in which a non-durable contributor was produced was released. Either the pipeline no "
-            + "longer stores what an extension returns, in which case this suite needs revisiting, or the framework "
-            + "now enforces the durability requirement, in which case this test should assert the enforcement." );
+        MemoryLeakAssert.RetainedThrough(
+            initialCompilation,
+            nameof(TestContributor),
+            "The compilation in which a non-durable contributor was produced",
+            ("pipelineFactory", factory) );
     }
 
     /// <summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/ExtensionContributorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/ExtensionContributorMemoryLeakTests.cs
@@ -1,0 +1,338 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Code;
+using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.CodeModel.Helpers;
+using Metalama.Framework.Engine.CodeModel.References;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Extensibility;
+using Metalama.Framework.Engine.Pipeline;
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests the durability requirement that the design-time pipeline places on the contributors an extension produces,
+/// and that no part of the extension contract states.
+/// </summary>
+/// <remarks>
+/// <para>
+/// An extension returns its contributors from <see cref="PipelineExtension.ExecuteDesignTimePipelineContributorsAsync"/>,
+/// and the pipeline files each of them under the path of the syntax tree it reports, in the
+/// <c>SyntaxTreePipelineResult</c> of that file. The results of the files the pipeline did not re-analyse are carried
+/// forward unchanged from one version of the project to the next, and <c>SplitResultsByTree</c> goes further: when a
+/// later run produces a contributor for a file that is not dirty, it discards the new instance precisely so that the
+/// one produced earlier survives. A contributor therefore keeps the version of the project in which its file was last
+/// analysed, which for a file the user never edits is the first version of the session.
+/// </para>
+/// <para>
+/// This is sound only if the contributor holds nothing bound to the compilation it was produced in. The requirement
+/// is real, it is what <c>SyntaxTreePipelineResult</c> claims about itself ("compilation-independent and cacheable"),
+/// and nothing in <see cref="IDesignTimePipelineResultExtension"/> or
+/// <see cref="ITransitivePipelineContributor.ToDesignTime"/> states it, so an extension author has no way of learning
+/// it other than by measuring the memory of the analysis process.
+/// </para>
+/// <para>
+/// The two tests below are a matched pair over the same extension, differing only in whether the reference the
+/// contributor carries is made durable. That is what makes the result interpretable: a suite in which only the
+/// non-durable case were present could not distinguish a genuine retention from an assertion that never holds.
+/// The reference validation of Metalama.Extensions.Validation is the production extension that takes this path, and
+/// the contributor below reproduces the shape of what it stores without depending on it. The missing requirement is
+/// tracked by issue #1799.
+/// </para>
+/// </remarks>
+public sealed class ExtensionContributorMemoryLeakTests : DesignTimeTestBase
+{
+    /// <summary>
+    /// The name of the file that declares the type the contributor refers to. No test edits it, so its result, and
+    /// the contributor filed under it, are produced during the first run and then survive the whole session.
+    /// </summary>
+    private const string _anchorFileName = "Anchor.cs";
+
+    /// <summary>
+    /// The name of the run-time file that the tests edit.
+    /// </summary>
+    private const string _targetFileName = "Target.cs";
+
+    /// <summary>
+    /// The name of the file that declares the aspect that registers an extension contributor.
+    /// </summary>
+    private const string _aspectFileName = "Aspect.cs";
+
+    /// <summary>
+    /// An aspect that registers a diagnostic source, which is a contributor of extension kind.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The design-time stage invokes an extension only when the project contributed at least one contributor of
+    /// extension kind, which is how the production extensions are reached: a fabric or an aspect registers a source,
+    /// and the extension turns the sources into the contributors that the pipeline then stores.
+    /// </para>
+    /// <para>
+    /// The source is registered by an aspect rather than by a project fabric on purpose. The amender of a project
+    /// fabric lives in the pipeline configuration and retains the version of the project it was built from, which is
+    /// the separate defect that <see cref="FabricMemoryLeakTests"/> covers. Registering the source from an aspect
+    /// keeps the query owned by the per-run aspect builder, so that the outcome of the pair below depends on the
+    /// durability of the contributor's own reference and on nothing else.
+    /// </para>
+    /// <para>
+    /// The argument of the diagnostic is the name of the method rather than the method itself, for the same reason:
+    /// a diagnostic whose argument is a declaration retains the compilation through the argument, which is the
+    /// separate defect that <see cref="DiagnosticArgumentMemoryLeakTests"/> covers.
+    /// </para>
+    /// </remarks>
+    private const string _aspectCode = """
+                                       using Metalama.Framework.Aspects;
+                                       using Metalama.Framework.Code;
+                                       using Metalama.Framework.Diagnostics;
+                                       using System.Linq;
+
+                                       public class ValidateAttribute : TypeAspect
+                                       {
+                                           private static readonly DiagnosticDefinition<string> _warning =
+                                               new( "MY001", Severity.Warning, "Warning on {0}." );
+
+                                           public override void BuildAspect( IAspectBuilder<INamedType> builder )
+                                               => builder.Outbound.SelectMany( t => t.Methods ).ReportDiagnostic( m => _warning.WithArguments( m.Name ) );
+                                       }
+                                       """;
+
+    private const string _anchorCode = """
+                                       [Validate]
+                                       public class Anchor
+                                       {
+                                           public int Value;
+
+                                           public int GetValue() => this.Value;
+                                       }
+                                       """;
+
+    public ExtensionContributorMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    private static string GetTargetCode( int version )
+        => $$"""
+             public class Target
+             {
+                 public int Method() => {{version}};
+             }
+             """;
+
+    private static Dictionary<string, string> CreateInitialCode()
+        => new()
+        {
+            [_aspectFileName] = _aspectCode,
+            [_anchorFileName] = _anchorCode,
+            [_targetFileName] = GetTargetCode( 0 )
+        };
+
+    /// <summary>
+    /// Runs an editing session on the given pipeline factory and returns a weak reference to the compilation of the
+    /// first version, which is the version the contributor is produced in.
+    /// </summary>
+    /// <remarks>
+    /// The factory is created by the caller and outlives this method, because it is the root the assertion is made
+    /// against: a session whose factory had already been disposed would release everything for a reason unrelated to
+    /// the property under test. Conversely, the weak reference is returned rather than asserted here, so that no local
+    /// of this frame holds the compilation when the caller makes the assertion.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private WeakReference RunEditingSession(
+        TestContext testContext,
+        TestDesignTimeAspectPipelineFactory factory,
+        string sessionName,
+        int editCount )
+    {
+        var simulator = new DesignTimeEditingSimulator( testContext, factory, sessionName, CreateInitialCode() );
+
+        var initialCompilation = simulator.GetWeakReferenceToCurrentCompilation();
+        simulator.Execute();
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            simulator.ApplyEdit( _targetFileName, GetTargetCode( version ) );
+        }
+
+        var contributorCount = simulator.GetPipeline().AspectPipelineResult.Extensions.Extensions.Length;
+        this.TestOutput.WriteLine( $"The pipeline holds {contributorCount} contributor(s) after {editCount} edits." );
+
+        Assert.True(
+            contributorCount > 0,
+            "The extension produced no contributor that survived the session, therefore the test did not exercise the "
+            + "retention it was supposed to exercise." );
+
+        return initialCompilation;
+    }
+
+    /// <summary>
+    /// Creates a test context in which the given extension type is the only registered extension.
+    /// </summary>
+    private TestContext CreateTestContextWithExtension( Type extensionType )
+        => this.CreateTestContext(
+            this.CreateDefaultTestContextOptions() with { ExtensionTypes = ImmutableArray.Create( extensionType ) } );
+
+    /// <summary>
+    /// Verifies that a contributor holding a durable reference does not retain the version of the project in which it
+    /// was produced.
+    /// </summary>
+    /// <remarks>
+    /// This is the guarantee of the pair, and
+    /// <see cref="NonDurableContributor_RetainsTheCompilationItWasProducedIn"/> is the control that establishes the
+    /// assertion can fail. The two sessions differ by one call to <c>ToDurable</c> and by nothing else, so passing
+    /// here is attributable to the reference the contributor carries and to nothing else.
+    /// </remarks>
+    [Fact]
+    public void DurableContributor_DoesNotRetainTheCompilationItWasProducedIn()
+    {
+        using var testContext = this.CreateTestContextWithExtension( typeof(DurableContributorExtension) );
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var initialCompilation = this.RunEditingSession( testContext, factory, "DurableContributor", 10 );
+
+        MemoryLeakAssert.Collected(
+            initialCompilation,
+            "The compilation in which a durable contributor was produced",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that a contributor holding a reference obtained from the code model, without making it durable, does
+    /// retain the version of the project in which it was produced.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This test asserts that the retention happens, which is the opposite of what the rest of this suite asserts, and
+    /// it does so for two reasons.
+    /// </para>
+    /// <para>
+    /// It is the control that gives <see cref="DurableContributor_DoesNotRetainTheCompilationItWasProducedIn"/> its
+    /// meaning. The two sessions differ by one call to <c>ToDurable</c> and by nothing else, so a suite in which the
+    /// durable case passed while nothing established that the assertion can fail would be a suite whose assertion
+    /// never fires.
+    /// </para>
+    /// <para>
+    /// It also records that the framework does not, and cannot, enforce the requirement stated on
+    /// <see cref="IDesignTimePipelineResultExtension"/>. What a contributor carries is opaque to the pipeline, which
+    /// stores the object as the extension produced it. The requirement is therefore documented on the contract and
+    /// tested here from the outside. Should enforcement ever be added, this test fails, and that failure is the signal
+    /// to replace it with an assertion that the enforcement works.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void NonDurableContributor_RetainsTheCompilationItWasProducedIn()
+    {
+        using var testContext = this.CreateTestContextWithExtension( typeof(NonDurableContributorExtension) );
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var initialCompilation = this.RunEditingSession( testContext, factory, "NonDurableContributor", 10 );
+
+        GarbageCollectionHelper.Collect();
+
+        Assert.True(
+            initialCompilation.IsAlive,
+            "The compilation in which a non-durable contributor was produced was released. Either the pipeline no "
+            + "longer stores what an extension returns, in which case this suite needs revisiting, or the framework "
+            + "now enforces the durability requirement, in which case this test should assert the enforcement." );
+    }
+
+    /// <summary>
+    /// A test extension that produces one contributor per run, referring to a declaration of the anchor file.
+    /// </summary>
+    /// <remarks>
+    /// The extension has no state of its own, exactly as the production extensions have none. Everything that could
+    /// retain a compilation is in the contributor it returns, which is what the pipeline stores.
+    /// </remarks>
+    private abstract class ContributorExtension : PipelineExtension
+    {
+        /// <summary>
+        /// Builds the reference that the contributor carries. The two implementations differ only in this method.
+        /// </summary>
+        protected abstract object CreatePayload( INamedType anchor );
+
+        public override Task<ExtensionPipelineContributorsResult> ExecuteDesignTimePipelineContributorsAsync(
+            AspectPipelineConfiguration pipelineConfiguration,
+            IEnumerable<IPipelineContributor> contributors,
+            CompilationModel initialCompilation,
+            CompilationModel finalCompilation,
+            CancellationToken cancellationToken )
+        {
+            var anchor = initialCompilation.Types.SingleOrDefault( t => t.Name == "Anchor" );
+
+            if ( anchor == null )
+            {
+                // The anchor type is absent from a partial compilation that does not include its file, which is the
+                // normal case for every run after the first. The contributor produced by the first run is the one
+                // whose retention is under test, so there is nothing to add here.
+                return Task.FromResult( ExtensionPipelineContributorsResult.Empty );
+            }
+
+            var contributor = new TestContributor( anchor.GetPrimarySyntaxTree(), this.CreatePayload( anchor ) );
+
+            return Task.FromResult(
+                new ExtensionPipelineContributorsResult(
+                    ImmutableArray.Create<ITransitivePipelineContributor>( contributor ),
+                    ImmutableUserDiagnosticList.Empty ) );
+        }
+    }
+
+    /// <summary>
+    /// Produces a contributor whose reference is durable, which is the correct behaviour.
+    /// </summary>
+    private sealed class DurableContributorExtension : ContributorExtension
+    {
+        protected override object CreatePayload( INamedType anchor ) => anchor.ToRef().ToDurable();
+    }
+
+    /// <summary>
+    /// Produces a contributor whose reference is the one the code model returns, which is backed by a symbol.
+    /// </summary>
+    private sealed class NonDurableContributorExtension : ContributorExtension
+    {
+        protected override object CreatePayload( INamedType anchor ) => anchor.ToRef();
+    }
+
+    /// <summary>
+    /// A minimal contributor, carrying an opaque payload whose durability is what the tests vary.
+    /// </summary>
+    /// <remarks>
+    /// The payload is typed as <see cref="object"/> so that the contributor itself is identical in both cases and the
+    /// only difference between the two sessions is the reference the extension chose to store, which is the decision
+    /// an extension author actually makes.
+    /// </remarks>
+    private sealed class TestContributor : ITransitivePipelineContributor, IDesignTimePipelineResultExtension
+    {
+        private static readonly ContributorKind<TestContributor> _kind = new( nameof(TestContributor) );
+
+#pragma warning disable IDE0052 // The field is never read: holding the payload is its entire purpose.
+        private readonly object _payload;
+#pragma warning restore IDE0052
+
+        public TestContributor( SyntaxTree? syntaxTree, object payload )
+        {
+            this.SyntaxTree = syntaxTree;
+            this._payload = payload;
+        }
+
+        public SyntaxTree? SyntaxTree { get; }
+
+        public ContributorKind ContributorKind => _kind;
+
+        public IDesignTimePipelineResultExtension? ToDesignTime() => this;
+
+        public ITransitiveAspectsManifestExtension ToTransitiveAspectManifestExtension() => throw new NotSupportedException();
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/FabricMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/FabricMemoryLeakTests.cs
@@ -1,0 +1,274 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using Metalama.Testing.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that a project that declares a fabric does not retain the version of the project from which the pipeline
+/// configuration was built.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A fabric contributes to the pipeline through an amender, and the amender is reachable from the
+/// <c>AspectPipelineConfiguration</c>, which the design-time pipeline builds once and then reuses for every
+/// subsequent version of the project. The configuration is discarded only when the compile-time code changes, so in a
+/// session in which the user edits run-time code alone it is the configuration built from the very first version that
+/// remains in use, however long the session lasts.
+/// </para>
+/// <para>
+/// That reuse is correct in itself, and it is what makes the design-time pipeline fast. It is sound only as long as
+/// the objects the configuration holds carry no reference bound to the compilation they were built from, because the
+/// version so retained is the oldest of the session and is held in addition to the current one. This suite states
+/// that property for the objects a fabric contributes.
+/// </para>
+/// <para>
+/// The defect this suite reports is tracked by issue #1799.
+/// </para>
+/// <para>
+/// The suite is the fabric counterpart of <see cref="DesignTimePipelineMemoryLeakTests"/>, which states the same
+/// property for a project whose aspects are applied by attribute alone. A fabric is also the mechanism by which the
+/// extension packages register their own contributors, so this is the path taken by a project that uses reference
+/// validation.
+/// </para>
+/// </remarks>
+public sealed class FabricMemoryLeakTests : DesignTimeTestBase
+{
+    /// <summary>
+    /// The number of versions of the project that the design-time host is allowed to retain, for the same reasons as
+    /// in <see cref="DesignTimePipelineMemoryLeakTests"/>: the version whose results it currently serves, plus one for
+    /// a version that a difference not yet superseded still references.
+    /// </summary>
+    private const int _allowedSurvivingVersions = 2;
+
+    private const string _aspectFileName = "Aspect.cs";
+    private const string _fabricFileName = "Fabric.cs";
+    private const string _targetFileName = "Target.cs";
+
+    public FabricMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    private const string _aspectCode = """
+                                       using Metalama.Framework.Aspects;
+
+                                       public class LogAttribute : OverrideMethodAspect
+                                       {
+                                           public override dynamic? OverrideMethod()
+                                           {
+                                               return meta.Proceed();
+                                           }
+                                       }
+                                       """;
+
+    /// <summary>
+    /// A project fabric that adds an aspect to every method of the project.
+    /// </summary>
+    /// <remarks>
+    /// The call to <c>AddAspect</c> is what makes these tests meaningful rather than vacuous. A fabric that registers
+    /// no contributor leaves its amender unreachable from the pipeline configuration, so nothing of it survives the
+    /// run and the assertions would hold for a reason unrelated to the property under test.
+    /// </remarks>
+    private const string _fabricCode = """
+                                       using Metalama.Framework.Aspects;
+                                       using Metalama.Framework.Fabrics;
+                                       using System.Linq;
+
+                                       public class TheFabric : ProjectFabric
+                                       {
+                                           public override void AmendProject( IProjectAmender amender )
+                                               => amender.SelectMany( c => c.Types.SelectMany( t => t.Methods ) ).AddAspect<LogAttribute>();
+                                       }
+                                       """;
+
+    /// <summary>
+    /// Returns the content of the run-time file that the tests edit, for a given version.
+    /// </summary>
+    /// <remarks>
+    /// The methods carry no aspect attribute, because the fabric is what applies the aspect here. Applying it twice
+    /// would exercise the deduplication of aspect instances rather than the retention under test.
+    /// </remarks>
+    private static string GetTargetCode( int version )
+        => $$"""
+             public class Target
+             {
+                 public int Method()
+                 {
+                     var x = {{version}};
+                     return x;
+                 }
+
+                 public string OtherMethod() => "{{version}}";
+             }
+             """;
+
+    private static string GetFillerCode( int index )
+        => $$"""
+             public class Filler{{index}}
+             {
+                 public int Compute( int a, int b ) => a + b + {{index}};
+             }
+             """;
+
+    /// <summary>
+    /// Builds the initial content of the simulated project.
+    /// </summary>
+    /// <param name="withFabric">
+    /// Whether the project declares a fabric. The two projects are otherwise identical, which is what makes the
+    /// control case in <see cref="WithoutFabric_InitialCompilationIsCollected"/> discriminating.
+    /// </param>
+    private static Dictionary<string, string> CreateInitialCode( bool withFabric )
+    {
+        var code = new Dictionary<string, string> { [_aspectFileName] = _aspectCode, [_targetFileName] = GetTargetCode( 0 ) };
+
+        if ( withFabric )
+        {
+            code[_fabricFileName] = _fabricCode;
+        }
+
+        for ( var i = 0; i < 3; i++ )
+        {
+            code[$"Filler{i}.cs"] = GetFillerCode( i );
+        }
+
+        return code;
+    }
+
+    /// <summary>
+    /// Runs an editing session over the given project and returns a weak reference to the compilation of its first
+    /// version, which is the version from which the pipeline configuration is built.
+    /// </summary>
+    /// <remarks>
+    /// Only the run-time file is edited. An edit to the fabric or to the aspect is an edit to compile-time code, which
+    /// makes the pipeline discard its configuration and build a new one, and would therefore hide the very retention
+    /// this suite is about. It would also bring in the accumulation of the compiled compile-time assemblies, which is
+    /// an accepted cost and to which no assertion here should be sensitive.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private WeakReference RunEditingSession(
+        TestContext testContext,
+        TestDesignTimeAspectPipelineFactory factory,
+        bool withFabric,
+        int editCount )
+    {
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            $"FabricMemoryLeak_{withFabric}",
+            CreateInitialCode( withFabric ) );
+
+        var initialCompilation = simulator.GetWeakReferenceToCurrentCompilation();
+
+        // This first run is the one that builds the pipeline configuration, from the version the weak reference above
+        // points to.
+        simulator.Execute();
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            simulator.ApplyEdit( _targetFileName, GetTargetCode( version ) );
+        }
+
+        var executionCount = simulator.GetPipeline().PipelineExecutionCount;
+        this.TestOutput.WriteLine( $"The pipeline was executed {executionCount} times for {editCount} edits." );
+
+        Assert.True(
+            executionCount >= editCount,
+            $"The pipeline was executed only {executionCount} times for {editCount} edits, therefore the test did not "
+            + "exercise the retention it was supposed to exercise." );
+
+        return initialCompilation;
+    }
+
+    /// <summary>
+    /// Verifies that a project that declares a fabric releases the compilation of its first version once the user has
+    /// made further edits to run-time code.
+    /// </summary>
+    /// <remarks>
+    /// The compilation of the first version is the one from which the pipeline configuration was built. Because the
+    /// configuration survives every run-time edit, anything it holds that is bound to that compilation keeps the
+    /// oldest version of the project alive for the whole editing session, in addition to the current one.
+    /// </remarks>
+    [Fact]
+    public void WithFabric_InitialCompilationIsCollected()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var initialCompilation = this.RunEditingSession( testContext, factory, withFabric: true, editCount: 10 );
+
+        MemoryLeakAssert.Collected(
+            initialCompilation,
+            "The compilation from which the pipeline configuration of a project with a fabric was built",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// The control case for <see cref="WithFabric_InitialCompilationIsCollected"/>: the same project without the
+    /// fabric.
+    /// </summary>
+    /// <remarks>
+    /// Without this case a failure of the test above would not be attributable to the fabric, because the same
+    /// assertion would fail for any project that retained its first version for an unrelated reason. The two projects
+    /// differ by the fabric file alone.
+    /// </remarks>
+    [Fact]
+    public void WithoutFabric_InitialCompilationIsCollected()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var initialCompilation = this.RunEditingSession( testContext, factory, withFabric: false, editCount: 10 );
+
+        MemoryLeakAssert.Collected(
+            initialCompilation,
+            "The compilation from which the pipeline configuration of a project without a fabric was built",
+            ("pipelineFactory", factory) );
+    }
+
+    /// <summary>
+    /// Verifies that the number of versions a project with a fabric retains does not grow with the number of edits.
+    /// </summary>
+    /// <remarks>
+    /// This test and <see cref="WithFabric_InitialCompilationIsCollected"/> answer two different questions, and the
+    /// combination of their outcomes is what characterises the defect. The configuration is built once, so a
+    /// reference held by it reaches exactly one version however long the session is. A failure here instead would mean
+    /// that the configuration, or something reachable from it, accumulates versions, which would be a different and
+    /// worse defect.
+    /// </remarks>
+    [Theory]
+    [InlineData( 5 )]
+    [InlineData( 25 )]
+    public void WithFabric_SurvivingCompilationCountDoesNotGrow( int editCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.WithFabric_SurvivingCompilationCountDoesNotGrow),
+            CreateInitialCode( withFabric: true ) );
+
+        simulator.Execute();
+
+        var compilations = new WeakReference[editCount];
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            compilations[version - 1] = simulator.EditAndExecute( _targetFileName, GetTargetCode( version ) );
+        }
+
+        MemoryLeakAssert.AtMostAlive(
+            compilations,
+            _allowedSurvivingVersions,
+            $"compilations of a session of {editCount} edits in a project that declares a fabric",
+            ("pipelineFactory", factory) );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/MemoryLeakAssert.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/MemoryLeakAssert.cs
@@ -95,6 +95,60 @@ internal static class MemoryLeakAssert
     }
 
     /// <summary>
+    /// Asserts that the target of a weak reference is still alive and that what retains it is the expected route.
+    /// </summary>
+    /// <param name="weakReference">A weak reference to the object that is known to be retained.</param>
+    /// <param name="expectedInPath">
+    /// A fragment of the retention chain, usually the name of the type or of the field that carries the reference.
+    /// </param>
+    /// <param name="description">A description of the object, used in the failure messages.</param>
+    /// <param name="roots">The objects that play the role of garbage-collection roots in the analysis.</param>
+    /// <remarks>
+    /// <para>
+    /// This is the inverse of <see cref="Collected"/> and is used to record a retention that is known and tracked but
+    /// not yet fixed. Asserting only that the object is alive would be a weak record, because it would hold whether the
+    /// documented route retains the object or something else does, and it would go on holding after the documented
+    /// route was removed. Naming the route makes the assertion say what it means, and makes it fail in both of the
+    /// directions that matter: when the retention is fixed, and when the retention survives for a different reason
+    /// than the one written down.
+    /// </para>
+    /// <para>
+    /// A failure of the first kind is the signal to replace the call with <see cref="Collected"/>.
+    /// </para>
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    public static void RetainedThrough(
+        WeakReference weakReference,
+        string expectedInPath,
+        string description,
+        params (string Name, object Root)[] roots )
+    {
+        GarbageCollectionHelper.Collect();
+
+        var target = weakReference.Target;
+
+        Assert.True(
+            target != null,
+            $"{description} was released, so the retention through {expectedInPath} is gone. If the issue that tracks "
+            + $"it has been fixed, replace this control with {nameof(Collected)}." );
+
+        var finder = new RetentionPathFinder();
+
+        if ( !finder.TryFindPath( target!, out var path, roots ) )
+        {
+            Assert.Fail(
+                $"{description} is retained, as expected, but no retention path was found from the given roots, "
+                + $"therefore this control cannot confirm that {expectedInPath} is what retains it. The search visited "
+                + $"{finder.VisitedObjectCount} objects and "
+                + (finder.IsExhausted ? "was exhausted before completing." : "completed.") );
+        }
+
+        Assert.True(
+            path!.Contains( expectedInPath, StringComparison.Ordinal ),
+            $"{description} is retained, but not through {expectedInPath}. Retention path:{Environment.NewLine}{path}" );
+    }
+
+    /// <summary>
     /// Builds a failure message that includes the retention chain of <paramref name="target"/>, when one can be found.
     /// </summary>
     private static string BuildFailureMessage( object target, string description, (string Name, object Root)[] roots )

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TransitiveContributorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TransitiveContributorMemoryLeakTests.cs
@@ -105,6 +105,64 @@ public sealed class TransitiveContributorMemoryLeakTests : DesignTimeTestBase
         };
 
     /// <summary>
+    /// Records that the transitive contributor which survives the session still retains the version of the project it
+    /// was produced in, and by which route.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The contributor reaches a compilation by two routes. Its own target declaration is now durable, and so is the
+    /// one of the aspect instance that carries it. What remains is the aspect object, which for the pull strategy
+    /// holds a reference to the parameter that was pulled, and that parameter is one an earlier aspect introduced, so
+    /// the reference is an <c>IntroducedRef</c>.
+    /// </para>
+    /// <para>
+    /// That reference cannot simply be made durable, which was established by trying it: an <c>IntroducedRef</c> does
+    /// have a serializable identifier, and <c>ToDurable</c> compiles and closes this retention, but fixing the
+    /// identifier at the moment the advice runs breaks the cross-project case. With the parameter reference made
+    /// durable, <c>PullParameterTests.CrossProjectIntegration</c> fails: the consuming project resolves nothing and
+    /// the transitive aspect silently does not apply. The identity of an introduced declaration is not yet settled
+    /// when the transitive aspect is created, so making it durable has to happen later than that, which is a change of
+    /// design rather than a change of call. Issue #1797 carries the detail.
+    /// </para>
+    /// <para>
+    /// The assertion is deliberately the opposite of the one the rest of this suite makes. It is a control: it holds
+    /// the measurement that the retention is real and confined to that single route, and it fails the moment #1797 is
+    /// fixed, which is the signal to replace it with the ordinary assertion that the compilation is released.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void TransitiveContributor_StillRetainsTheCompilation_ThroughTheIntroducedParameterOnly()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.TransitiveContributor_StillRetainsTheCompilation_ThroughTheIntroducedParameterOnly),
+            CreateInitialCode() );
+
+        var initialCompilation = simulator.GetWeakReferenceToCurrentCompilation();
+        simulator.Execute();
+
+        for ( var version = 1; version <= 10; version++ )
+        {
+            simulator.ApplyEdit( _editedFileName, GetEditedCode( version ) );
+        }
+
+        // Without a surviving contributor there would be nothing to retain anything, and the assertion below would
+        // hold for a reason unrelated to what it measures.
+        Assert.NotEmpty( simulator.GetPipeline().AspectPipelineResult.Extensions.Extensions );
+
+        GarbageCollectionHelper.Collect();
+
+        Assert.True(
+            initialCompilation.IsAlive,
+            "The compilation was released, so the retention through the introduced parameter is gone. If issue #1797 "
+            + "has been fixed, replace this control with MemoryLeakAssert.Collected." );
+    }
+
+    /// <summary>
     /// Verifies that the number of transitive contributors the pipeline holds does not grow with the number of edits.
     /// </summary>
     /// <remarks>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TransitiveContributorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TransitiveContributorMemoryLeakTests.cs
@@ -1,0 +1,152 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
+using System.Collections.Generic;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that the transitive pipeline contributors kept in the design-time results do not accumulate as the user
+/// edits the project.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A contributor is stored in the <c>SyntaxTreePipelineResult</c> of the file that declares its target, which the
+/// pipeline carries forward from one version of the project to the next without re-analysing that file. The
+/// production implementation holds a target declaration built from the code model and the syntax tree of that
+/// declaration, so a contributor that survives an edit could pin the version of the project it was produced in, in
+/// the same way as the inheritable aspect instances addressed by issue #1793.
+/// </para>
+/// <para>
+/// The aspect below is the producer named in the audit of #1793: <c>PullStrategy.IntroduceParameterAndPull</c> makes
+/// the advice export a transitive aspect onto the declaring type of the base constructor, which is a declaration the
+/// aspect did not itself target and which lives in another file. That file is never edited by these tests, so its
+/// result, and the contributor it carries, survive every subsequent version.
+/// </para>
+/// </remarks>
+public sealed class TransitiveContributorMemoryLeakTests : DesignTimeTestBase
+{
+    public TransitiveContributorMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    private const string _baseFileName = "Base.cs";
+    private const string _derivedFileName = "Derived.cs";
+    private const string _editedFileName = "Edited.cs";
+
+    private const string _aspectCode = """
+                                       using System;
+                                       using Metalama.Framework.Advising;
+                                       using Metalama.Framework.Aspects;
+                                       using Metalama.Framework.Code;
+                                       using Metalama.Framework.Code.SyntaxBuilders;
+
+                                       public class PullAspect : TypeAspect
+                                       {
+                                           public override void BuildAspect( IAspectBuilder<INamedType> builder )
+                                           {
+                                               foreach ( var constructor in builder.Target.Constructors )
+                                               {
+                                                   builder.With( constructor )
+                                                       .IntroduceParameter(
+                                                           "creationTime",
+                                                           typeof(DateTime),
+                                                           pullStrategy: PullStrategy.IntroduceParameterAndPull(
+                                                               forwarderExpression: ExpressionFactory.Parse( "global::System.DateTime.Now" ) ) );
+                                               }
+                                           }
+                                       }
+                                       """;
+
+    /// <summary>
+    /// The base class, whose constructor receives the pulled parameter. Its file is never edited.
+    /// </summary>
+    private const string _baseCode = """
+                                     public class BaseClass
+                                     {
+                                         public int Id;
+
+                                         public BaseClass( int id )
+                                         {
+                                             this.Id = id;
+                                         }
+                                     }
+                                     """;
+
+    private const string _derivedCode = """
+                                        [PullAspect]
+                                        public class DerivedClass : BaseClass
+                                        {
+                                            public DerivedClass( int id ) : base( id ) { }
+                                        }
+                                        """;
+
+    /// <summary>
+    /// Returns the content of the run-time file that the test edits.
+    /// </summary>
+    private static string GetEditedCode( int version )
+        => $$"""
+             public class Edited
+             {
+                 public int Method() => {{version}};
+             }
+             """;
+
+    private static Dictionary<string, string> CreateInitialCode()
+        => new()
+        {
+            ["Aspect.cs"] = _aspectCode,
+            [_baseFileName] = _baseCode,
+            [_derivedFileName] = _derivedCode,
+            [_editedFileName] = GetEditedCode( 0 )
+        };
+
+    /// <summary>
+    /// Verifies that the number of transitive contributors the pipeline holds does not grow with the number of edits.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the end-to-end counterpart of
+    /// <see cref="SplitResultsByTreeExtensionAccumulationTests.ContributorOnTreeOutsidePartialCompilation_DoesNotAccumulate"/>,
+    /// which drives the same property through <c>Update</c> directly.
+    /// </para>
+    /// <para>
+    /// The contributor that survives is a single one, but it does retain the compilation it was produced in, through
+    /// the reference held by the aspect object it carries. That is a bounded retention rather than an accumulation,
+    /// it has a cause of its own, and it is tracked separately by issue #1797. This suite asserts the count only, so
+    /// that a fix for the accumulation is not held up by the other defect.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData( 4 )]
+    [InlineData( 16 )]
+    public void TransitiveContributorCountDoesNotGrowWithEdits( int editCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var simulator = new DesignTimeEditingSimulator(
+            testContext,
+            factory,
+            nameof(this.TransitiveContributorCountDoesNotGrowWithEdits),
+            CreateInitialCode() );
+
+        simulator.Execute();
+
+        var afterFirstRun = simulator.GetPipeline().AspectPipelineResult.Extensions.Extensions.Length;
+
+        for ( var version = 1; version <= editCount; version++ )
+        {
+            simulator.ApplyEdit( _editedFileName, GetEditedCode( version ) );
+        }
+
+        var afterEdits = simulator.GetPipeline().AspectPipelineResult.Extensions.Extensions.Length;
+
+        this.TestOutput.WriteLine( $"Contributors after the first run: {afterFirstRun}; after {editCount} edits: {afterEdits}." );
+
+        Assert.Equal( afterFirstRun, afterEdits );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TransitiveContributorMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TransitiveContributorMemoryLeakTests.cs
@@ -2,6 +2,7 @@
 // SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
 // Refer to LICENSE.md in the repository root for complete details.
 
+using Metalama.Framework.Engine.AdviceImpl.Introduction.Constructors;
 using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
 using Metalama.Framework.Tests.UnitTestHelpers.TestClasses;
 using System.Collections.Generic;
@@ -154,12 +155,11 @@ public sealed class TransitiveContributorMemoryLeakTests : DesignTimeTestBase
         // hold for a reason unrelated to what it measures.
         Assert.NotEmpty( simulator.GetPipeline().AspectPipelineResult.Extensions.Extensions );
 
-        GarbageCollectionHelper.Collect();
-
-        Assert.True(
-            initialCompilation.IsAlive,
-            "The compilation was released, so the retention through the introduced parameter is gone. If issue #1797 "
-            + "has been fixed, replace this control with MemoryLeakAssert.Collected." );
+        MemoryLeakAssert.RetainedThrough(
+            initialCompilation,
+            nameof(PullConstructorParameterTransitiveAspect),
+            "The compilation in which the transitive contributor was produced",
+            ("pipelineFactory", factory) );
     }
 
     /// <summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/WithCancellationMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/WithCancellationMemoryLeakTests.cs
@@ -35,6 +35,12 @@ namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
 /// cancellations is what fails, rather than the exact figure, which is a few units of asynchronous bookkeeping still
 /// in flight.
 /// </para>
+/// <para>
+/// This class deliberately does not derive from <c>UnitTestClass</c>, unlike the rest of the suite. What it measures
+/// belongs to the runtime and to Microsoft.VisualStudio.Threading, not to Metalama, so it needs neither a test context
+/// nor a service provider, and constructing one would suggest that the compilation or the pipeline takes part in the
+/// result. It writes through the logger it is given for the same reason.
+/// </para>
 /// </remarks>
 public sealed class WithCancellationMemoryLeakTests( ITestOutputHelper logger )
 {

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/WithCancellationMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/WithCancellationMemoryLeakTests.cs
@@ -1,0 +1,192 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - the foreign task is what these tests are about
+#pragma warning disable VSTHRD103 // Cancel synchronously blocks - CancelAsync not available on all target frameworks
+
+using System;
+using System.Collections;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that waiting on a long-lived task with a cancellation token leaves nothing behind on that task when the wait
+/// is cancelled, for both implementations of <c>WithCancellation</c> that the design-time code uses.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Awaiting a task attaches a continuation to it, and a task releases its continuations only when it completes. A task
+/// that stays incomplete for a long time would therefore accumulate one entry per wait, unless something removes them.
+/// Such tasks exist on the design-time surface and are waited on with tokens that are cancelled constantly: the
+/// initialization of an RPC service is completed only when a client attaches to its endpoint, and no client attaches
+/// at all when the Visual Studio extension is absent.
+/// </para>
+/// <para>
+/// Both implementations wait by way of <see cref="Task.WhenAny(Task[])"/>, which does remove its continuation from the
+/// task that did not win. These tests exist to hold that property, which is a guarantee of the runtime and of a
+/// third-party library rather than of this codebase, and which nothing else here would notice losing. The count is
+/// asserted against a constant far below the number of waits, so that growth proportional to the number of
+/// cancellations is what fails, rather than the exact figure, which is a few units of asynchronous bookkeeping still
+/// in flight.
+/// </para>
+/// </remarks>
+public sealed class WithCancellationMemoryLeakTests( ITestOutputHelper logger )
+{
+    private readonly ITestOutputHelper _logger = logger;
+
+    /// <summary>
+    /// Counts the continuations attached to a task.
+    /// </summary>
+    /// <remarks>
+    /// This reads a private field of <see cref="Task"/>, which is the only way to observe the property under test:
+    /// what accumulates is invisible to every public API and holds nothing that a weak reference could track. The
+    /// field holds <c>null</c> when there is no continuation, the continuation itself when there is exactly one, and a
+    /// list beyond that. A future runtime may rename it, which is why the absence of the field fails the test with an
+    /// explicit message rather than silently reporting zero.
+    /// </remarks>
+    private static int CountContinuations( Task task )
+    {
+        var field = typeof(Task).GetField( "m_continuationObject", BindingFlags.Instance | BindingFlags.NonPublic );
+
+        Assert.True(
+            field != null,
+            "Task.m_continuationObject was not found. The runtime has changed and this test needs to be updated; it "
+            + "must not be assumed to pass." );
+
+        if ( task.IsCompleted )
+        {
+            // A completed task stores a sentinel in this field rather than continuations, because it has already run
+            // and released them. Reading the field would count the sentinel as one continuation.
+            return 0;
+        }
+
+        return field!.GetValue( task ) switch
+        {
+            null => 0,
+            ICollection collection => collection.Count,
+            _ => 1
+        };
+    }
+
+    /// <summary>
+    /// Verifies that the number of continuations left on a task that never completes does not grow with the number of
+    /// cancelled waits.
+    /// </summary>
+    /// <remarks>
+    /// The cases span two orders of magnitude, which is what distinguishes a constant overhead from growth. A count
+    /// that tracks the number of waits is the defect; a count that stays constant is the property.
+    /// </remarks>
+    [Theory]
+    [InlineData( 10 )]
+    [InlineData( 100 )]
+    [InlineData( 1000 )]
+    public async Task CancelledWaits_DoNotAccumulateOnTheAwaitedTask( int waitCount )
+    {
+        // Never completed, standing in for the initialization of a service no client ever attaches to.
+        var neverCompleted = new TaskCompletionSource<bool>();
+
+        for ( var i = 0; i < waitCount; i++ )
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            var waitTask = Metalama.Framework.Engine.Utilities.Threading.TaskExtensions.WithCancellation(
+                neverCompleted.Task,
+                cancellationTokenSource.Token );
+
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>( () => waitTask );
+        }
+
+        var continuationCount = CountContinuations( neverCompleted.Task );
+
+        this._logger.WriteLine( $"After {waitCount} cancelled waits, the task holds {continuationCount} continuation(s)." );
+
+        AssertDoesNotGrow( continuationCount, waitCount );
+    }
+
+    /// <summary>
+    /// Repeats <see cref="CancelledWaits_DoNotAccumulateOnTheAwaitedTask"/> for the implementation of
+    /// <c>WithCancellation</c> that comes from Microsoft.VisualStudio.Threading.
+    /// </summary>
+    /// <remarks>
+    /// Two of the three waits fixed by issue #1799 resolve to that implementation rather than to the one of this
+    /// codebase, because Metalama.Framework.DesignTime.Rpc does not reference the engine. The property has to hold for
+    /// both, and neither is ours to guarantee.
+    /// </remarks>
+    [Theory]
+    [InlineData( 10 )]
+    [InlineData( 1000 )]
+    public async Task CancelledWaits_DoNotAccumulateOnTheAwaitedTask_VisualStudioThreading( int waitCount )
+    {
+        var neverCompleted = new TaskCompletionSource<bool>();
+
+        for ( var i = 0; i < waitCount; i++ )
+        {
+            using var cancellationTokenSource = new CancellationTokenSource();
+
+            var waitTask = Microsoft.VisualStudio.Threading.ThreadingTools.WithCancellation(
+                neverCompleted.Task,
+                cancellationTokenSource.Token );
+
+            cancellationTokenSource.Cancel();
+
+            await Assert.ThrowsAnyAsync<OperationCanceledException>( () => waitTask );
+        }
+
+        var continuationCount = CountContinuations( neverCompleted.Task );
+
+        this._logger.WriteLine(
+            $"After {waitCount} cancelled waits through Microsoft.VisualStudio.Threading, the task holds {continuationCount} continuation(s)." );
+
+        AssertDoesNotGrow( continuationCount, waitCount );
+    }
+
+    /// <summary>
+    /// Asserts that a continuation count is a constant rather than a function of the number of waits.
+    /// </summary>
+    /// <remarks>
+    /// The bound is generous on purpose. What it has to separate is a constant from growth proportional to
+    /// <paramref name="waitCount"/>, and the largest case makes that separation two orders of magnitude wide, so a
+    /// tight bound would buy nothing and would make the test sensitive to how much asynchronous bookkeeping happens to
+    /// be in flight.
+    /// </remarks>
+    private static void AssertDoesNotGrow( int continuationCount, int waitCount )
+        => Assert.True(
+            continuationCount <= 16,
+            $"After {waitCount} cancelled waits the task holds {continuationCount} continuations, which is not a "
+            + "constant. Each cancelled wait leaves one behind, and the task never completes, therefore nothing will "
+            + "ever release them." );
+
+    /// <summary>
+    /// The control for <see cref="CancelledWaits_DoNotAccumulateOnTheAwaitedTask"/>: a wait that ends because the
+    /// awaited task completed leaves nothing behind either.
+    /// </summary>
+    /// <remarks>
+    /// Without this case, a failure above could not be attributed to cancellation, since a task releases its
+    /// continuations when it completes and the assertion would hold for that reason alone.
+    /// </remarks>
+    [Fact]
+    public async Task CompletedWaits_LeaveNothingBehind()
+    {
+        var source = new TaskCompletionSource<bool>();
+
+        using var cancellationTokenSource = new CancellationTokenSource();
+
+        var waitTask = Metalama.Framework.Engine.Utilities.Threading.TaskExtensions.WithCancellation(
+            source.Task,
+            cancellationTokenSource.Token );
+
+        source.SetResult( true );
+
+        await waitTask;
+
+        Assert.Equal( 0, CountContinuations( source.Task ) );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
@@ -89,7 +89,7 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
 
         // The subset the pipeline ran on: target.cs is dirty, base.cs is not.
         var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
-        Assert.DoesNotContain( "base.cs", partialCompilation.SyntaxTrees.Keys );
+        Assert.False( partialCompilation.TryGetSyntaxTree( DocumentKey.FromPath( "base.cs" ), out _ ) );
 
         var result = executed.Result;
 
@@ -123,14 +123,14 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
         var wholeCompilation = PartialCompilation.CreatePartial( compilation, new[] { baseTree, targetTree } );
         var afterFullRun = Update( executed.Result, compilation, wholeCompilation, contributor );
 
-        Assert.Contains( contributor, afterFullRun.SyntaxTreeResults["base.cs"].Extensions );
+        Assert.Contains( contributor, afterFullRun.SyntaxTreeResults[DocumentKey.FromPath( "base.cs" )].Extensions );
         Assert.Contains( contributor, afterFullRun.Extensions.Extensions );
 
         // A later run in which only target.cs is dirty must leave that entry alone, and must not add a second one.
         var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
         var afterPartialRun = Update( afterFullRun, compilation, partialCompilation, contributor );
 
-        Assert.Contains( contributor, afterPartialRun.SyntaxTreeResults["base.cs"].Extensions );
+        Assert.Contains( contributor, afterPartialRun.SyntaxTreeResults[DocumentKey.FromPath( "base.cs" )].Extensions );
         Assert.Same( contributor, Assert.Single( afterPartialRun.Extensions.Extensions ) );
     }
 
@@ -301,7 +301,7 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
         }
 
         Assert.Single( result.Extensions.Extensions );
-        Assert.Single( result.SyntaxTreeResults["base.cs"].Extensions );
+        Assert.Single( result.SyntaxTreeResults[DocumentKey.FromPath( "base.cs" )].Extensions );
     }
 
     /// <summary>
@@ -340,7 +340,7 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
         ImmutableArray<ITransitivePipelineContributor> contributors )
     {
         var pipelineResults = new DesignTimePipelineExecutionResult(
-            partialCompilation.SyntaxTrees,
+            partialCompilation.SyntaxTreeCollection,
             ImmutableArray<IntroducedSyntaxTree>.Empty,
             ImmutableUserDiagnosticList.Empty,
             ImmutableArray<InheritableAspectInstance>.Empty,

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
@@ -1,0 +1,232 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+using Metalama.Framework.Aspects;
+using Metalama.Framework.Code;
+using Metalama.Framework.DesignTime.Pipeline;
+using Metalama.Framework.Engine;
+using Metalama.Framework.Engine.Aspects;
+using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.Collections;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Extensibility;
+using Metalama.Framework.Engine.HierarchicalOptions;
+using Metalama.Framework.Engine.Pipeline;
+using Metalama.Framework.Engine.Transformations;
+using Metalama.Framework.Options;
+using Metalama.Framework.Tests.UnitTestHelpers.Mocks;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline;
+
+/// <summary>
+/// Regression test for https://github.com/metalama/Metalama/issues/1796: a transitive pipeline contributor whose
+/// syntax tree is not a part of the partial compilation the pipeline ran on used to be appended to the accumulated
+/// <see cref="DesignTimeAspectPipelineResult.Extensions"/> collection, which nothing could ever remove it from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The design-time pipeline runs on the dirty trees only, and a contributor is not bound to that subset: an aspect
+/// can export one onto a declaration it did not itself target, such as the declaring type of a base constructor for
+/// <c>PullStrategy.IntroduceParameterAndPull</c>. When that declaration is in a tree that is not dirty, the path of
+/// that tree is not a key of the result builders.
+/// </para>
+/// <para>
+/// The contributor used to go to an <c>externalValidators</c> bucket that <c>Update</c> appended to the accumulated
+/// collection on every run. The only removal path, <c>UnindexOldTree</c>, reaches contributors filed under a
+/// <see cref="SyntaxTreePipelineResult"/>, and a contributor in that bucket was never filed under any, so the
+/// collection gained an entry per run for the lifetime of the process. Each entry also indexes itself by validated
+/// declaration, so a lookup returned one copy per run and the validation work grew with the length of the session.
+/// </para>
+/// <para>
+/// The inheritable-aspect loop of the same method had the same defect and was fixed for issue #1768 by skipping the
+/// item, because the tree keeps the result of the run that did include it and overwriting that result would drop the
+/// diagnostics and introductions it holds. The fix applies the same treatment to contributors, which
+/// <see cref="ContributorOnTreeOutsidePartialCompilationSurvivesThroughItsOwnTree"/> checks is lossless.
+/// </para>
+/// <para>
+/// The tests drive <c>Update</c> directly rather than through an edit-and-rerun sequence, for the reason given in
+/// <see cref="SplitResultsByTreePathLookupTests"/>: which trees the pipeline considers dirty is a function of the
+/// change graph and not something a test can dictate.
+/// </para>
+/// </remarks>
+public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
+{
+    public SplitResultsByTreeExtensionAccumulationTests( ITestOutputHelper testOutput ) : base( testOutput ) { }
+
+    private const string _baseCode = "public class BaseClass { }";
+
+    private const string _targetCode = "public class TargetClass { }";
+
+    /// <summary>
+    /// A contributor whose syntax tree is outside the partial compilation, submitted once per run, as the pipeline
+    /// does when the tree that declares its target stays clean while another tree is edited.
+    /// </summary>
+    /// <remarks>
+    /// Before the fix, the accumulated collection grew by one entry per update. The assertion is made for two
+    /// different numbers of updates so that what is tested is the absence of accumulation rather than a particular
+    /// count.
+    /// </remarks>
+    [Theory]
+    [InlineData( 3 )]
+    [InlineData( 12 )]
+    public void ContributorOnTreeOutsidePartialCompilation_DoesNotAccumulate( int updateCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (executed, compilation) = Execute( testContext, factory );
+
+        var baseTree = compilation.SyntaxTrees.Single( t => t.FilePath == "base.cs" );
+        var targetTree = compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" );
+
+        // The subset the pipeline ran on: target.cs is dirty, base.cs is not.
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
+        Assert.DoesNotContain( "base.cs", partialCompilation.SyntaxTrees.Keys );
+
+        var result = executed.Result;
+
+        for ( var i = 0; i < updateCount; i++ )
+        {
+            result = Update( result, compilation, partialCompilation, new TestContributor( baseTree ) );
+        }
+
+        this.TestOutput.WriteLine( $"After {updateCount} updates the collection holds {result.Extensions.Extensions.Length} extension(s)." );
+
+        Assert.Empty( result.Extensions.Extensions );
+    }
+
+    /// <summary>
+    /// Verifies that skipping the contributor loses nothing, because the result of its own tree, produced by a run
+    /// that did include that tree, keeps it.
+    /// </summary>
+    [Fact]
+    public void ContributorOnTreeOutsidePartialCompilationSurvivesThroughItsOwnTree()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (executed, compilation) = Execute( testContext, factory );
+
+        var baseTree = compilation.SyntaxTrees.Single( t => t.FilePath == "base.cs" );
+        var targetTree = compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" );
+        var contributor = new TestContributor( baseTree );
+
+        // A run that includes base.cs files the contributor under that tree.
+        var wholeCompilation = PartialCompilation.CreatePartial( compilation, new[] { baseTree, targetTree } );
+        var afterFullRun = Update( executed.Result, compilation, wholeCompilation, contributor );
+
+        Assert.Contains( contributor, afterFullRun.SyntaxTreeResults["base.cs"].Extensions );
+        Assert.Contains( contributor, afterFullRun.Extensions.Extensions );
+
+        // A later run in which only target.cs is dirty must leave that entry alone, and must not add a second one.
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
+        var afterPartialRun = Update( afterFullRun, compilation, partialCompilation, contributor );
+
+        Assert.Contains( contributor, afterPartialRun.SyntaxTreeResults["base.cs"].Extensions );
+        Assert.Same( contributor, Assert.Single( afterPartialRun.Extensions.Extensions ) );
+    }
+
+    /// <summary>
+    /// The control case: a contributor whose syntax tree is inside the partial compilation is filed under that tree,
+    /// so repeated updates replace the entry rather than adding to it.
+    /// </summary>
+    [Fact]
+    public void ContributorOnTreeInsidePartialCompilation_IsFiledUnderItsTree()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (executed, compilation) = Execute( testContext, factory );
+
+        var baseTree = compilation.SyntaxTrees.Single( t => t.FilePath == "base.cs" );
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, baseTree );
+
+        var result = executed.Result;
+
+        for ( var i = 0; i < 5; i++ )
+        {
+            result = Update( result, compilation, partialCompilation, new TestContributor( baseTree ) );
+        }
+
+        Assert.Single( result.Extensions.Extensions );
+        Assert.Single( result.SyntaxTreeResults["base.cs"].Extensions );
+    }
+
+    /// <summary>
+    /// Runs a full design-time execution, which supplies the real pipeline configuration that <c>Update</c> requires.
+    /// </summary>
+    private static (DesignTimeAspectPipelineResultAndState Executed, Compilation Compilation) Execute(
+        TestContext testContext,
+        TestDesignTimeAspectPipelineFactory factory )
+    {
+        var compilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["base.cs"] = _baseCode, ["target.cs"] = _targetCode } );
+
+        Assert.True( factory.TryExecute( testContext.ProjectOptions, compilation, default, out var executed ) );
+
+        return (executed, compilation);
+    }
+
+    /// <summary>
+    /// Files an execution result that carries <paramref name="contributor"/> and nothing else into the accumulated
+    /// result, over the given partial compilation.
+    /// </summary>
+    private static DesignTimeAspectPipelineResult Update(
+        DesignTimeAspectPipelineResult result,
+        Compilation compilation,
+        PartialCompilation partialCompilation,
+        ITransitivePipelineContributor contributor )
+    {
+        var pipelineResults = new DesignTimePipelineExecutionResult(
+            partialCompilation.SyntaxTrees,
+            ImmutableArray<IntroducedSyntaxTree>.Empty,
+            ImmutableUserDiagnosticList.Empty,
+            ImmutableArray<InheritableAspectInstance>.Empty,
+            ImmutableArray<KeyValuePair<HierarchicalOptionsKey, IHierarchicalOptions>>.Empty,
+            ImmutableArray.Create( contributor ),
+            ImmutableArray<IAspectInstance>.Empty,
+            ImmutableArray<ITransformationBase>.Empty,
+            ImmutableDictionaryOfArray<IRef<IDeclaration>, AnnotationInstance>.Empty );
+
+        var projectVersion = new DesignTimeProjectVersion(
+            new TestProjectVersion( compilation ),
+            ImmutableArray<DesignTimeProjectReference>.Empty,
+            DesignTimeAspectPipelineStatus.Default );
+
+        return result.Update( partialCompilation, projectVersion, pipelineResults, result.Configuration.AssertNotNull() );
+    }
+
+    /// <summary>
+    /// A minimal transitive contributor bound to a chosen syntax tree.
+    /// </summary>
+    /// <remarks>
+    /// The production implementation, <c>TransitiveAspectInstance</c>, is internal to the engine and is produced only
+    /// by the advice that exports an aspect onto the declaring type of a base constructor, which cannot be arranged
+    /// while also pinning the partial compilation to a chosen subset. Only the syntax tree of the contributor matters
+    /// to the code under test, which is what this stub supplies. The approach follows
+    /// <see cref="TransitiveManifestValidatorChannelTests"/>.
+    /// </remarks>
+    private sealed class TestContributor : ITransitivePipelineContributor, IDesignTimePipelineResultExtension
+    {
+        public TestContributor( SyntaxTree syntaxTree )
+        {
+            this.SyntaxTree = syntaxTree;
+        }
+
+        public SyntaxTree? SyntaxTree { get; }
+
+        public ContributorKind ContributorKind => ContributorKind.TransitiveAspectInstance;
+
+        public IDesignTimePipelineResultExtension? ToDesignTime() => this;
+
+        public ITransitiveAspectsManifestExtension ToTransitiveAspectManifestExtension() => throw new NotSupportedException();
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
@@ -220,10 +220,6 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
     }
 
     /// <summary>
-    /// Creates a syntax tree that belongs to another compilation, standing in for a declaration of a referenced
-    /// project.
-    /// </summary>
-    /// <summary>
     /// A run that carries no contributor at all must not discard the contributors of another compilation that earlier
     /// runs established.
     /// </summary>
@@ -269,6 +265,10 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
         Assert.Contains( contributor, afterEmptyRun.Extensions.Extensions );
     }
 
+    /// <summary>
+    /// Creates a syntax tree that belongs to another compilation, standing in for a declaration of a referenced
+    /// project.
+    /// </summary>
     private static SyntaxTree CreateForeignTree( TestContext testContext )
     {
         var referencedCompilation = testContext.CreateCSharpCompilation(

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
@@ -135,6 +135,104 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
     }
 
     /// <summary>
+    /// A contributor whose syntax tree belongs to a <em>different</em> compilation must be kept, because this project
+    /// has no result keyed by that path and never will.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This is the case the deleted comment named "cross-project validators". A fabric in this project can validate
+    /// references to declarations in a referenced project, which is a core scenario of
+    /// <c>Metalama.Extensions.Architecture</c>. The syntax tree that a reference validator reports is that of the
+    /// validated declaration, not of the code that declared the validator, and at design time an in-solution project
+    /// reference is a <see cref="Microsoft.CodeAnalysis.CompilationReference"/>, so the symbol does have a syntax
+    /// tree and that tree belongs to the other project's compilation.
+    /// </para>
+    /// <para>
+    /// Skipping such a contributor, which is correct for a tree of this project that is merely not dirty, loses it
+    /// altogether here: no <see cref="SyntaxTreePipelineResult"/> of this project is keyed by that path, so nothing
+    /// carries it. In <c>Metalama.Premium</c> the observable effect is that
+    /// <c>SideBySideVersionTests.TransitiveValidator</c> reports no diagnostic at all, that is, the architecture rules
+    /// of a project silently stop being enforced. This test reproduces the same condition without Premium, so that
+    /// this repository is self-contained.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void ContributorOnTreeOfAnotherCompilation_IsRetained()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (executed, compilation) = Execute( testContext, factory );
+
+        var foreignTree = CreateForeignTree( testContext );
+        var targetTree = compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" );
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
+
+        Assert.DoesNotContain( foreignTree, compilation.SyntaxTrees );
+
+        var contributor = new TestContributor( foreignTree );
+        var updated = Update( executed.Result, compilation, partialCompilation, contributor );
+
+        Assert.Contains( contributor, updated.Extensions.Extensions );
+    }
+
+    /// <summary>
+    /// The contributor of another compilation must be kept, but exactly once, however many times the pipeline runs.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Together with <see cref="ContributorOnTreeOfAnotherCompilation_IsRetained"/> this pins the whole of the
+    /// required behaviour, and the two are what distinguish a correct fix from either of the two wrong ones. Appending
+    /// the contributor keeps it but grows the collection by one entry per run, which is the defect of issue #1796.
+    /// Skipping it bounds the collection but drops the contributor, which is the regression described above.
+    /// </para>
+    /// <para>
+    /// A distinct instance is submitted on every update, because that is what the pipeline does: it re-materializes
+    /// every reference validator on every run. In <c>Metalama.Premium</c>,
+    /// <c>ValidationPipelineExtension.ExecuteDesignTimePipelineContributorsAsync</c> runs every validator source over
+    /// the whole compilation, so the complete set is produced each time and replacing the previous set loses nothing.
+    /// </para>
+    /// </remarks>
+    [Theory]
+    [InlineData( 3 )]
+    [InlineData( 12 )]
+    public void ContributorOnTreeOfAnotherCompilation_DoesNotAccumulate( int updateCount )
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (executed, compilation) = Execute( testContext, factory );
+
+        var foreignTree = CreateForeignTree( testContext );
+        var targetTree = compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" );
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
+
+        var result = executed.Result;
+
+        for ( var i = 0; i < updateCount; i++ )
+        {
+            result = Update( result, compilation, partialCompilation, new TestContributor( foreignTree ) );
+        }
+
+        this.TestOutput.WriteLine( $"After {updateCount} updates the collection holds {result.Extensions.Extensions.Length} extension(s)." );
+
+        Assert.Single( result.Extensions.Extensions );
+    }
+
+    /// <summary>
+    /// Creates a syntax tree that belongs to another compilation, standing in for a declaration of a referenced
+    /// project.
+    /// </summary>
+    private static SyntaxTree CreateForeignTree( TestContext testContext )
+    {
+        var referencedCompilation = testContext.CreateCSharpCompilation(
+            new Dictionary<string, string> { ["referenced.cs"] = "public class ReferencedClass { }" },
+            assemblyName: "ReferencedProject" );
+
+        return referencedCompilation.SyntaxTrees.Single( t => t.FilePath == "referenced.cs" );
+    }
+
+    /// <summary>
     /// The control case: a contributor whose syntax tree is inside the partial compilation is filed under that tree,
     /// so repeated updates replace the entry rather than adding to it.
     /// </summary>

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/SplitResultsByTreeExtensionAccumulationTests.cs
@@ -223,6 +223,52 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
     /// Creates a syntax tree that belongs to another compilation, standing in for a declaration of a referenced
     /// project.
     /// </summary>
+    /// <summary>
+    /// A run that carries no contributor at all must not discard the contributors of another compilation that earlier
+    /// runs established.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The set of foreign contributors is replaced on each run rather than appended to, which is correct only for a
+    /// run that actually re-produced them. A run can carry none for reasons that say nothing about whether the rules
+    /// still apply: <c>DesignTimePipelineStage</c> invokes the extensions only when the run produced at least one
+    /// contributor of extension kind, so a validator source registered by an aspect contributes nothing on a run in
+    /// which that aspect's file is clean, and a run whose pipeline failed carries none either, because
+    /// <c>PipelineState</c> reads <c>TransitiveContributors</c> from a result that is then null.
+    /// </para>
+    /// <para>
+    /// Replacing unconditionally in that situation loses the rules of a referenced project silently, which is the
+    /// regression that <see cref="ContributorOnTreeOfAnotherCompilation_IsRetained"/> exists to prevent, reached
+    /// through a different door.
+    /// </para>
+    /// </remarks>
+    [Fact]
+    public void RunWithoutContributors_KeepsTheContributorsOfAnotherCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+        using var factory = new TestDesignTimeAspectPipelineFactory( testContext );
+
+        var (executed, compilation) = Execute( testContext, factory );
+
+        var foreignTree = CreateForeignTree( testContext );
+        var targetTree = compilation.SyntaxTrees.Single( t => t.FilePath == "target.cs" );
+        var partialCompilation = PartialCompilation.CreatePartial( compilation, targetTree );
+
+        var contributor = new TestContributor( foreignTree );
+        var afterFirstRun = Update( executed.Result, compilation, partialCompilation, contributor );
+
+        Assert.Contains( contributor, afterFirstRun.Extensions.Extensions );
+
+        // The second run produces nothing, as happens when no source of extension contributors ran.
+        var afterEmptyRun = Update(
+            afterFirstRun,
+            compilation,
+            partialCompilation,
+            ImmutableArray<ITransitivePipelineContributor>.Empty );
+
+        Assert.Contains( contributor, afterEmptyRun.Extensions.Extensions );
+    }
+
     private static SyntaxTree CreateForeignTree( TestContext testContext )
     {
         var referencedCompilation = testContext.CreateCSharpCompilation(
@@ -282,6 +328,16 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
         Compilation compilation,
         PartialCompilation partialCompilation,
         ITransitivePipelineContributor contributor )
+        => Update( result, compilation, partialCompilation, ImmutableArray.Create( contributor ) );
+
+    /// <summary>
+    /// Files an execution result carrying the given contributors, which may be none, into the accumulated result.
+    /// </summary>
+    private static DesignTimeAspectPipelineResult Update(
+        DesignTimeAspectPipelineResult result,
+        Compilation compilation,
+        PartialCompilation partialCompilation,
+        ImmutableArray<ITransitivePipelineContributor> contributors )
     {
         var pipelineResults = new DesignTimePipelineExecutionResult(
             partialCompilation.SyntaxTrees,
@@ -289,7 +345,7 @@ public sealed class SplitResultsByTreeExtensionAccumulationTests : UnitTestClass
             ImmutableUserDiagnosticList.Empty,
             ImmutableArray<InheritableAspectInstance>.Empty,
             ImmutableArray<KeyValuePair<HierarchicalOptionsKey, IHierarchicalOptions>>.Empty,
-            ImmutableArray.Create( contributor ),
+            contributors,
             ImmutableArray<IAspectInstance>.Empty,
             ImmutableArray<ITransformationBase>.Empty,
             ImmutableDictionaryOfArray<IRef<IDeclaration>, AnnotationInstance>.Empty );

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.ITestApi.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.ITestApi.cs
@@ -1,0 +1,15 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Rpc;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Rpc;
+
+public sealed partial class RpcServiceCancellationTests
+{
+    /// <summary>
+    /// A minimal RPC API. The tests never call it: they exercise the wait that precedes any call.
+    /// </summary>
+    private interface ITestApi : IRpcApi { }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.TestServerEndpoint.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.TestServerEndpoint.cs
@@ -1,0 +1,37 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Rpc;
+using Metalama.Framework.Engine;
+using System;
+using System.Collections.Generic;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Rpc;
+
+public sealed partial class RpcServiceCancellationTests
+{
+    /// <summary>
+    /// A server endpoint hosting a single <see cref="TestService"/>, which the tests never connect a client to.
+    /// </summary>
+    /// <remarks>
+    /// A service is initialized when a client attaches, so an endpoint no client attaches to is exactly the state the
+    /// tests need. It is also a state that occurs in production: the analysis process always creates its endpoints,
+    /// and no client attaches to them when the Visual Studio extension is not installed.
+    /// </remarks>
+    private sealed class TestServerEndpoint : ServerEndpoint
+    {
+        public TestServerEndpoint( IServiceProvider serviceProvider, string pipeName )
+            : base( serviceProvider, pipeName ) { }
+
+        private TestService? _service;
+
+        protected override IEnumerable<RpcService> CreateServices() => [this._service = new TestService( this )];
+
+        /// <summary>
+        /// Gets the service this endpoint hosts. Available once <see cref="ServerEndpoint.Start"/> has been called,
+        /// which is when the endpoint creates its services.
+        /// </summary>
+        public TestService Service => this._service.AssertNotNull();
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.TestService.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.TestService.cs
@@ -1,0 +1,36 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.DesignTime.Rpc;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Rpc;
+
+public sealed partial class RpcServiceCancellationTests
+{
+    /// <summary>
+    /// An RPC service that exposes the protected wait for initialization, which is otherwise reachable only through
+    /// the service methods of the production services.
+    /// </summary>
+    /// <remarks>
+    /// Every production service awaits this wait before doing anything, including
+    /// <c>RpcService{TApi}.RaiseEventAsync</c>, which awaits it before it even checks whether there is a client to
+    /// raise the event to. Exposing the wait directly is what makes the tests deterministic: they state a property of
+    /// the wait itself rather than of whichever caller happens to reach it.
+    /// </remarks>
+    private sealed class TestService : RpcService<ITestApi>
+    {
+        public TestService( ServerEndpoint serverEndpoint ) : base( serverEndpoint ) { }
+
+        protected override ITestApi CreateApi( IRpcEventSender eventSender ) => new Api();
+
+        /// <summary>
+        /// Awaits initialization, in the same way as every method of every production service does.
+        /// </summary>
+        public Task WaitAsync( CancellationToken cancellationToken ) => this.WaitUntilInitializedAsync( cancellationToken );
+
+        private sealed class Api : ITestApi { }
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Rpc/RpcServiceCancellationTests.cs
@@ -1,0 +1,169 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+#pragma warning disable VSTHRD003 // Avoid awaiting foreign Tasks - acceptable in test code
+#pragma warning disable VSTHRD103 // Cancel synchronously blocks - CancelAsync not available on all target frameworks
+
+using Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+using Xunit.Abstractions;
+
+// ReSharper disable AccessToDisposedClosure
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Rpc;
+
+/// <summary>
+/// Tests that the wait a server-side RPC service performs before serving a request observes its cancellation token.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Every method of every server-side service begins by awaiting <c>RpcService.WaitUntilInitializedAsync</c>, and the
+/// underlying <see cref="TaskCompletionSource{TResult}"/> is completed only when a client attaches to the endpoint. A
+/// caller that reaches the wait while no client is attached therefore waits until one is, which in the configuration
+/// where no client ever attaches means forever.
+/// </para>
+/// <para>
+/// Waiting is correct. Waiting without observing the cancellation token is not, because a suspended asynchronous
+/// method keeps its own frame alive, and with it every local and every argument it captured. On this surface those
+/// arguments are Roslyn objects: the source generator awaits the wait while holding the compilation whose generated
+/// sources it is publishing, and the user-process services await it while holding a compilation or a symbol. The
+/// caller passes a cancellation token in each case, and cancelling it releases nothing.
+/// </para>
+/// <para>
+/// The client side of the same wait, <c>RpcClient.WaitUntilInitializedAsync</c>, composes the token with
+/// <c>WithCancellation</c> and is already covered by
+/// <c>RpcClientTests.WaitUntilInitializedAsync_Cancelled_ThrowsOperationCancelledException</c>. This suite is its
+/// server-side counterpart.
+/// </para>
+/// <para>
+/// Extensions reach this surface: an extension may register its own RPC services during initialization, as
+/// <c>DesignTimeExtensionRpcTests</c> demonstrates, and those services inherit the same wait. The defect is tracked
+/// by issue #1799.
+/// </para>
+/// </remarks>
+public sealed partial class RpcServiceCancellationTests : RpcUnitTestClass
+{
+    public RpcServiceCancellationTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    /// <summary>
+    /// Verifies that the wait ends when the cancellation token given to it is cancelled.
+    /// </summary>
+    [Fact]
+    public async Task WaitUntilInitializedAsync_Cancelled_ThrowsOperationCancelledException()
+    {
+        using var testContext = this.CreateShortTimeoutRpcTestContext();
+
+        var pipeName = $"{nameof(RpcServiceCancellationTests)}_{Guid.NewGuid()}";
+
+        using var serverEndpoint = new TestServerEndpoint( testContext.ServiceProvider, pipeName );
+        serverEndpoint.Start();
+
+        using var cts = new CancellationTokenSource();
+
+        var waitTask = serverEndpoint.Service.WaitAsync( cts.Token );
+
+        // No client attaches to the endpoint, so the service is never initialized and the wait cannot have completed.
+        Assert.False( waitTask.IsCompleted );
+
+        cts.Cancel();
+
+        Assert.True(
+            await EndedAsync( waitTask, testContext ),
+            "The wait did not end after its cancellation token was cancelled." );
+
+        await Assert.ThrowsAnyAsync<OperationCanceledException>( () => waitTask );
+    }
+
+    /// <summary>
+    /// Verifies that cancelling the wait releases what the suspended caller was holding.
+    /// </summary>
+    /// <remarks>
+    /// This is the consequence that matters for the memory of the analysis process, and it is stated separately from
+    /// the test above because the two could in principle diverge: an implementation could complete the returned task
+    /// on cancellation while leaving the original continuation attached to the
+    /// <see cref="TaskCompletionSource{TResult}"/>, which would satisfy the first test and still retain the frame.
+    /// </remarks>
+    [Fact]
+    public async Task WaitUntilInitializedAsync_Cancelled_ReleasesTheCallerFrame()
+    {
+        using var testContext = this.CreateShortTimeoutRpcTestContext();
+
+        var pipeName = $"{nameof(RpcServiceCancellationTests)}_{Guid.NewGuid()}";
+
+        using var serverEndpoint = new TestServerEndpoint( testContext.ServiceProvider, pipeName );
+        serverEndpoint.Start();
+
+        using var cts = new CancellationTokenSource();
+
+        var (waitTask, payload) = StartWaitingWithPayload( serverEndpoint, cts.Token );
+
+        Assert.False( waitTask.IsCompleted );
+
+        cts.Cancel();
+
+        // The outcome of the wait is not asserted here: it is the subject of the test above. This test observes only
+        // what the suspended frame holds once its token has been cancelled, so it waits for the task to end and
+        // proceeds either way.
+        _ = await EndedAsync( waitTask, testContext );
+
+        MemoryLeakAssert.Collected(
+            payload,
+            "The object captured by a caller suspended on the wait for initialization",
+            ("serverEndpoint", serverEndpoint) );
+    }
+
+    /// <summary>
+    /// Creates a test context whose timeout is short, because these tests deliberately provoke a wait that does not
+    /// end, and the timeout is what bounds it.
+    /// </summary>
+    /// <remarks>
+    /// The default timeout of a test context is four minutes, which is the right order of magnitude for a test that
+    /// is expected to complete and is far too long for one whose failure mode is precisely that nothing happens.
+    /// </remarks>
+    private RpcTestContext CreateShortTimeoutRpcTestContext()
+        => this.CreateRpcTestContext( this.CreateDefaultTestContextOptions() with { Timeout = TimeSpan.FromSeconds( 10 ) } );
+
+    /// <summary>
+    /// Waits for a task to end, bounded by the timeout of the test context, and reports whether it did.
+    /// </summary>
+    /// <remarks>
+    /// A plain <c>await</c> would hang for as long as the defect is present, which would make a failure indefinite
+    /// rather than reported. The bound is the cancellation token of the test context rather than a delay of a chosen
+    /// duration, so that these tests contain no timing assumption of their own.
+    /// </remarks>
+    private static async Task<bool> EndedAsync( Task task, RpcTestContext testContext )
+    {
+        var timeout = Task.Delay( Timeout.Infinite, testContext.CancellationToken );
+
+        return await Task.WhenAny( task, timeout ) == task;
+    }
+
+    /// <summary>
+    /// Starts a caller that suspends on the wait while holding an object, and returns that object weakly.
+    /// </summary>
+    /// <remarks>
+    /// The object is created and captured inside a method that is not inlinable, so that no frame of the calling test
+    /// holds it once this method has returned. That is the same precaution as the one taken throughout the memory
+    /// suite, and it is what makes the assertion above about the suspended frame and about nothing else.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static (Task WaitTask, WeakReference Payload) StartWaitingWithPayload( TestServerEndpoint endpoint, CancellationToken cancellationToken )
+    {
+        var payload = new object();
+
+        async Task WaitAsync()
+        {
+            await endpoint.Service.WaitAsync( cancellationToken );
+
+            // Keeps the object captured by the state machine for the whole of the suspension, which is the point.
+            GC.KeepAlive( payload );
+        }
+
+        return (WaitAsync(), new WeakReference( payload ));
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Diagnostics/DiagnosticArgumentMaterializationTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Diagnostics/DiagnosticArgumentMaterializationTests.cs
@@ -1,0 +1,125 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Code;
+using Metalama.Framework.Diagnostics;
+using Metalama.Framework.Engine.Diagnostics;
+using Metalama.Framework.Engine.Utilities;
+using Metalama.Testing.UnitTesting;
+using System.Linq;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Diagnostics;
+
+/// <summary>
+/// Tests that materializing the compilation-bound arguments of a diagnostic ahead of time does not change the message
+/// the diagnostic produces.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A diagnostic reported on a declaration used to keep the declaration, and therefore the whole compilation, for as
+/// long as the diagnostic was stored, which at design time is the whole editing session (issue #1799). The arguments
+/// that can reach a compilation are now formatted when the diagnostic is created rather than when its message is
+/// requested.
+/// </para>
+/// <para>
+/// The risk this creates is that formatting early is not the same as formatting late.
+/// <see cref="MetalamaStringFormatter"/> passes the format specifier of the composite format string to an argument that
+/// implements <see cref="System.IFormattable"/>, so an argument materialized ahead of time would have its specifier
+/// applied to a string instead: <c>{0:N2}</c> would lose its grouping and <c>{0:x}</c> would throw. Each test below is
+/// a category of argument, and each asserts that the message is the one late formatting would have produced.
+/// </para>
+/// <para>
+/// Two of the categories, <see cref="bool"/> and <see cref="char"/>, are excluded from materialization for economy
+/// rather than for correctness, because neither reads the format specifier and the message is the same either way. The
+/// tests over them therefore pass under either decision; they are here because the categories belong in the list, not
+/// because they discriminate.
+/// </para>
+/// </remarks>
+public sealed class DiagnosticArgumentMaterializationTests : UnitTestClass
+{
+    private const string _format = "The value is {0}.";
+
+    private static readonly DiagnosticDefinition<bool> _boolean = new( "MY001", Severity.Warning, _format, "Title", "Category" );
+
+    private static readonly DiagnosticDefinition<char> _character = new( "MY002", Severity.Warning, _format, "Title", "Category" );
+
+    private static readonly DiagnosticDefinition<int> _hexadecimal = new( "MY003", Severity.Warning, "The value is {0:x}.", "Title", "Category" );
+
+    private static readonly DiagnosticDefinition<double> _grouped = new( "MY004", Severity.Warning, "The value is {0:N2}.", "Title", "Category" );
+
+    private static readonly DiagnosticDefinition<Severity> _enumeration = new( "MY005", Severity.Warning, _format, "Title", "Category" );
+
+    private static readonly DiagnosticDefinition<string[]> _strings = new( "MY006", Severity.Warning, _format, "Title", "Category" );
+
+    private static readonly DiagnosticDefinition<IDeclaration> _declaration = new( "MY007", Severity.Warning, _format, "Title", "Category" );
+
+    /// <summary>
+    /// Returns the message that the diagnostic produces, which is formatted when this method is called and not before.
+    /// </summary>
+    private static string GetMessage<T>( DiagnosticDefinition<T> definition, T arguments )
+        where T : notnull
+        => definition.CreateRoslynDiagnostic( null, arguments ).GetMessage();
+
+    /// <summary>
+    /// Returns the message that late formatting would have produced, which is the reference every test compares
+    /// against.
+    /// </summary>
+    private static string FormatLate( string format, params object?[] arguments )
+        => string.Format( MetalamaStringFormatter.Instance, format, arguments );
+
+    [Fact]
+    public void BooleanArgumentIsFormattedAsLateFormattingWould() => Assert.Equal( FormatLate( _format, true ), GetMessage( _boolean, true ) );
+
+    [Fact]
+    public void CharacterArgumentIsFormattedAsLateFormattingWould() => Assert.Equal( FormatLate( _format, 'x' ), GetMessage( _character, 'x' ) );
+
+    /// <summary>
+    /// The specifier that would throw if it reached a string rather than the number it was written for.
+    /// </summary>
+    [Fact]
+    public void HexadecimalSpecifierReachesTheArgument()
+    {
+        Assert.Equal( "The value is ff.", GetMessage( _hexadecimal, 255 ) );
+    }
+
+    /// <summary>
+    /// The specifier that would be silently lost, which is the worse of the two failures because nothing reports it.
+    /// </summary>
+    [Fact]
+    public void GroupingSpecifierReachesTheArgument()
+    {
+        Assert.Equal( FormatLate( "The value is {0:N2}.", 1234.5678 ), GetMessage( _grouped, 1234.5678 ) );
+        Assert.Contains( "1", GetMessage( _grouped, 1234.5678 ), System.StringComparison.Ordinal );
+    }
+
+    [Fact]
+    public void EnumerationArgumentIsFormattedAsLateFormattingWould()
+        => Assert.Equal( FormatLate( _format, Severity.Error ), GetMessage( _enumeration, Severity.Error ) );
+
+    /// <summary>
+    /// An array of strings has a presentation of its own, which materializing the array as a whole would lose.
+    /// </summary>
+    [Fact]
+    public void StringArrayArgumentIsFormattedAsLateFormattingWould()
+    {
+        var value = new[] { "a", "b" };
+
+        Assert.Equal( FormatLate( _format, (object)value ), GetMessage( _strings, value ) );
+    }
+
+    /// <summary>
+    /// The category the whole mechanism exists for: the argument is materialized, and the message is nevertheless the
+    /// one late formatting would have produced.
+    /// </summary>
+    [Fact]
+    public void DeclarationArgumentIsFormattedAsLateFormattingWould()
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( "class C { void M() {} }" );
+        var method = compilation.Types.OfName( "C" ).Single().Methods.OfName( "M" ).Single();
+
+        Assert.Equal( FormatLate( _format, method ), GetMessage( _declaration, method ) );
+    }
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/UserCodeExecutionContextTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/UserCodeExecutionContextTests.cs
@@ -1,0 +1,119 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.Utilities.UserCode;
+using Metalama.Testing.UnitTesting;
+using System.Linq;
+using Xunit;
+
+namespace Metalama.Framework.Tests.UnitTests.Utilities;
+
+/// <summary>
+/// Tests of what a <see cref="UserCodeExecutionContext"/> takes from the context that is current when it is created.
+/// </summary>
+public sealed class UserCodeExecutionContextTests : UnitTestClass
+{
+    private const string _code = """
+                                 class Caller { }
+
+                                 class Other { }
+                                 """;
+
+    /// <summary>
+    /// Verifies that the ordinary factory fills in the target declaration from the ambient context, which is what an
+    /// aspect relies on when it reports a diagnostic without naming a declaration.
+    /// </summary>
+    [Fact]
+    public void CreateInstance_InheritsTheTargetDeclarationOfTheAmbientContext()
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( _code );
+        var caller = compilation.Types.OfName( "Caller" ).Single();
+
+        var ambient = new UserCodeExecutionContext(
+            testContext.ServiceProvider,
+            UserCodeDescription.Create( "the ambient context" ),
+            compilation,
+            targetDeclaration: caller );
+
+        using ( UserCodeExecutionContext.WithContext( ambient ) )
+        {
+            var created = UserCodeExecutionContext.CreateInstance(
+                testContext.ServiceProvider,
+                UserCodeDescription.Create( "the created context" ),
+                compilation );
+
+            Assert.Same( caller, created.TargetDeclaration );
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the factory used by a static fabric amender takes nothing from the ambient context.
+    /// </summary>
+    /// <remarks>
+    /// A static fabric amender builds a context on demand rather than storing one, so that the pipeline configuration
+    /// does not pin a compilation (issue #1799). It is not running user code when it does so, and the queries it owns
+    /// are reachable from user code through the public <c>IQuery.ToCollection</c>, so an ambient context at that moment
+    /// belongs to the caller. Inheriting from it would give a fabric query the target declaration and the meta API of
+    /// an unrelated aspect.
+    /// </remarks>
+    [Fact]
+    public void CreateWithoutInheritance_TakesNothingFromTheAmbientContext()
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( _code );
+        var caller = compilation.Types.OfName( "Caller" ).Single();
+
+        var ambient = new UserCodeExecutionContext(
+            testContext.ServiceProvider,
+            UserCodeDescription.Create( "the ambient context" ),
+            compilation,
+            targetDeclaration: caller );
+
+        using ( UserCodeExecutionContext.WithContext( ambient ) )
+        {
+            var created = UserCodeExecutionContext.CreateWithoutInheritance(
+                testContext.ServiceProvider,
+                UserCodeDescription.Create( "the created context" ),
+                compilation );
+
+            Assert.Null( created.TargetDeclaration );
+        }
+    }
+
+    /// <summary>
+    /// Verifies that the ambient context is restored after a context has been created without inheritance, including
+    /// when there was no ambient context to begin with.
+    /// </summary>
+    [Fact]
+    public void CreateWithoutInheritance_RestoresTheAmbientContext()
+    {
+        using var testContext = this.CreateTestContext();
+        var compilation = testContext.CreateCompilationModel( _code );
+
+        Assert.Null( UserCodeExecutionContext.CurrentOrNull );
+
+        _ = UserCodeExecutionContext.CreateWithoutInheritance(
+            testContext.ServiceProvider,
+            UserCodeDescription.Create( "the created context" ),
+            compilation );
+
+        Assert.Null( UserCodeExecutionContext.CurrentOrNull );
+
+        var ambient = new UserCodeExecutionContext(
+            testContext.ServiceProvider,
+            UserCodeDescription.Create( "the ambient context" ),
+            compilation );
+
+        using ( UserCodeExecutionContext.WithContext( ambient ) )
+        {
+            _ = UserCodeExecutionContext.CreateWithoutInheritance(
+                testContext.ServiceProvider,
+                UserCodeDescription.Create( "the created context" ),
+                compilation );
+
+            Assert.Same( ambient, UserCodeExecutionContext.CurrentOrNull );
+        }
+    }
+}


### PR DESCRIPTION
Design-time retention work across three issues. The branch began as the fix for #1796 and grew as the audit behind it
found more; the commits are separated by defect so they can be read independently.

## #1796 — cross-project contributors accumulated on every run

`SplitResultsByTree` files each transitive pipeline contributor under the document of its syntax tree. At design time
the pipeline runs on the dirty trees only, so a contributor belonging to a tree that is not dirty had no result to be
filed under, and went to a bucket that `Update` appended to the accumulated `Extensions` collection on every run.
Nothing could remove those entries, so the collection gained one per run for the lifetime of the process, and because
each entry also indexes itself by validated declaration, a lookup returned one copy per run and the validation work
grew with the length of the editing session.

Two cases had to be told apart, which the first attempt did not do:

- **an own tree that is merely not dirty** is skipped, because the tree keeps the result of the run that did include
  the contributor and that result already carries it (#1768);
- **a foreign tree**, which is what a cross-project validator reports, is kept, in a set that `Update` replaces on
  every run rather than appending to. Replacing is lossless because a run re-produces the complete set.

Skipping both, which the first attempt did, silently dropped cross-project validators. `TransitiveValidationSource` in
Metalama.Premium is the producer, and `SideBySideVersionTests.TransitiveValidator` there is what caught it.

**Replacing that set unconditionally was itself a defect**, found in review. A run can produce no foreign contributor
for reasons that say nothing about whether the rules still apply: `DesignTimePipelineStage` invokes the extensions only
when the run produced at least one contributor of extension kind, and `PipelineState` reads `TransitiveContributors`
from a result that is null when the pipeline failed. The set is now replaced only when the run produced some. The
residual is documented where the decision is made: a rule genuinely removed survives until the next run producing any
foreign contributor, and removing a rule is a compile-time edit, which discards the configuration and this result with
it.

## #1799 — retention defects on the extension, fabric and query surface

`AspectPipelineConfiguration` is long-lived by design, reused across keystrokes because rebuilding it per keystroke
would mean recompiling the compile-time assemblies each time. That reuse stays. What follows from it is a constraint:
it must not pin a compilation, because in a session of run-time edits alone it would retain the *first* version of the
session, held in addition to the current one.

| Commit | Defect |
|---|---|
| `030e70f` | A diagnostic reported on a declaration pinned the compilation: `DiagnosticDefinition` formats lazily, so the argument is held by the stored diagnostic. |
| `24e9061`, `737bce8` | Three waits on a `TaskCompletionSource` did not observe their cancellation token, so a caller parked while holding a `Compilation` was never released. |
| `f74f2e1` | The pipeline configuration pinned a compilation by three routes. |
| `8a14020` | Nothing stated that what an extension stores in a design-time contributor must be durable. |
| `ba5ec81` | The durable form chosen for a query base type lost the type arguments of a constructed generic type, and could not denote an introduced type at all. |
| `f72ef24` | A context built on demand inherited from whichever ambient context happened to be current. |

Points a reviewer should look at rather than take on trust.

**The diagnostic fix materializes selectively.** `MetalamaStringFormatter` passes the composite format specifier to an
`IFormattable` argument, so pre-formatting every argument would change `{0:N2}` and make `{0:x}` throw. Only the
compilation-bound arguments are materialized, and every formatter branch that handles one ignores the specifier, so no
message can change. `DiagnosticArgumentMaterializationTests` asserts that per category of argument, and the two
specifiers above are the cases that discriminate. The cost was measured, because it is paid on the compile-time path
too: about 3.2 µs to create a diagnostic whose argument is a declaration, of which about 2.3 are the display string,
against about 0.25 with a string argument. Ten thousand never-displayed diagnostics would cost about 20 ms, which does
not justify gating on the execution scenario, which this static extension has no way of reading.

**`IQueryOwner` gained a factory in place of a property.** A fabric amender no longer stores a
`UserCodeExecutionContext` at all; it keeps the compilation-neutral `UserCodeDescription` and builds a context per run.
This is deliberately structural: clearing the compilation from a stored context would leave a field that a later change
could repopulate. The two owners whose lifetime is a single run, the aspect builder and a type fabric's amender, return
the context they hold, rebound.

That change moved *when* the inheritance from the ambient context is sampled, which is a behavioural change and not
only a memory one. It used to happen once, while the fabric was running; it now happens on demand. `ToCollection` is
public, so a fabric query can be executed from inside an aspect and would acquire that aspect's target declaration and
meta API, the latter being what `WithCompilationAndDiagnosticAdder` asserts against carrying across compilations.
`UserCodeExecutionContext.CreateWithoutInheritance` is the shape for an owner that is not itself running user code.

**`SelectTypesDerivedFrom( INamedType )` needed a type identifier, not a declaration identifier.** The overload had no
test at all before this branch, here or in Metalama.Premium, where both fabric tests use the `System.Type` overload.
Making its base type durable with `ToDurable()` resolved `Base<int>` back to `Base<T>`, silently, because a
`SerializableDeclarationId` names a declaration: the query then matched the types derived from every construction of
the generic type. The durable form is a `SerializableTypeId`.

A type identifier resolves through the symbol table, so it cannot denote a type an aspect introduced, and converting
one unconditionally replaced a query that works with one that throws `SymbolNotFoundException` while it runs, far from
the call site. The conversion is therefore verified rather than assumed, and the type is kept as it is when no
identifier denotes it. Keeping it is safe here for a reason worth stating, because it is what bounds the retention:
only an aspect can hold an introduced type, the queries of an aspect do not outlive the run, and a fabric, whose
queries do, runs before any aspect and never sees one.

Both cases have an aspect test that fails on the previous conversion, and `RefTests` records the difference between the
two identifiers directly.

**One defect is documented rather than fixed.** What a contributor carries is opaque to the pipeline, so the durability
requirement can be stated but not enforced. Its test is a matched pair differing by one `ToDurable` call: the durable
case asserts release, the other asserts retention. The violation known at the time,
[`TypeEqualityPredicate`](https://github.com/metalama/Metalama.Premium/pull/74) in Metalama.Premium, is fixed there.

## #1797 — transitive aspect instances, half fixed

A `TransitiveAspectInstance` reached its compilation by two routes. The target declarations, its own and the one the
pull aspect records, are now durable, and `TransitiveAspectInstance.TargetDeclaration` is typed `IDurableRef<IDeclaration>`
so that the requirement is the compiler's business rather than the caller's discipline.

The second route stays open, and the reason is not the one previously given in that issue. An `IntroducedRef` **does**
have a serializable identifier: it overrides `ToSerializableId`, `FullRef.ToDurable` is built on it, and the identifier
of a pulled parameter names the constructor signature and the ordinal, which the resolution path handles explicitly and
`ConstructorParameterIdResolutionTests` covers. `ToDurable` therefore compiles on the parameter reference and closes
the retention, which was verified.

It also breaks the cross-project case: `PullParameterTests.CrossProjectIntegration` then fails, the consuming project
resolving nothing and the transitive aspect silently not applying. The identity of an introduced declaration is not
settled at the moment the advice runs, so making it durable has to happen later than that. That is a change of design
and is not attempted here.

## Testing

`MemoryLeakAssert.RetainedThrough` records a retention that is known and tracked but not yet fixed. Asserting liveness
alone would hold whether the documented route retains the object or something else does, and would go on holding after
that route was removed, so the assertion now requires the retention chain, which `RetentionPathFinder` already computes
for failures, to pass through a named type. The two controls on this branch, for the transitive aspect instance above
and for the non-durable extension payload, therefore fail in both directions that matter: when the defect is fixed,
which is the signal to replace the call with `Collected`, and when the object is retained for a different reason than
the one written down.

## Residuals, and three claims of mine that were wrong

`Metalama.Framework/docs/design-time-memory.md` is where the state of this work lives, because a pull request
description is not where the next person to work on it will look. It records what is open, what was positively
established as clean, and what was never examined.

Three conclusions I had recorded were subsequently disproved, and all three are kept, rewritten as the measurement, so
that the same wrong conclusion is not reached again from the same reading of the same code:

- **`WithCancellation` does not accumulate.** `Task.WhenAny` removes its continuation from the task that did not win.
  Measured on a task that is never completed, the count is the same small constant after 10, 100 and 1000 cancelled
  waits, for both implementations in use.
- **`TransitiveManifestDeserializationCache` is invalidated.** The wholesale replacement in `EnsureBoundTo` is not a
  substitute for missing eviction, it *is* the invalidation, keyed on the consuming project's `CompileTimeProject`.
- **`ToDurable()` cannot apply to an `IntroducedRef`** was false, as set out under #1797 above.

## Verification

Unit tests 2320 on `net8.0` and 2264 on `net48`, aspect tests 2273, all with 0 failures.
`PullParameterTests.CrossProjectIntegration`, which runs on `net48` only, is included in the net48 figure.

Each project this branch modifies builds with 0 errors under `-p:ContinuousIntegrationBuild=true`. Building the whole
`.slnf` that way reports 381 style errors, all of them in the hand-written **test input** files of the aspect, linker
and template suites and none in any file this branch touches; that is a pre-existing condition of the repository.

`develop/2026.1` is merged in, which brings the change that keys the syntax tree index by `DocumentKey` (#1742). It
conflicted in `Update` and additionally broke the skip trace of `SplitResultsByTree` and the accumulation tests, one of
those only under `ContinuousIntegrationBuild`, where the obsolete `PartialCompilation.SyntaxTrees` becomes an error.

Fixes #1796
Fixes #1799
