### PR TITLE
Move the durable and immutable contracts to IIncrementalObject

### DIFF
--- a/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DependencyInjectionFrameworkRegistration.cs
+++ b/Metalama.Extensions/src/Metalama.Extensions.DependencyInjection/Implementation/DependencyInjectionFrameworkRegistration.cs
@@ -5,7 +5,6 @@
 using JetBrains.Annotations;
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Options;
-using Metalama.Framework.Utilities;
 using System;
 
 namespace Metalama.Extensions.DependencyInjection.Implementation;
@@ -13,10 +12,8 @@ namespace Metalama.Extensions.DependencyInjection.Implementation;
 /// <summary>
 /// Represents a registration of a <see cref="IDependencyInjectionFramework"/>.
 /// </summary>
-[Durable]
 [CompileTime]
 [PublicAPI]
-[ImmutableType]
 public sealed class DependencyInjectionFrameworkRegistration : IIncrementalKeyedCollectionItem<Type>
 {
     /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework.Analyzers/WellKnownImmutableTypes.cs
+++ b/Metalama.Framework/src/Metalama.Framework.Analyzers/WellKnownImmutableTypes.cs
@@ -192,18 +192,6 @@ namespace Metalama.Framework.Analyzers.Immutability
             // verifies the claim instead of taking it on trust.
             // ----------------------------------------------------------------------------------------------------
 
-            // Logically immutable: every mutator returns a new instance through Create, and the type is already
-            // [Durable]. It cannot be written in an immutable style, and the reason is structural rather than
-            // accidental. Its serializer derives from ReferenceTypeSerializer<T>, which splits construction from
-            // field assignment -- CreateInstance then DeserializeFields -- so that a cycle in an object graph can be
-            // broken. A field that DeserializeFields restores therefore cannot be readonly. The second writeable
-            // field is a memoized Count, marked [NonCompileTimeSerialized] for the same reason it exists.
-            //
-            // This is the general case, not one type: no ICompileTimeSerializable type with a hand-written
-            // ReferenceTypeSerializer can satisfy the read-only rule, and IAspect derives from
-            // ICompileTimeSerializable. See immutability-FINDINGS-TODO.md.
-            Transparent( "Metalama.Framework.Options.IncrementalKeyedCollection`2" );
-
             Immutable( "Metalama.Framework.Code.IRef" );
             Immutable( "Metalama.Framework.Code.IRef`1" );
             Immutable( "Metalama.Framework.Code.IDurableRef" );

--- a/Metalama.Framework/src/Metalama.Framework/Options/IHierarchicalOptions.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Options/IHierarchicalOptions.cs
@@ -5,7 +5,6 @@
 using Metalama.Framework.Code;
 using Metalama.Framework.Fabrics;
 using Metalama.Framework.Serialization;
-using Metalama.Framework.Utilities;
 
 namespace Metalama.Framework.Options;
 
@@ -64,8 +63,6 @@ namespace Metalama.Framework.Options;
 /// <seealso cref="IIncrementalObject"/>
 /// <seealso href="@exposing-options"/>
 /// <seealso href="@aspect-configuration"/>
-[Durable]
-[ImmutableType]
 public interface IHierarchicalOptions : IIncrementalObject, ICompileTimeSerializable
 {
     /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework/Options/IIncrementalObject.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Options/IIncrementalObject.cs
@@ -3,6 +3,7 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Aspects;
+using Metalama.Framework.Utilities;
 
 namespace Metalama.Framework.Options;
 
@@ -34,6 +35,8 @@ namespace Metalama.Framework.Options;
 /// <seealso href="@exposing-options"/>
 /// <seealso href="@configuration-custom-merge"/>
 [CompileTime]
+[Durable]
+[ImmutableType]
 public interface IIncrementalObject
 {
     /// <summary>

--- a/Metalama.Framework/src/Metalama.Framework/Options/IncrementalHashSet{T}.Serializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Options/IncrementalHashSet{T}.Serializer.cs
@@ -26,7 +26,9 @@ public partial class IncrementalHashSet<T>
 
         public override void DeserializeFields( IncrementalHashSet<T> obj, IArgumentsReader initializationArguments )
         {
+#pragma warning disable LAMA0887
             obj._dictionary = initializationArguments.GetValue<ImmutableDictionary<T, bool>>( "items" )!;
+#pragma warning restore LAMA0887
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Options/IncrementalHashSet{T}.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Options/IncrementalHashSet{T}.cs
@@ -170,7 +170,9 @@ public partial class IncrementalHashSet<T> : IIncrementalObject, IReadOnlyCollec
     /// <value>
     /// The count of items that are marked as added (not removed) in this incremental hash set layer.
     /// </value>
+#pragma warning disable LAMA0887
     public int Count => this._count ??= this._dictionary.Count( x => x.Value );
+#pragma warning restore LAMA0887
 
     /// <summary>
     /// Gets a value indicating whether this collection layer is empty.

--- a/Metalama.Framework/src/Metalama.Framework/Options/IncrementalKeyedCollection{TKey,TValue}.Serializer.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Options/IncrementalKeyedCollection{TKey,TValue}.Serializer.cs
@@ -31,7 +31,9 @@ public partial class IncrementalKeyedCollection<TKey, TValue>
 
         public override void DeserializeFields( IncrementalKeyedCollection<TKey, TValue> obj, IArgumentsReader initializationArguments )
         {
+#pragma warning disable LAMA0887
             obj._dictionary = initializationArguments.GetValue<ImmutableDictionary<TKey, Item>>( "items" )!;
+#pragma warning restore LAMA0887
         }
     }
 }

--- a/Metalama.Framework/src/Metalama.Framework/Options/IncrementalKeyedCollection{TKey,TValue}.cs
+++ b/Metalama.Framework/src/Metalama.Framework/Options/IncrementalKeyedCollection{TKey,TValue}.cs
@@ -4,7 +4,6 @@
 
 using JetBrains.Annotations;
 using Metalama.Framework.Serialization;
-using Metalama.Framework.Utilities;
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Immutable;
@@ -45,7 +44,6 @@ namespace Metalama.Framework.Options;
 /// <seealso cref="IIncrementalKeyedCollectionItem{TKey}"/>
 /// <seealso href="@exposing-options"/>
 [PublicAPI]
-[Durable]
 public partial class IncrementalKeyedCollection<TKey, TValue> : IIncrementalObject, IReadOnlyCollection<TValue>, ICompileTimeSerializable
     where TKey : notnull
     where TValue : class, IIncrementalKeyedCollectionItem<TKey>
@@ -60,7 +58,10 @@ public partial class IncrementalKeyedCollection<TKey, TValue> : IIncrementalObje
     public static IncrementalKeyedCollection<TKey, TValue> Empty { get; } = new( ImmutableDictionary<TKey, Item>.Empty );
 
     private readonly bool _clear;
+    
+#pragma warning disable LAMA0882
     private ImmutableDictionary<TKey, Item> _dictionary;
+#pragma warning restore LAMA0882
 
     [NonCompileTimeSerialized]
     private int? _count;
@@ -212,7 +213,9 @@ public partial class IncrementalKeyedCollection<TKey, TValue> : IIncrementalObje
     /// <value>
     /// The count of items that are enabled (not removed) in this incremental keyed collection layer.
     /// </value>
+#pragma warning disable LAMA0887
     public int Count => this._count ??= this._dictionary.Count( i => i.Value.IsEnabled );
+#pragma warning restore LAMA0887
 
     /// <summary>
     /// Gets a value indicating whether this collection layer is empty.

--- a/Metalama.Framework/src/tests/Metalama.Framework.Analyzers.Tests/OptionsCollectionTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Analyzers.Tests/OptionsCollectionTests.cs
@@ -1,0 +1,76 @@
+// Copyright (c) 2020-2025 SharpCrafters s.r.o. and contributors.
+// SharpCrafters s.r.o. licenses this file to you under either the MIT license or a proprietary license, depending on the repository from which it was obtained.
+// Refer to LICENSE.md in the repository root for complete details.
+
+using Metalama.Framework.Options;
+using Xunit;
+
+namespace Metalama.Framework.Analyzers.Tests;
+
+/// <summary>
+/// The source of the fragment that both test classes below analyze. It is the shape that an options class of a
+/// consuming repository has: a class implementing <c>IHierarchicalOptions</c>, whose properties are the two
+/// incremental collections of the framework, and a keyed-collection item.
+/// </summary>
+/// <remarks>
+/// No type of the fragment carries a contract attribute. Both contracts reach every type of it from
+/// <see cref="IIncrementalObject"/>, so an attribute here would be redundant and reported as such.
+/// </remarks>
+internal static class OptionsCollectionCode
+{
+    public const string Options = """
+                                  using Metalama.Framework.Options;
+
+                                  class Library : IIncrementalKeyedCollectionItem<string>
+                                  {
+                                      public Library( string name ) { this.Name = name; }
+
+                                      public string Name { get; }
+
+                                      string IIncrementalKeyedCollectionItem<string>.Key => this.Name;
+
+                                      public object ApplyChanges( object changes, in ApplyChangesContext context ) => changes;
+                                  }
+
+                                  class MyOptions : IHierarchicalOptions
+                                  {
+                                      public IncrementalHashSet<string> Included { get; init; } = IncrementalHashSet.Empty<string>();
+
+                                      public IncrementalKeyedCollection<string, Library> Libraries { get; init; }
+                                          = IncrementalKeyedCollection.Empty<string, Library>();
+
+                                      public object ApplyChanges( object changes, in ApplyChangesContext context ) => this;
+                                  }
+                                  """;
+}
+
+/// <summary>
+/// Tests that an options class storing the incremental collections of the framework satisfies the durable contract
+/// that <see cref="IIncrementalObject"/> imposes on it.
+/// </summary>
+/// <remarks>
+/// <see cref="IncrementalHashSet{T}"/> reached no contract before the marker moved to
+/// <see cref="IIncrementalObject"/>, so every options class that had a property of that type was reported. No type
+/// of this repository has such a property, which is why the omission was found by a consuming repository.
+/// </remarks>
+public sealed class DurableOptionsCollectionTests : DurableAnalyzerTestBase
+{
+    [Fact]
+    public async Task IncrementalCollectionsOfAnOptionsClass_AreNotReported()
+        => await AssertNoDiagnosticAsync( OptionsCollectionCode.Options );
+}
+
+/// <summary>
+/// Tests that an options class storing the incremental collections of the framework satisfies the immutable contract
+/// that <see cref="IIncrementalObject"/> imposes on it.
+/// </summary>
+/// <remarks>
+/// Both collections are trusted for the type arguments they store, so the verdict of a property is that of its type
+/// arguments.
+/// </remarks>
+public sealed class ImmutableOptionsCollectionTests : ImmutableAnalyzerTestBase
+{
+    [Fact]
+    public async Task IncrementalCollectionsOfAnOptionsClass_AreNotReported()
+        => await AssertNoDiagnosticAsync( OptionsCollectionCode.Options );
+}

--- a/Metalama.Patterns/src/Metalama.Patterns.Caching.Aspects/Configuration/ParameterFilterRegistration.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Caching.Aspects/Configuration/ParameterFilterRegistration.cs
@@ -3,12 +3,9 @@
 // Refer to LICENSE.md in the repository root for complete details.
 
 using Metalama.Framework.Options;
-using Metalama.Framework.Utilities;
 
 namespace Metalama.Patterns.Caching.Aspects.Configuration;
 
-[Durable]
-[ImmutableType]
 internal sealed class ParameterFilterRegistration : IIncrementalKeyedCollectionItem<string>
 {
     private readonly string _name;

--- a/Metalama.Patterns/src/Metalama.Patterns.Wpf/Implementation/NamingConvention/NamingConventionRegistration.cs
+++ b/Metalama.Patterns/src/Metalama.Patterns.Wpf/Implementation/NamingConvention/NamingConventionRegistration.cs
@@ -5,13 +5,10 @@
 using Metalama.Framework.Aspects;
 using Metalama.Framework.Options;
 using Metalama.Framework.Serialization;
-using Metalama.Framework.Utilities;
 
 namespace Metalama.Patterns.Wpf.Implementation.NamingConvention;
 
-[Durable]
 [CompileTime]
-[ImmutableType]
 internal sealed class NamingConventionRegistration<T> : IIncrementalKeyedCollectionItem<string>
     where T : class, INamingConvention, ICompileTimeSerializable
 {


### PR DESCRIPTION
## Summary

- Move `[Durable]` and `[ImmutableType]` to `IIncrementalObject`, whose documentation already states that implementations must be immutable. Before this, the markers sat on `IHierarchicalOptions` and on `IncrementalKeyedCollection`, so `IncrementalHashSet<T>` and every implementation of `IIncrementalKeyedCollectionItem<TKey>` reached neither contract.
- Remove the markers that inheritance now makes redundant, on `IHierarchicalOptions`, on both incremental collections, and on `DependencyInjectionFrameworkRegistration`, `ParameterFilterRegistration` and `NamingConventionRegistration`. The redundant-attribute rules report each of them.
- Suppress `LAMA0887` at the four write sites of the two collections. Their serializers derive from `ReferenceTypeSerializer<T>`, which restores fields after `CreateInstance`, so no field can be read-only, and each memoizes its `Count`. `LAMA0882` is suppressed on the one field whose element type is the nested `Item`.
- Remove the `Transparent` entries of `WellKnownImmutableTypes` for the two collections. A type bound by the contract is trusted for the type arguments it stores, which yields the same verdict.
- Add `OptionsCollectionTests`, which compiles the shape that reported: an options class with one property of each incremental collection, plus a keyed-collection item, none carrying an attribute.

## Context

Found by the `Metalama.Community` build, which fails with eight errors on `CosturaOptions` — four `LAMA0870` and four `LAMA0882`, on the two `IncrementalHashSet<string>` properties and the two `IncrementalKeyedCollection` properties. No type of this repository has a property of type `IncrementalHashSet<T>`, so no build here could surface it.

Follow-up to #1871, which added the two contracts (#1829).

## Verification

- `Build.ps1 build` of the whole product: successful, no `LAMA` diagnostic.
- `Metalama.Framework.Analyzers.Tests`: 378 passed. The count drops from 380 because two theory cases are enumerated from the two table entries this removes.
- `Metalama.Community` built against this package with **no change to that repository**: successful, no diagnostic, 42 tests passed. Its eight errors are gone without any attribute added there.