### PR TITLE
Construct the inconsistent line index in tests (#1966)

### DIFF
--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/InconsistentLineIndexSourceText.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/InconsistentLineIndexSourceText.cs
@@ -4,20 +4,24 @@
 
 using Microsoft.CodeAnalysis.Text;
 using System;
+using System.Text;
 using Xunit;
 
 namespace Metalama.Framework.Tests.UnitTests.Utilities
 {
     /// <summary>
-    /// Builds a <see cref="SourceText"/> whose line index does not agree with its content, so that converting a
-    /// <see cref="TextSpan"/> into a <see cref="LinePosition"/> throws <see cref="ArgumentOutOfRangeException"/>.
+    /// A <see cref="SourceText"/> whose line index does not agree with its content, so that converting a position
+    /// after the first line into a <see cref="LinePosition"/> throws <see cref="ArgumentOutOfRangeException"/>.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// Roslyn represents an incremental edit as a <c>ChangedText</c> over a composition of segments of the previous
-    /// text. When the edit replaces the carriage return of a CR LF pair, the line index computed over those segments
-    /// reports, for a position after the edit, a line that starts after that position. The conversion then builds a
-    /// <see cref="LinePosition"/> with a negative character offset and throws.
+    /// This class reproduces a defect of Roslyn. When Roslyn represents an incremental edit as a composition of
+    /// segments of the previous text, the line collection of that composition enumerates the correct line spans, but
+    /// it resolves a position to a line that starts after that position. <see cref="TextLineCollection.GetLinePosition"/>
+    /// then builds a <see cref="LinePosition"/> with a negative character offset and throws. The defect was fixed in
+    /// Roslyn 5.10 by pull request 83000 of the <c>dotnet/roslyn</c> repository, and it is still present in Roslyn
+    /// 5.0, which is the lowest version that the supported platform baseline requires. The state is therefore
+    /// constructed here instead of being obtained from an edit, so that the tests cover it on every Roslyn version.
     /// </para>
     /// <para>
     /// This is the state a document is in at design time when the user types such an edit. Every operation that maps
@@ -25,50 +29,93 @@ namespace Metalama.Framework.Tests.UnitTests.Utilities
     /// attribute, which is what issue #1858 reports.
     /// </para>
     /// </remarks>
-    internal static class InconsistentLineIndexSourceText
+    internal sealed class InconsistentLineIndexSourceText : SourceText
     {
-        /// <summary>
-        /// Returns the given code as a <see cref="SourceText"/> whose line index is inconsistent. The code must use
-        /// CR LF line endings and must remain valid C# after the first CR LF pair is replaced by two line feeds.
-        /// </summary>
-        public static SourceText Create( string codeWithCarriageReturns )
+        private readonly SourceText _text;
+
+        private InconsistentLineIndexSourceText( SourceText text )
         {
-            var carriageReturnIndex = codeWithCarriageReturns.IndexOf( '\r' );
+            this._text = text;
+        }
 
-            Assert.True( carriageReturnIndex >= 0, "The code must use CR LF line endings." );
+        /// <summary>
+        /// Returns the given code as a <see cref="SourceText"/> whose line index is inconsistent. No position of the
+        /// first line is affected, and no position after the first line can be converted into a
+        /// <see cref="LinePosition"/>. The code must contain at least two lines and must end with a line break.
+        /// </summary>
+        public static SourceText Create( string code )
+        {
+            var text = new InconsistentLineIndexSourceText( From( code ) );
 
-            var text = SourceText.From( codeWithCarriageReturns )
-                .WithChanges( new TextChange( new TextSpan( carriageReturnIndex, 1 ), "\n" ) );
+            Assert.True( text.FirstPositionWithoutLineMapping < text.Length, "The code must contain at least two lines." );
 
-            Assert.True(
-                TryFindPositionWithoutLineMapping( text, out _ ),
-                "Roslyn no longer produces an inconsistent line index for this edit. The tests that rely on this "
-                + "helper no longer cover issue #1858 and must be revised." );
+            // A test that relies on this state must fail rather than pass without covering anything, so the state is
+            // verified here instead of being assumed.
+            for ( var position = text.FirstPositionWithoutLineMapping; position < text.Length; position++ )
+            {
+                var positionToTest = position;
+
+                Assert.Throws<ArgumentOutOfRangeException>( () => text.Lines.GetLinePosition( positionToTest ) );
+            }
 
             return text;
         }
 
         /// <summary>
-        /// Determines whether the given text has a position that cannot be converted to a <see cref="LinePosition"/>,
-        /// and returns the first such position.
+        /// Gets the first position that cannot be converted into a <see cref="LinePosition"/>, which is the first
+        /// position after the line break of the first line.
         /// </summary>
-        public static bool TryFindPositionWithoutLineMapping( SourceText text, out int position )
+        private int FirstPositionWithoutLineMapping => this._text.Lines[0].EndIncludingLineBreak;
+
+        /// <inheritdoc />
+        public override char this[ int position ] => this._text[position];
+
+        /// <inheritdoc />
+        public override Encoding? Encoding => this._text.Encoding;
+
+        /// <inheritdoc />
+        public override int Length => this._text.Length;
+
+        /// <inheritdoc />
+        public override void CopyTo( int sourceIndex, char[] destination, int destinationIndex, int count )
+            => this._text.CopyTo( sourceIndex, destination, destinationIndex, count );
+
+        /// <inheritdoc />
+        public override string ToString( TextSpan span ) => this._text.ToString( span );
+
+        /// <inheritdoc />
+        protected override TextLineCollection GetLinesCore() => new LineCollection( this._text.Lines, this.FirstPositionWithoutLineMapping );
+
+        /// <summary>
+        /// A <see cref="TextLineCollection"/> that enumerates the correct lines but resolves every position after the
+        /// first line to the last line of the text.
+        /// </summary>
+        /// <remarks>
+        /// When the text ends with a line break, the last line is empty and starts at the end of the text, so the
+        /// start of the line that this collection returns is greater than the position that was resolved, and
+        /// <see cref="TextLineCollection.GetLinePosition"/> throws. <see cref="Create"/> verifies that the mapping
+        /// does fail for every position after the first line.
+        /// </remarks>
+        private sealed class LineCollection : TextLineCollection
         {
-            for ( position = 0; position <= text.Length; position++ )
+            private readonly TextLineCollection _lines;
+            private readonly int _firstPositionWithoutLineMapping;
+
+            public LineCollection( TextLineCollection lines, int firstPositionWithoutLineMapping )
             {
-                try
-                {
-                    _ = text.Lines.GetLinePosition( position );
-                }
-                catch ( ArgumentOutOfRangeException )
-                {
-                    return true;
-                }
+                this._lines = lines;
+                this._firstPositionWithoutLineMapping = firstPositionWithoutLineMapping;
             }
 
-            position = -1;
+            /// <inheritdoc />
+            public override int Count => this._lines.Count;
 
-            return false;
+            /// <inheritdoc />
+            public override TextLine this[ int index ] => this._lines[index];
+
+            /// <inheritdoc />
+            public override int IndexOf( int position )
+                => position >= this._firstPositionWithoutLineMapping ? this.Count - 1 : this._lines.IndexOf( position );
         }
     }
 }

--- a/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SyntaxProcessingExceptionTests.cs
+++ b/Metalama.Framework/src/tests/Metalama.Framework.Tests.UnitTests/Utilities/SyntaxProcessingExceptionTests.cs
@@ -21,8 +21,7 @@ namespace Metalama.Framework.Tests.UnitTests.Utilities
     {
         /// <summary>
         /// The code that the tests parse. The attribute is on the second line because only the positions after the
-        /// edited line ending have no line mapping in the text returned by
-        /// <see cref="InconsistentLineIndexSourceText"/>.
+        /// first line have no line mapping in the text returned by <see cref="InconsistentLineIndexSourceText"/>.
         /// </summary>
         private const string _code = "// The attribute is on the next line.\r\n[My]\r\nclass Target { }\r\n";
 


### PR DESCRIPTION
## Summary

- `InconsistentLineIndexSourceText` no longer relies on a defect of Roslyn to build a `SourceText` whose line index does not agree with its content. It now derives from `SourceText` and returns a line collection that enumerates the correct lines but resolves every position after the first line to the last line of the text.
- The two tests that depend on that state therefore cover issue #1858 on every Roslyn version, including the versions in which the defect is fixed.
- The helper no longer requires CR LF line endings, and no longer requires the code to remain valid C# after an edit. It verifies that the line mapping does fail for every position after the first line, so a test cannot pass without covering anything.

## Background

The line collection of a Roslyn `CompositeText`, which represents an incremental edit as a composition of segments of the previous text, enumerates the correct line spans but resolves a position to a line that starts after that position. `TextLineCollection.GetLinePosition` then builds a `LinePosition` with a negative character offset and throws `ArgumentOutOfRangeException`. That is the state issue #1858 reports.

The defect was fixed in Roslyn 5.10 by [dotnet/roslyn#83000](https://github.com/dotnet/roslyn/pull/83000). Over 16802 fuzzed pairs of a text and an edit, Roslyn 5.0.0 produced 2471 inconsistent line indexes and Roslyn 5.10.0-1.26365.3 produced none.

The tests were written on `develop/2026.1`, where `RoslynApiMaxVersion` is 5.0.0, and reached `develop/2027.0` through the merge of that branch. The Roslyn 5.10 leg is new in 2027.0, so the tests had never run against a Roslyn in which the defect is fixed.

`RoslynApiMinVersion` is 5.0.0, so a supported design-time analyzer host still carries the defect and issue #1858 remains reachable. The tests are therefore kept on every leg rather than restricted to the Roslyn versions in which the scenario is reachable through an edit.

## Verification

`SyntaxProcessingExceptionTests` and `AttributeDiscoveryTests` pass on the Roslyn 5.0 and Roslyn 5.10 legs, on `net10.0` and on `net48`. Both test projects build without a compiler warning under `-p:ContinuousIntegrationBuild=True`.

## Issues Fixed

Fixes #1966 - Two unit tests fail on Roslyn 5.10 because `InconsistentLineIndexSourceText` can no longer set up the scenario of #1858

🤖 Generated with [Claude Code](https://claude.com/claude-code)