### PR TITLE
Do not pin the source compilation in the template reflection context (#1808)

### DIFF
--- a/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CacheableTemplateDiscoveryContextProvider.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/CompileTime/CacheableTemplateDiscoveryContextProvider.cs
@@ -8,6 +8,7 @@ using Metalama.Framework.Engine.Services;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Metalama.Framework.Engine.CompileTime;
@@ -16,16 +17,33 @@ namespace Metalama.Framework.Engine.CompileTime;
 /// This class provides a <see cref="ITemplateReflectionContext"/> that can be cached because the <see cref="Compilation"/>
 /// stores only references to <see cref="PortableExecutableReference"/>, and nothing that holds a <see cref="SyntaxTree"/>.
 /// </summary>
+/// <remarks>
+/// <para>
+/// A template declared in a referenced assembly cannot be discovered against the compilation that the compiler supplies,
+/// because that compilation imports only the public and protected members of its references, and a template is
+/// frequently neither. The compilation created here therefore sets <see cref="MetadataImportOptions.All"/>, which cannot
+/// be set on the compilation of the project itself without changing the accessibility rules that apply to the code of
+/// the user.
+/// </para>
+/// <para>
+/// The current instance holds the references and the options of the compilation it is built from, but not the
+/// compilation itself. The compilation of a project is replaced on every keystroke at design time, whereas an instance
+/// of this class is reachable from the pipeline configuration, which is reused across keystrokes, so holding one would
+/// pin a version of the project that the user has already replaced. See issue #1808.
+/// </para>
+/// </remarks>
 internal sealed class CacheableTemplateDiscoveryContextProvider
 {
-    private readonly Compilation _compilation;
+    private readonly ImmutableArray<PortableExecutableReference> _references;
+    private readonly CSharpCompilationOptions? _compilationOptions;
     private readonly Lazy<CacheableContext?> _lazyImpl;
     private readonly ProjectServiceProvider _serviceProvider;
     private bool _mustEnlargeVisibility;
 
     public CacheableTemplateDiscoveryContextProvider( Compilation compilation, in ProjectServiceProvider serviceProvider )
     {
-        this._compilation = compilation;
+        this._references = compilation.References.OfType<PortableExecutableReference>().ToImmutableArray();
+        this._compilationOptions = (CSharpCompilationOptions?) compilation.Options.WithMetadataImportOptions( MetadataImportOptions.All );
         this._serviceProvider = serviceProvider;
 
         this._lazyImpl = new Lazy<CacheableContext?>( this.CreateContext );
@@ -39,10 +57,10 @@ internal sealed class CacheableTemplateDiscoveryContextProvider
         {
             Compilation compilation = CSharpCompilation.Create(
                 nameof(CacheableTemplateDiscoveryContextProvider),
-                references: this._compilation.References.OfType<PortableExecutableReference>(),
-                options: (CSharpCompilationOptions?) this._compilation.Options.WithMetadataImportOptions( MetadataImportOptions.All ) );
+                references: this._references,
+                options: this._compilationOptions );
 
-            return new CacheableContext( compilation.GetCompilationContext(), this );
+            return new CacheableContext( compilation.GetCompilationContext(), this._serviceProvider );
         }
         else
         {
@@ -56,18 +74,27 @@ internal sealed class CacheableTemplateDiscoveryContextProvider
 
     private sealed class CacheableContext : ITemplateReflectionContext
     {
-        private readonly CacheableTemplateDiscoveryContextProvider _parent;
         private readonly Lazy<CompilationModel> _compilationModel;
 
-        public CacheableContext( CompilationContext compilationContext, CacheableTemplateDiscoveryContextProvider parent )
+        /// <summary>
+        /// Initializes a new instance of the <see cref="CacheableContext"/> class.
+        /// </summary>
+        /// <remarks>
+        /// The service provider is passed rather than the <see cref="CacheableTemplateDiscoveryContextProvider"/> that
+        /// creates the instance, and is captured directly by the closure below, so that neither the instance nor the
+        /// closure reaches the provider. That is what keeps the current instance cacheable in the sense stated by
+        /// <see cref="IsCacheable"/>.
+        /// </remarks>
+        public CacheableContext( CompilationContext compilationContext, in ProjectServiceProvider serviceProvider )
         {
-            this._parent = parent;
             this.CompilationContext = compilationContext;
+
+            var capturedServiceProvider = serviceProvider;
 
             this._compilationModel = new Lazy<CompilationModel>(
                 () => CompilationModel.CreateInitialInstance(
-                    new ProjectModel( compilationContext.Compilation, parent._serviceProvider ),
-                    this.Compilation,
+                    new ProjectModel( compilationContext.Compilation, capturedServiceProvider ),
+                    compilationContext.Compilation,
                     new CompilationModelOptions( true ),
                     "CacheableTemplateDiscoveryContextProvider" ) );
         }
@@ -80,6 +107,6 @@ internal sealed class CacheableTemplateDiscoveryContextProvider
 
         public bool IsCacheable => true;
 
-        public override string ToString() => $"CacheableContext EnlargedVisibility={this._parent._mustEnlargeVisibility}";
+        public override string ToString() => nameof(CacheableContext);
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/UserCodeRetentionPolicy.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Engine/Pipeline/UserCodeRetentionPolicy.cs
@@ -166,6 +166,15 @@ internal sealed class UserCodeRetentionPolicy
             case CompileTimeProject:
             case CompileTimeDomain:
 
+            // A cacheable template reflection context owns the compilation against which the templates of a referenced
+            // assembly are reflected. That compilation has no syntax tree and only portable executable references, so
+            // the engine keeps it deliberately, for the whole session. A fabric reaches it through the template class of
+            // its own aspect, therefore descending into it would report a compilation that the user did not create and
+            // cannot release, and would name the fabric as the cause. The compilation context of the source compilation
+            // also implements this interface, but it is classified as pinning and is reported before this method is
+            // consulted.
+            case ITemplateReflectionContext:
+
             // A logger is process-wide infrastructure. Nothing reached through one is a retention that the owner of the
             // chain could act upon, and the graph behind it is unbounded: in a test host it reaches the runner, and
             // through the runner every other test in the process.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TemplateReflectionContextMemoryLeakTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/DesignTime/Pipeline/MemoryLeaks/TemplateReflectionContextMemoryLeakTests.cs
@@ -1,0 +1,178 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Engine.CompileTime;
+using Metalama.Testing.UnitTesting;
+using Microsoft.CodeAnalysis;
+using System;
+using System.Runtime.CompilerServices;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace Metalama.Framework.Tests.UnitTests.DesignTime.Pipeline.MemoryLeaks;
+
+/// <summary>
+/// Tests that the cacheable template reflection context, and the provider that creates it, do not retain the
+/// compilation they were derived from.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A template declared in a referenced assembly cannot be discovered against the compilation that Roslyn supplies,
+/// because that compilation imports only the public and protected members of its references, and a template is
+/// frequently neither. <see cref="CacheableTemplateDiscoveryContextProvider"/> therefore creates a compilation of its
+/// own, with <c>MetadataImportOptions.All</c> and no syntax tree, and template discovery runs against that one.
+/// </para>
+/// <para>
+/// That synthetic compilation is what the word "cacheable" refers to: it holds only
+/// <see cref="PortableExecutableReference"/> instances, whose symbols belong to a reference manager that Roslyn shares
+/// between compilations, so it is independent of any version of the project and may be kept for a whole design-time
+/// session. The source compilation is a different matter. It is an input of the construction and nothing more, yet the
+/// provider stores it, and both the provider and the context it creates are reachable from
+/// <c>AspectPipelineConfiguration</c>, which is reused across keystrokes. See issue #1808.
+/// </para>
+/// </remarks>
+public sealed class TemplateReflectionContextMemoryLeakTests : UnitTestClass
+{
+    public TemplateReflectionContextMemoryLeakTests( ITestOutputHelper logger ) : base( logger ) { }
+
+    private const string _code = """
+                                 public class C
+                                 {
+                                     public int Method() => 42;
+                                 }
+                                 """;
+
+    /// <summary>
+    /// Verifies that the provider releases the source compilation once it has created the context.
+    /// </summary>
+    /// <remarks>
+    /// This is the path that <c>CompileTimeProject</c> follows: it holds the provider rather than the context, because
+    /// <c>CompileTimeProject.TemplateReflectionContext</c> resolves through it on every call, and a
+    /// <c>CompileTimeProject</c> is reachable from the pipeline configuration both directly and through the
+    /// compile-time project repository.
+    /// </remarks>
+    [Fact]
+    public void Provider_DoesNotRetainTheSourceCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var provider = CreateProvider( testContext, out var sourceCompilation );
+
+        // Forcing the creation of the context is what the pipeline does, and it is the point after which the source
+        // compilation is no longer needed for anything.
+        Assert.NotNull( provider.GetTemplateDiscoveryContext() );
+
+        MemoryLeakAssert.Collected(
+            sourceCompilation,
+            "The compilation from which the cacheable template reflection context was derived",
+            ("provider", provider) );
+    }
+
+    /// <summary>
+    /// Verifies that the context itself releases the source compilation.
+    /// </summary>
+    /// <remarks>
+    /// This is the path that <c>TemplateClass</c> follows. <c>TemplateClass</c> stores the context only when
+    /// <see cref="ITemplateReflectionContext.IsCacheable"/> is <c>true</c>, precisely so that the pipeline
+    /// configuration does not retain a compilation, and that precaution is defeated if the cacheable context reaches
+    /// the source compilation through the provider that created it.
+    /// </remarks>
+    [Fact]
+    public void CacheableContext_DoesNotRetainTheSourceCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var context = CreateContext( testContext, out var sourceCompilation );
+
+        Assert.True( context.IsCacheable );
+
+        MemoryLeakAssert.Collected(
+            sourceCompilation,
+            "The compilation from which the cacheable template reflection context was derived",
+            ("context", context) );
+    }
+
+    /// <summary>
+    /// Verifies that the compilation model that the context builds for template reflection does not reach the source
+    /// compilation either.
+    /// </summary>
+    /// <remarks>
+    /// The model is built lazily, so a test that never asks for it leaves a closure unevaluated and does not state
+    /// anything about what that closure captures. The pipeline evaluates it as soon as an aspect declares advice, and
+    /// the model then survives for as long as the context does.
+    /// </remarks>
+    [Fact]
+    public void CacheableContextWithCompilationModel_DoesNotRetainTheSourceCompilation()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var context = CreateContext( testContext, out var sourceCompilation );
+
+        // The cacheable implementation ignores this argument and reflects templates against its own compilation, so
+        // passing no source compilation keeps the test free of any compilation other than the one under examination.
+        var compilationModel = context.GetCompilationModel( null! );
+
+        Assert.NotNull( compilationModel );
+
+        MemoryLeakAssert.Collected(
+            sourceCompilation,
+            "The compilation from which the cacheable template reflection context was derived",
+            ("context", context),
+            ("compilationModel", compilationModel) );
+    }
+
+    /// <summary>
+    /// Verifies that the synthetic compilation is the one against which templates are reflected, and that it carries
+    /// the metadata import options without which the non-public templates of a referenced assembly are invisible.
+    /// </summary>
+    /// <remarks>
+    /// The other tests of this class state what the context must not retain. This one states what it must be, so that
+    /// a change that satisfied them by not creating the synthetic compilation at all would still fail.
+    /// </remarks>
+    [Fact]
+    public void CacheableContext_UsesASyntheticCompilationThatImportsAllMetadata()
+    {
+        using var testContext = this.CreateTestContext();
+
+        var context = CreateContext( testContext, out _ );
+
+        Assert.Empty( context.Compilation.SyntaxTrees );
+        Assert.All( context.Compilation.References, reference => Assert.IsAssignableFrom<PortableExecutableReference>( reference ) );
+        Assert.NotEmpty( context.Compilation.References );
+        Assert.Equal( MetadataImportOptions.All, context.Compilation.Options.MetadataImportOptions );
+    }
+
+    /// <summary>
+    /// Creates a provider over a fresh compilation and returns a weak reference to that compilation.
+    /// </summary>
+    /// <remarks>
+    /// The compilation is never returned by a strong reference, and the method is not inlinable, so that the local
+    /// variable that holds it belongs to a stack frame that no longer exists when the caller resumes. A debug build
+    /// keeps every local alive until the end of the method that declares it, therefore a test that created the
+    /// compilation in its own body would retain it whatever the product code does.
+    /// </remarks>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static CacheableTemplateDiscoveryContextProvider CreateProvider( TestContext testContext, out WeakReference sourceCompilation )
+    {
+        var compilation = testContext.CreateCSharpCompilation( _code );
+
+        var provider = new CacheableTemplateDiscoveryContextProvider( compilation, testContext.ServiceProvider );
+
+        // Without this call the provider concludes that no reference contains compile-time code and returns no
+        // context at all, because the source compilation is then sufficient for template discovery.
+        provider.OnPortableExecutableReferenceDiscovered();
+
+        sourceCompilation = new WeakReference( compilation );
+
+        return provider;
+    }
+
+    /// <summary>
+    /// Creates a cacheable context over a fresh compilation and returns a weak reference to that compilation, without
+    /// retaining the provider.
+    /// </summary>
+    [MethodImpl( MethodImplOptions.NoInlining )]
+    private static ITemplateReflectionContext CreateContext( TestContext testContext, out WeakReference sourceCompilation )
+        => CreateProvider( testContext, out sourceCompilation ).GetTemplateDiscoveryContext()!;
+}

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Fabrics/UserCodeRetentionPolicyTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Fabrics/UserCodeRetentionPolicyTests.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Engine.CodeModel;
+using Metalama.Framework.Engine.CompileTime;
 using Metalama.Framework.Engine.Pipeline;
 using Metalama.Framework.Engine.Utilities.ObjectGraph;
 using Metalama.Testing.UnitTesting;
@@ -178,6 +179,47 @@ public sealed class UserCodeRetentionPolicyTests : UnitTestClass
         Assert.True(
             visited.Count < 100,
             $"The walk visited {visited.Count} objects from a single delegate, which means it escaped through a runtime internal." );
+    }
+
+    [Fact]
+    public void TemplateReflectionContext_IsABoundary()
+    {
+        // The cacheable template reflection context owns the compilation against which the templates of a referenced
+        // assembly are reflected. That compilation has no syntax tree and only portable executable references, so the
+        // framework keeps it deliberately, for the whole session. A fabric reaches it through the template class of its
+        // own aspect, therefore a walk that descended into it would report a compilation the user did not create and
+        // cannot release, and would name the fabric as the cause.
+        using var testContext = this.CreateTestContext();
+
+        var provider = new CacheableTemplateDiscoveryContextProvider(
+            testContext.CreateCSharpCompilation( "class C { }" ),
+            testContext.ServiceProvider );
+
+        // Without this call the provider concludes that no reference contains compile-time code and creates no context.
+        provider.OnPortableExecutableReferenceDiscovered();
+
+        var context = provider.GetTemplateDiscoveryContext()!;
+
+        Assert.True( UserCodeRetentionPolicy.IsBoundary( context ) );
+        Assert.Empty( FindRetentions( new Holder { Value = context } ) );
+    }
+
+    [Fact]
+    public void SourceCompilationContext_IsStillReported()
+    {
+        // The pair of the case above, and the reason why the boundary is safe: the compilation context of the source
+        // compilation also implements the template reflection context interface, but it pins a compilation the user
+        // does edit, so it must keep being reported.
+        using var testContext = this.CreateTestContext();
+        var compilationModel = testContext.CreateCompilationModel( "class C { }" );
+        var compilationContext = compilationModel.CompilationContext;
+
+        Assert.IsAssignableFrom<ITemplateReflectionContext>( compilationContext );
+        Assert.True( UserCodeRetentionPolicy.IsPinning( compilationContext ) );
+
+        var finding = Assert.Single( FindRetentions( new Holder { Value = compilationContext } ) );
+
+        Assert.Same( compilationContext, finding.Node.Object );
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

`CacheableTemplateDiscoveryContextProvider` builds a synthetic compilation with `MetadataImportOptions.All` and no syntax trees, because the templates of a referenced assembly are frequently non-public and Roslyn does not otherwise materialise them. That synthetic compilation is genuinely cacheable and is not the problem. The problem is the **source** compilation, which is only an input to the construction yet was stored for the lifetime of the provider, pinning a version of the project that the user had already replaced.

- The provider no longer holds a `Compilation` at all. It captures the two things `CreateContext` consumes, the `PortableExecutableReference`s and the options carrying `MetadataImportOptions.All`. This was preferred over clearing the field after the lazy is forced, because it makes the invariant structural: the type cannot reach a compilation even when the context is never created.
- `CacheableContext` receives the `ProjectServiceProvider` instead of its parent, captures it directly in the closure that builds the compilation model, and no longer reads the parent's flag in `ToString()`. The `_parent` field is gone.
- `UserCodeRetentionPolicy.IsBoundary` now stops at `ITemplateReflectionContext`, alongside `CompileTimeProject`, `CompileTimeDomain` and `ServiceProvider`. A fabric reaches the context through the template class of its own aspect, so without the boundary `UserCodeRetentionAnalyzer` reports the compilation the engine deliberately keeps and names the fabric as the cause. This remains necessary after the fix above, because the synthetic compilation is still a `Compilation`.

Two retention paths reached the source compilation from the long-lived `AspectPipelineConfiguration`. The issue describes the first; the second is not mentioned there and would have survived the fix proposed in it:

```
BoundAspectClasses -> AspectClass -> TemplateClass._templateReflectionContext
  -> CacheableContext._parent -> provider._compilation

CompileTimeProject / CompileTimeProjectRepository
  -> CompileTimeProject._cacheableTemplateDiscoveryContextProvider -> _compilation
```

## Tests

Written before the fixes and confirmed to fail for the expected reason, with `RetentionPathFinder` naming both chains above.

- `TemplateReflectionContextMemoryLeakTests`: the provider, the context, and the lazily built compilation model must each release the source compilation. A fourth test pins down what the synthetic compilation must be (no syntax trees, portable executable references only, `MetadataImportOptions.All`), so that a change satisfying the other three by not building it would still fail.
- `UserCodeRetentionPolicyTests.TemplateReflectionContext_IsABoundary`, paired with `SourceCompilationContext_IsStillReported`. The compilation context of the source compilation implements the same interface, and the pair guards that the new boundary does not silence it: it is classified as pinning and is reported before `IsBoundary` is consulted.

## Known residual, not addressed here

The synthetic compilation inherits the source `CompilationOptions`, whose `SyntaxTreeOptionsProvider` can hold a dictionary keyed by `SyntaxTree`. If the design-time host supplies such a provider, the synthetic compilation would pin those trees. This behaviour is unchanged by this PR, the previous code passed the same options object, and the tests cannot detect it because `TestContext` builds plain options with no provider. `WithSyntaxTreeOptionsProvider` is not public, so clearing it would mean not inheriting the options at all, which is a larger change than this issue warrants.

## Issues Fixed

Fixes #1808 - the cacheable template reflection context pins the source compilation through its parent.
