### PR TITLE
Design proposal: type facets in the code model

### DIFF
--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -342,10 +342,11 @@ expression for it.
 
 The member that this calls for is `IMethodBaseInvoker`, declaring the operations that `IMethodInvoker` and
 `IConstructorInvoker` have in common, with `IMethodBase` deriving from it. Creating an instance of a union case
-would then be the invocation of its creation member. That is a story of its own, because it changes `IMethodBase`
-and because the relationship between the three invoker interfaces has to be settled: `IMethod` and `IConstructor`
-already derive from the two specific invokers. It is not part of this proposal, and until it exists a consumer that
-invokes a creation member tests whether it is an `IMethod` or an `IConstructor`.
+would then be the invocation of its creation member. That is a story of its own, issue
+[#1999](https://github.com/metalama/Metalama/issues/1999), because it changes `IMethodBase` and because the
+relationship between the three invoker interfaces has to be settled: `IMethod` and `IConstructor` already derive
+from the two specific invokers. It is not part of this proposal, and until it exists a consumer that invokes a
+creation member tests whether it is an `IMethod` or an `IConstructor`.
 
 ### 2.4. Writing is on builders, not on facets
 
@@ -449,10 +450,12 @@ The flags are the discriminators and the facets are the structure, so they answe
 the same one twice. That is the same relationship that `TypeKind.Delegate` and `TypeKind.Enum` already have with
 their facets.
 
-What does not go on `INamedType` is the structure. Pull request #1991 proposes `IsUnion`, `IsUnionDeclaration` and
-`UnionCaseTypes`. Under this proposal `IsUnion` ships as a flag, and the other two are replaced by `Facets.Union`.
-The recommendation is to hold those two back from #1991 rather than ship them and duplicate them later, because a
-shipped public member cannot be withdrawn.
+What does not go on `INamedType` is the structure. Pull request
+[#1991](https://github.com/metalama/Metalama/pull/1991) proposes `IsUnion`, `IsUnionDeclaration` and
+`UnionCaseTypes`. Under this proposal `IsUnion` ships as a flag, and the other two are replaced by `Facets.Union`,
+which issue [#1941](https://github.com/metalama/Metalama/issues/1941) delivers. The recommendation is to hold those
+two back from #1991 rather than ship them and duplicate them later, because a shipped public member cannot be
+withdrawn.
 
 Both would be wrong as specified there in any case. `UnionCaseTypes` is documented as empty when
 `IsUnionDeclaration` is false, which describes the current implementation from syntax rather than the contract:
@@ -472,7 +475,7 @@ the elements of a tuple are a view over the fields of the underlying `ValueTuple
 that describe the structure of a type that a type expression forms, that are reached by a type test, and that are
 constructed at one site. Section 1.3 states why that mechanism is correct for that family and does not extend to a
 declared type. `ITupleType` and `ITupleElement` move to `Metalama.Framework.Code.Types` so that they sit with that
-family.
+family, which is issue [#1998](https://github.com/metalama/Metalama/issues/1998).
 
 `ITypeFacetCollection` has no tuple property in this proposal, and `INamedType.IsTuple` is the flag. An
 `ITupleFacet` declaring the members of `ITupleType` may be added later for completeness, which would make the
@@ -506,24 +509,45 @@ The delegate facet is implemented first, and deliberately. It requires no C# 15,
 language version, and it has about fifteen call sites to convert, so the shape is exercised against shipped
 behaviour before anything that cannot be revised is public.
 
-| Pull request | Content | Depends on |
+### 6.1. Reading the facets
+
+| Issue | Content | Blocked by |
 | --- | --- | --- |
-| 1 | `TypeFacetKind`, `ITypeFacet`, `ITypeFacetCollection`, `INamedType.Facets`, `INamedType.IsDelegate`, `IDelegateFacet`. Conversion of the `Invoke` lookups and of `IEvent.Signature`. | — |
-| 2 | `IEnumFacet` and `INamedType.IsEnum`. | 1 |
-| 3 | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | 1 |
-| 4 | `INamedType.IsTuple`, and the move of `ITupleType` and `ITupleElement` to `Metalama.Framework.Code.Types`. Takes the `breaking` label. | — |
-| 5 | `IUnionFacet`, `IUnionCase`, `UnionKind`, `INamedType.IsUnion`. | 1, and the move to the stable Roslyn |
-| 6 | `IUnionBuilder`, and the builder shapes of the other kinds. | 5, and the union introduction story |
+| [#1995](https://github.com/metalama/Metalama/issues/1995) | `TypeFacetKind`, `ITypeFacet`, `ITypeFacetCollection`, `INamedType.Facets`, `INamedType.IsDelegate`, `IDelegateFacet`. Conversion of the `Invoke` lookups and of `IEvent.Signature`. | nothing |
+| [#1996](https://github.com/metalama/Metalama/issues/1996) | `IEnumFacet` and `INamedType.IsEnum`. | #1995 |
+| [#1997](https://github.com/metalama/Metalama/issues/1997) | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | #1995 |
+| [#1998](https://github.com/metalama/Metalama/issues/1998) | `INamedType.IsTuple`, and the move of `ITupleType` and `ITupleElement` to `Metalama.Framework.Code.Types`. Carries the `breaking` label. | nothing |
+| [#1941](https://github.com/metalama/Metalama/issues/1941) | `IUnionFacet`, `IUnionCase`, `UnionKind`, `INamedType.IsUnion`. The union facet is delivered by the existing union code model story, not by an issue of its own. | #1995, and the move to the stable Roslyn |
+| [#1999](https://github.com/metalama/Metalama/issues/1999) | An invoker on `IMethodBase`, described in section 2.3. | nothing |
+| [#2000](https://github.com/metalama/Metalama/issues/2000) | Conceptual and reference documentation of the facets. | #1995, and completed after the other facets exist |
 
-`IMethodBaseInvoker` is a story of its own, described in section 2.3, and it is not one of these pull requests.
+### 6.2. Introducing the types
 
-Pull request 1 changes one shipped behaviour: `EligibilityRuleFactory` currently throws `InvalidOperationException`
+The four issues below are the type introduction backlog, which predates this proposal. They are named here because
+this document decides the shape of their builder interfaces, in section 2.4, and because each of them replaces
+implementation guideline 5 for its own kind: the type that the builder produces has to report the facet of that
+kind. They are not C# 15 work, they are not gated on the move to the stable Roslyn, and their milestone is a
+separate decision.
+
+| Issue | Content | Blocked by |
+| --- | --- | --- |
+| [#869](https://github.com/metalama/Metalama/issues/869) | Introduce a struct. A struct has no facet, so this issue adds no builder interface. It carries the machinery that the other three need, which is emitting a type kind other than `class` at build time and at design time. | nothing |
+| [#865](https://github.com/metalama/Metalama/issues/865) | Introduce a delegate, with `IDelegateBuilder`. Every member-introduction operation inherited from `INamedTypeBuilder` throws, because a delegate declaration has no members. | #1995, #869 |
+| [#866](https://github.com/metalama/Metalama/issues/866) | Introduce an enum, with `IEnumBuilder`. | #1996, #869 |
+| [#867](https://github.com/metalama/Metalama/issues/867) | Introduce a record, with `IRecordBuilder`. The largest of the four, because the synthesized members have to exist as builders. | #1997, #869 |
+
+`IUnionBuilder` belongs to the union introduction stories S-29 and S-30 of
+[`../2027.0/user-stories/README.md`](../2027.0/user-stories/README.md), and not to an issue of its own.
+
+### 6.3. What the first issue measures
+
+Issue #1995 changes one shipped behaviour: `EligibilityRuleFactory` currently throws `InvalidOperationException`
 when the type of an event is not a well-formed delegate, and it returns `false` after the conversion.
 
-Pull request 1 is also the acceptance test of the design. Fourteen of the fifteen call sites assert that the
-`Invoke` method exists, while `Facets.Delegate` is `null` for a malformed type. If several converted sites end up
-asserting that the facet is not `null`, the nullable collection property is the wrong shape for those consumers, and
-the design has to be revised before the union facet is built on it.
+It is also the acceptance test of the design. Fourteen of the fifteen call sites assert that the `Invoke` method
+exists, while `Facets.Delegate` is `null` for a malformed type. If several converted sites end up asserting that the
+facet is not `null`, the nullable collection property is the wrong shape for those consumers, and the design has to
+be revised before the union facet is built on it.
 
 ## 7. Resolved questions
 

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -1,15 +1,16 @@
 # Type facets
 
 This document proposes an addition to the public code model: a uniform way to expose the structure that is specific
-to a kind of named type. It covers delegates, enums, records, tuples and C# 15 unions. It is a design proposal.
-Nothing described here is implemented.
+to a kind of declared named type. It covers delegates, enums, records and C# 15 unions. Section 4.5 explains why it
+does not cover tuples. It is a design proposal. Nothing described here is implemented.
 
 ## 1. The problem
 
 A named type of some kinds carries structure that other named types do not have. A delegate has a signature. An
 enum has an underlying type and a set of members. A record has an equality contract and a set of synthesized
-members. A tuple has elements. A C# 15 union has case types and a `Value` property. The code model exposes that
-structure in four different ways today, and three of them are defective.
+members. A C# 15 union has case types and a `Value` property. The code model exposes that structure in four
+different ways today. Two of them are defective, the third is correct only for a type that a type expression forms,
+and the fourth is the one this proposal replaces.
 
 ### 1.1. A member reached by a string literal
 
@@ -41,30 +42,24 @@ INamedType UnderlyingType { get; }
 
 The caller has to know the kind of the type to know what the property returned.
 
-### 1.3. A derived interface keyed on a type kind
+### 1.3. A derived interface reached by a type test
 
 `ITupleType` derives from `INamedType`, adds `TupleElements`, `TupleLength` and `CreateCreateInstanceExpression`,
-and is reached by a type test. `IExtensionBlock` follows the same pattern. Both have a value of their own in
-`TypeKind`.
+and is reached by a type test. `IArrayType`, `IPointerType`, `IFunctionPointerType` and `IDynamicType` follow the
+same pattern, and so does `IExtensionBlock`.
 
-The mechanism gives correct answers, and the tuple case is the closest existing analogue of the union case. Roslyn
-models a tuple as `INamedTypeSymbol.IsTupleType` plus `TupleElements`, with `TypeKind` remaining `Struct`, which is
-exactly how it models a union as `ITypeSymbol.IsUnion` plus `UnionCaseTypes`. Metalama departed from Roslyn for
-tuples and introduced `TypeKind.Tuple`.
+This mechanism is correct for a type that a type expression forms. Such a type reaches the model through one
+construction path, the type factory, which decides its runtime interface at one site. Section 4.5 keeps the
+mechanism for those types.
 
-The defect is that the mechanism is a second one. The structure of a tuple is reached by a type test, while the
-structure of a delegate, an enum, a record or a union is reached in one of the other three ways, so a consumer has
-to know which kind uses which mechanism. Section 4.5 replaces it for tuples.
-
-The mechanism also does not extend to unions, for two reasons. First, a value `TypeKind.Union` would require a new arm in
-the seventeen switches over `TypeKind` that the analysis in
-[`../2027.0/03-code-model-unions-closed.md`](../2027.0/03-code-model-unions-closed.md) inventoried, and the union
-design depends on a union continuing to behave as a struct. Second, a tuple is constructed and a union is declared.
-A tuple reaches the model through one construction path, `TypeFactory.CreateTupleType`, which can decide to return
-an `ITupleType`. A union reaches the model through source symbols, metadata symbols, generic instantiation,
-builders, introduced types and the design-time partial pipeline, and for the attribute form its identity depends on
-an attribute that Roslyn synthesizes at emit time. Deciding the runtime type of the code model object correctly at
-every one of those sites is not reliable.
+The mechanism does not extend to a declared type, for two reasons. First, a declared type reaches the model through
+source symbols, metadata symbols, generic instantiation, builders, introduced types and the design-time partial
+pipeline. Deciding the runtime type of the code model object correctly at every one of those sites is not reliable,
+and for a union written with the union attribute the identity depends on an attribute that Roslyn synthesizes at
+emit time. Second, the type test is normally paired with a value of `TypeKind`, and a value `TypeKind.Union` would
+require a new arm in the seventeen switches over `TypeKind` that the analysis in
+[`../2027.0/03-code-model-unions-closed.md`](../2027.0/03-code-model-unions-closed.md) inventoried, while the union
+design depends on a union continuing to behave as a struct.
 
 ### 1.4. Flat members on `INamedType`
 
@@ -77,8 +72,8 @@ majority of named types.
 
 ### 2.1. One collection of facets
 
-A facet is the structure that a kind of type has and that other types do not have. A type has a collection of
-facets, which is empty for an ordinary class, struct or interface.
+A facet is the structure that a declared named type has because of its kind, and that other named types do not
+have. A type has a collection of facets, which is empty for an ordinary class, struct or interface.
 
 ```csharp
 // Metalama.Framework/Code/TypeFacetKind.cs
@@ -88,7 +83,6 @@ public enum TypeFacetKind
     Delegate,
     Enum,
     Record,
-    Tuple,
     Union
 }
 ```
@@ -122,8 +116,6 @@ public interface ITypeFacetCollection : IReadOnlyCollection<ITypeFacet>
     IEnumFacet? Enum { get; }
 
     IRecordFacet? Record { get; }
-
-    ITupleFacet? Tuple { get; }
 
     IUnionFacet? Union { get; }
 }
@@ -238,31 +230,6 @@ public interface IRecordFacet : ITypeFacet
 ```
 
 ```csharp
-// Metalama.Framework/Code/ITupleFacet.cs
-[CompileTime]
-public interface ITupleFacet : ITypeFacet
-{
-    /// <summary>
-    /// Gets the elements of the tuple.
-    /// </summary>
-    IReadOnlyList<ITupleElement> TupleElements { get; }
-
-    /// <summary>
-    /// Gets the number of elements in the tuple.
-    /// </summary>
-    int TupleLength { get; }
-
-    /// <summary>
-    /// Creates an expression that creates an instance of the tuple with the specified values.
-    /// </summary>
-    IExpression CreateCreateInstanceExpression( params IEnumerable<IExpression> values );
-}
-```
-
-The members of `ITupleFacet` are those of the existing `ITupleType`. Section 4.5 explains why the proposal
-duplicates them rather than deriving `ITupleType` from `ITypeFacet`.
-
-```csharp
 // Metalama.Framework/Code/IUnionFacet.cs
 [CompileTime]
 public interface IUnionFacet : ITypeFacet
@@ -335,10 +302,9 @@ invoker through the member, and no facet declares an invoker member of its own.
 var call = eventType.Facets.Delegate!.InvokeMethod.With( handler ).Invoke( args );
 ```
 
-A facet declares a method that creates an expression only where no member of the type carries the operation.
-`ITupleFacet.CreateCreateInstanceExpression` is such a method, and it is the precedent, because a tuple is created
-by a syntactic construct and not by calling a member. `IUnionCase.CreateCreateInstanceExpression` exists for the
-same reason: the
+A facet declares a method that creates an expression only where no member of the type carries the operation. The
+precedent is `ITupleType.CreateCreateInstanceExpression`, which exists because a tuple is created by a syntactic
+construct and not by calling a member. `IUnionCase.CreateCreateInstanceExpression` exists for the same reason: the
 creation member differs by form, so the consumer would otherwise have to test whether it is a constructor or a
 static method.
 
@@ -379,26 +345,21 @@ members are not yet resolvable.
 | `INamedType.IsRecord` | Kept. It is shipped, widely used, and cheap. The documentation gains a reference to `Facets.Record`. |
 | `INamedType.UnderlyingType` | Kept. It is shipped and it also serves nullable reference types. `IEnumFacet.UnderlyingType` is the member with one meaning, and the documentation of both says so. |
 | `IEvent.Signature` | Kept, and defined as `Type.Facets.Delegate!.InvokeMethod`. The four duplicate implementations are removed. The member currently has no documentation and gains it. |
-| `ITupleType` | Made obsolete, and kept working. Its members forward to `Facets.Tuple`. See section 4.5. |
-| `ITupleElement` | Kept and unchanged. It is the element type of `ITupleFacet.TupleElements`, and nothing about it is superseded. |
-| `TypeFactory.CreateTupleType` | The return type changes from `ITupleType` to `INamedType`, so that the factory does not return an obsolete type. See section 4.5. |
-| `TypeKind.Tuple` | Kept. See section 4.5. |
+| `ITupleType`, `ITupleElement`, `TypeKind.Tuple`, `TypeFactory.CreateTupleType` | Unchanged. A tuple is not a facet. See section 4.5. |
 | `INamedType.PrimaryConstructor` | Kept. A primary constructor is not specific to records since C# 12, so it does not move to `IRecordFacet`. |
 | `IExtensionBlock` | Unchanged, and deliberately not a facet. See section 4.1. |
 
-`ITupleType` is the only member that this proposal makes obsolete. The change to the return type of
-`TypeFactory.CreateTupleType` is a user-facing break, so the pull request that carries it takes the `breaking`
-label.
+No member is made obsolete by this proposal, and it carries no user-facing breaking change.
 
 ## 4. Decisions
 
 ### 4.1. An extension block is not a facet
 
-A facet describes the structure of a type that a program can use. A tuple is such a type: a variable can be declared
-of it. An extension block is not: it has no usable name, no variable can be declared of it, and it is reached from
-its containing type through `INamedType.ExtensionBlocks`, where it is a member rather than a facet of itself.
-`IExtensionBlock` derives from `INamedType` for the convenience of the implementation, not because an extension
-block is a type in the sense of the language.
+A facet describes the structure of a type that a program can use. An extension block is not such a type: it has no
+usable name, no variable can be declared of it, and it is reached from its containing type through
+`INamedType.ExtensionBlocks`, where it is a member rather than a facet of itself. `IExtensionBlock` derives from
+`INamedType` for the convenience of the implementation, not because an extension block is a type in the sense of the
+language.
 
 ### 4.2. A type may have more than one facet
 
@@ -448,35 +409,29 @@ The counter-argument is that `IsUnion` is the cheap first test, that it is what 
 `type.Facets.Union is not null` is longer to write in a predicate over a collection of types. The proposal accepts
 that cost, on the ground that a second way to ask the same question is the defect this document exists to remove.
 
-### 4.5. The tuple facet is a new interface, and `ITupleType` is made obsolete
+### 4.5. A tuple is not a facet
 
-The alternative is to derive `ITupleType` from `ITypeFacet` and let `ITypeFacetCollection.Tuple` return the type
-itself. That alternative is rejected for two reasons.
+A tuple is not declared. The type `(int X, string Y)` is formed by a type expression at the place where it is used,
+and the element names are attached there. Metalama models it that way: `TupleType` and `TupleTypeImpl` are in
+`CodeModel/Source/ConstructedTypes/`, beside the array, the pointer, the function pointer and the dynamic type, and
+the elements of a tuple are a view over the fields of the underlying `ValueTuple` with the names overridden.
 
-The first is that the tuple would be the only facet that is not a distinct object. Every other facet describes a
-type. A tuple facet obtained that way would be the type, `ITypeFacet.Type` would return the object it was reached
-from, and a consumer that descends from a type into its facets would reach the same object. The interface would have
-one member whose meaning differs from the same member on every other facet.
+`ITupleType` therefore belongs to the family of `IArrayType`, `IPointerType` and `IFunctionPointerType`: interfaces
+that describe the structure of a type that a type expression forms, that are reached by a type test, and that are
+constructed at one site. Section 1.3 states why that mechanism is correct for that family and does not extend to a
+declared type.
 
-The second is that the model would keep two mechanisms for the structure of a tuple, the type test and the
-collection, which is the defect described in section 1.3.
+A facet describes the other thing: the structure that a named type has because of what its declaration says. A
+delegate, an enum, a record and a union are declared. A tuple is not, so `ITupleType`, `ITupleElement`,
+`TypeKind.Tuple` and `TypeFactory.CreateTupleType` are unchanged, and `ITypeFacetCollection` has no tuple property.
 
-`ITupleFacet` therefore declares the three members of `ITupleType`, and `ITupleType` is made obsolete with a
-warning. It keeps deriving from `INamedType`, it keeps its members, and each member forwards to the facet, so code
-written against it compiles with a warning and behaves as before. The release in which the warning becomes an error
-is not decided here.
-
-`TypeFactory.CreateTupleType` returns `ITupleType` today. A factory that returns an obsolete type raises a warning
-at every call site, so the return type changes to `INamedType`. The change is source-compatible for a caller that
-uses `var` or that passes the result where an `IType` or an `INamedType` is expected, and it is a binary break. It
-is a user-facing break and is labelled as one.
-
-`TypeKind.Tuple` is kept. The property `Facets.Tuple is not null` is equivalent to `TypeKind == TypeKind.Tuple`, but
-the same equivalence holds between `Facets.Delegate` and `TypeKind.Delegate`, and between `Facets.Enum` and
-`TypeKind.Enum`. `TypeKind` is the kind discriminator of `IType`, and a facet is the structure of those kinds that
-have structure, so the two answer different questions. Section 4.4 rejects `IsUnion` for a reason that does not
-apply here: a union has no value in `TypeKind`, so `IsUnion` would be a second discriminator invented beside
-`Facets.Union` rather than the one that already exists.
+The cost of this decision is that a consumer that wants the structure of an arbitrary type has to know two
+mechanisms: a type test for a type that a type expression forms, and the facet collection for a declared one. An
+earlier revision of this document proposed the alternative, which is to declare `ITupleFacet` with the members of
+`ITupleType`, to make `ITupleType` obsolete and forward its members to the facet, and to change the return type of
+`TypeFactory.CreateTupleType` to `INamedType`. That alternative removes the second mechanism at the price of a
+user-facing breaking change, sixty-three references to convert inside the repository, and a facet that describes a
+type that nobody declared.
 
 ## 5. Implementation guidelines
 
@@ -510,10 +465,9 @@ behaviour before anything that cannot be revised is public.
 | --- | --- | --- |
 | 1 | `TypeFacetKind`, `ITypeFacet`, `ITypeFacetCollection`, `INamedType.Facets`, `IDelegateFacet`. Conversion of the `Invoke` lookups and of `IEvent.Signature`. | — |
 | 2 | `IEnumFacet`. | 1 |
-| 3 | `ITupleFacet` and `ITypeFacetCollection.Tuple`. `ITupleType` is made obsolete and bridged, and the return type of `TypeFactory.CreateTupleType` changes. Takes the `breaking` label. | 1 |
-| 4 | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | 1 |
-| 5 | `IUnionFacet`, `IUnionCase`, `UnionForm`. | 1, and the move to the stable Roslyn |
-| 6 | `IUnionBuilder`, and the builder shapes of the other kinds. | 5, and the union introduction story |
+| 3 | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | 1 |
+| 4 | `IUnionFacet`, `IUnionCase`, `UnionForm`. | 1, and the move to the stable Roslyn |
+| 5 | `IUnionBuilder`, and the builder shapes of the other kinds. | 4, and the union introduction story |
 
 Pull request 1 changes one shipped behaviour: `EligibilityRuleFactory` currently throws `InvalidOperationException`
 when the type of an event is not a well-formed delegate, and it returns `false` after the conversion.
@@ -537,8 +491,6 @@ the design has to be revised before the union facet is built on it.
 5. Whether the union facet is populated for a union read from a referenced assembly. The compiled form does not
    record the authoring form, so `Form` would report `Attribute` for a type that the author wrote with the `union`
    keyword.
-6. In which release the obsoletion of `ITupleType` becomes an error, and whether the sixty-three references to it
-   inside the repository are converted in the pull request that introduces `ITupleFacet` or over several.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -2,7 +2,7 @@
 
 This document proposes an addition to the public code model: a uniform way to expose the structure that is specific
 to a kind of declared named type. It covers delegates, enums, records and C# 15 unions. Section 4.5 explains why it
-does not cover tuples. It is a design proposal. Nothing described here is implemented.
+does not cover tuples today. It is a design proposal. Nothing described here is implemented.
 
 ## 1. The problem
 
@@ -68,7 +68,15 @@ is what pull request #1991 proposes, continues that pattern. The count grows: th
 `Value` property and the case constructors, which would be two more members. Each one is meaningless for the great
 majority of named types.
 
+The flag itself is not the problem, and section 4.4 keeps the flags. The problem is the structure that follows the
+flag.
+
 ## 2. The public interfaces
+
+The facet types are declared in the namespace `Metalama.Framework.Code.Types`, beside `IArrayType`, `IPointerType`,
+`IFunctionPointerType` and `IDynamicType`, because they describe the structure of a type.
+`ITypeFacetCollection` is declared in `Metalama.Framework.Code.Collections`, beside `IExtensionBlockCollection`,
+because it is a collection.
 
 ### 2.1. One collection of facets
 
@@ -76,22 +84,25 @@ A facet is the structure that a declared named type has because of its kind, and
 have. A type has a collection of facets, which is empty for an ordinary class, struct or interface.
 
 ```csharp
-// Metalama.Framework/Code/TypeFacetKind.cs
+// Metalama.Framework/Code/Types/TypeFacetKind.cs
 [CompileTime]
 public enum TypeFacetKind
 {
+    /// <summary>The type has no facet.</summary>
+    None,
+
     Delegate,
+
     Enum,
+
     Record,
+
     Union
 }
 ```
 
-The enum has no `None` member. A facet that exists has a kind, and the absence of a facet is represented by a `null`
-property of the collection.
-
 ```csharp
-// Metalama.Framework/Code/ITypeFacet.cs
+// Metalama.Framework/Code/Types/ITypeFacet.cs
 [CompileTime]
 public interface ITypeFacet
 {
@@ -137,9 +148,9 @@ The collection follows the precedent of `IExtensionBlockCollection`, which deriv
 Consumer code:
 
 ```csharp
-if ( type.Facets.Union is { } union )
+if ( type.IsUnion )
 {
-    foreach ( var unionCase in union.Cases ) { /* ... */ }
+    foreach ( var unionCase in type.Facets.Union!.Cases ) { /* ... */ }
 }
 
 var returnType = eventType.Facets.Delegate?.InvokeMethod.ReturnType;
@@ -154,8 +165,11 @@ coexist.
 A facet names every member that the compiler synthesizes for that kind of type, so that no consumer has to reach a
 member by a string literal.
 
+Every member of a facet is a lazy expression, cached with `[Memo]`. A consumer that obtains a facet and reads one
+member does not pay for resolving the others.
+
 ```csharp
-// Metalama.Framework/Code/IDelegateFacet.cs
+// Metalama.Framework/Code/Types/IDelegateFacet.cs
 [CompileTime]
 public interface IDelegateFacet : ITypeFacet
 {
@@ -170,8 +184,11 @@ public interface IDelegateFacet : ITypeFacet
 }
 ```
 
+`BeginInvoke` and `EndInvoke` are not exposed. They exist only for a delegate compiled for .NET Framework, and they
+are the asynchronous pattern that preceded `async`.
+
 ```csharp
-// Metalama.Framework/Code/IEnumFacet.cs
+// Metalama.Framework/Code/Types/IEnumFacet.cs
 [CompileTime]
 public interface IEnumFacet : ITypeFacet
 {
@@ -193,15 +210,19 @@ public interface IEnumFacet : ITypeFacet
 }
 ```
 
+The members of an enum are exposed as `IField`, and no interface of their own is declared for them. An enum member
+is a field, so an interface derived from `IField` would exist only to remove members that do not apply, which is
+more cumbersome than the property it would replace.
+
 ```csharp
-// Metalama.Framework/Code/IRecordFacet.cs
+// Metalama.Framework/Code/Types/IRecordFacet.cs
 [CompileTime]
 public interface IRecordFacet : ITypeFacet
 {
     /// <summary>
     /// Gets the <c>EqualityContract</c> property, or <c>null</c> when the type is a record struct, which has none.
     /// </summary>
-    IProperty? EqualityContract { get; }
+    IProperty? EqualityContractProperty { get; }
 
     IMethod PrintMembersMethod { get; }
 
@@ -229,15 +250,18 @@ public interface IRecordFacet : ITypeFacet
 }
 ```
 
+`IRecordFacet` is one interface with nullable members, and it is not split into a record class interface and a
+record struct interface. Three of its members are `null` for a record struct, and that is accepted.
+
 ```csharp
-// Metalama.Framework/Code/IUnionFacet.cs
+// Metalama.Framework/Code/Types/IUnionFacet.cs
 [CompileTime]
 public interface IUnionFacet : ITypeFacet
 {
     /// <summary>
-    /// Gets the form in which the union is written.
+    /// Gets the kind of the union.
     /// </summary>
-    UnionForm Form { get; }
+    new UnionKind Kind { get; }
 
     /// <summary>
     /// Gets the cases of the union, in the order in which the compiler reports them.
@@ -252,13 +276,19 @@ public interface IUnionFacet : ITypeFacet
 }
 
 [CompileTime]
-public enum UnionForm
+public enum UnionKind
 {
     /// <summary>The type is declared with the <c>union</c> keyword.</summary>
     Declaration,
 
     /// <summary>The type is a class or a struct that carries <c>UnionAttribute</c>.</summary>
-    Attribute
+    Attribute,
+
+    /// <summary>
+    /// The type is a union declared in a referenced assembly. The compiled form does not record the authoring form,
+    /// so the two forms above cannot be told apart there.
+    /// </summary>
+    External
 }
 
 [CompileTime]
@@ -276,19 +306,13 @@ public interface IUnionCase
     /// constructor of the attribute form, or the static <c>Create</c> method of the union member provider.
     /// </summary>
     IMethodBase CreationMember { get; }
-
-    /// <summary>
-    /// Creates an expression that creates an instance of the union holding a value of this case.
-    /// </summary>
-    IExpression CreateCreateInstanceExpression( IExpression value );
 }
 ```
 
 `IUnionCase` follows `ITupleElement`, which is richer than the type of the element and carries `Index`,
 `HasFriendlyName` and `CorrespondingTupleField`. The richer abstraction is required rather than convenient: Roslyn
 collapses duplicate case types through a set, so the index of a case is not recoverable from its type, and the
-creation member of the attribute form may be a static method rather than a constructor, which `IConstructor` cannot
-express.
+creation member of the attribute form may be a static method rather than a constructor.
 
 ### 2.3. Facets expose invokers
 
@@ -302,11 +326,19 @@ invoker through the member, and no facet declares an invoker member of its own.
 var call = eventType.Facets.Delegate!.InvokeMethod.With( handler ).Invoke( args );
 ```
 
-A facet declares a method that creates an expression only where no member of the type carries the operation. The
-precedent is `ITupleType.CreateCreateInstanceExpression`, which exists because a tuple is created by a syntactic
-construct and not by calling a member. `IUnionCase.CreateCreateInstanceExpression` exists for the same reason: the
-creation member differs by form, so the consumer would otherwise have to test whether it is a constructor or a
-static method.
+`IUnionCase.CreationMember` is typed as `IMethodBase`, which today derives from no invoker, because the creation
+member is a constructor for one form of union and a static method for another. The proposal therefore adds
+`IMethodBaseInvoker`, declaring the operations that `IMethodInvoker` and `IConstructorInvoker` have in common, and
+makes `IMethodBase` derive from it. Creating an instance of a union case is then the invocation of its creation
+member, and no facet declares a method to create an expression:
+
+```csharp
+var instance = unionCase.CreationMember.CreateInvokeExpression( value );
+```
+
+The relationship between the three invoker interfaces has to be settled during implementation. `IMethod` and
+`IConstructor` already derive from the two specific invokers, so `IMethodInvoker` and `IConstructorInvoker` either
+derive from `IMethodBaseInvoker` or keep their members independently.
 
 ### 2.4. Writing is on builders, not on facets
 
@@ -342,14 +374,17 @@ members are not yet resolvable.
 
 | Existing member | Disposition |
 | --- | --- |
-| `INamedType.IsRecord` | Kept. It is shipped, widely used, and cheap. The documentation gains a reference to `Facets.Record`. |
+| `INamedType.IsRecord` | Kept, and joined by `IsDelegate`, `IsEnum`, `IsTuple` and `IsUnion`. See section 4.4. |
 | `INamedType.UnderlyingType` | Kept. It is shipped and it also serves nullable reference types. `IEnumFacet.UnderlyingType` is the member with one meaning, and the documentation of both says so. |
 | `IEvent.Signature` | Kept, and defined as `Type.Facets.Delegate!.InvokeMethod`. The four duplicate implementations are removed. The member currently has no documentation and gains it. |
-| `ITupleType`, `ITupleElement`, `TypeKind.Tuple`, `TypeFactory.CreateTupleType` | Unchanged. A tuple is not a facet. See section 4.5. |
+| `IMethodBase` | Gains `IMethodBaseInvoker` as a base interface. See section 2.3. |
+| `ITupleType`, `ITupleElement` | Moved from `Metalama.Framework.Code` to `Metalama.Framework.Code.Types`. Otherwise unchanged. A tuple has no facet today. See section 4.5. |
+| `TypeKind.Tuple`, `TypeFactory.CreateTupleType` | Unchanged. |
 | `INamedType.PrimaryConstructor` | Kept. A primary constructor is not specific to records since C# 12, so it does not move to `IRecordFacet`. |
 | `IExtensionBlock` | Unchanged, and deliberately not a facet. See section 4.1. |
 
-No member is made obsolete by this proposal, and it carries no user-facing breaking change.
+No member is made obsolete by this proposal. It carries one user-facing breaking change, the namespace of
+`ITupleType` and `ITupleElement`, so the pull request that carries it takes the `breaking` label.
 
 ## 4. Decisions
 
@@ -391,25 +426,34 @@ The proposal adds no value to `TypeKind` and no interface derived from `INamedTy
 the two reasons. Roslyn made the same choice: `IsUnion` and `UnionCaseTypes` are declared on `ITypeSymbol`, and
 there is no `IUnionTypeSymbol`.
 
-### 4.4. No flat union members on `INamedType`
+### 4.4. The flags stay on `INamedType`, the structure does not
 
-Pull request #1991 proposes `INamedType.IsUnion`, `INamedType.IsUnionDeclaration` and
-`INamedType.UnionCaseTypes`. This proposal replaces all three with `Facets.Union`. The recommendation is to hold
-them back from #1991 rather than ship them and duplicate them later, because a shipped public member cannot be
-withdrawn and the repository already carries two members in that situation, `UnderlyingType` and `IsRecord`.
+`INamedType` keeps `IsRecord` and gains `IsDelegate`, `IsEnum`, `IsTuple` and `IsUnion`. Two reasons.
 
-Two of the three would be wrong as specified in any case. `UnionCaseTypes` is documented there as empty when
+The first is ease of use. A flag reads well in a predicate over a collection of types, in an eligibility rule and in
+a template, where `type.Facets.Union is not null` does not.
+
+The second is cost. Testing a flag through the collection allocates the collection and the facet in order to answer
+a Boolean question, and generic code that walks the model asks that question on every type. A flag answers it
+without allocating.
+
+The flags are the discriminators and the facets are the structure, so they answer different questions rather than
+the same one twice. That is the same relationship that `TypeKind.Delegate` and `TypeKind.Enum` already have with
+their facets.
+
+What does not go on `INamedType` is the structure. Pull request #1991 proposes `IsUnion`, `IsUnionDeclaration` and
+`UnionCaseTypes`. Under this proposal `IsUnion` ships as a flag, and the other two are replaced by `Facets.Union`.
+The recommendation is to hold those two back from #1991 rather than ship them and duplicate them later, because a
+shipped public member cannot be withdrawn.
+
+Both would be wrong as specified there in any case. `UnionCaseTypes` is documented as empty when
 `IsUnionDeclaration` is false, which describes the current implementation from syntax rather than the contract:
 Roslyn documents `ITypeSymbol.UnionCaseTypes` as returning the case types "when `IsUnion` is true", and it is
 defined for the attribute form. `IsUnionDeclaration` reads as a question about a declaration, on an object that is
-already an `IDeclaration`. `UnionForm` states the distinction with the vocabulary of the language proposal, which
+already an `IDeclaration`. `UnionKind` states the distinction with the vocabulary of the language proposal, which
 defines "union type" and "union declaration" as two terms, and it does so without that collision.
 
-The counter-argument is that `IsUnion` is the cheap first test, that it is what `ITypeSymbol` exposes, and that
-`type.Facets.Union is not null` is longer to write in a predicate over a collection of types. The proposal accepts
-that cost, on the ground that a second way to ask the same question is the defect this document exists to remove.
-
-### 4.5. A tuple is not a facet
+### 4.5. A tuple has no facet today
 
 A tuple is not declared. The type `(int X, string Y)` is formed by a type expression at the place where it is used,
 and the element names are attached there. Metalama models it that way: `TupleType` and `TupleTypeImpl` are in
@@ -419,41 +463,34 @@ the elements of a tuple are a view over the fields of the underlying `ValueTuple
 `ITupleType` therefore belongs to the family of `IArrayType`, `IPointerType` and `IFunctionPointerType`: interfaces
 that describe the structure of a type that a type expression forms, that are reached by a type test, and that are
 constructed at one site. Section 1.3 states why that mechanism is correct for that family and does not extend to a
-declared type.
+declared type. `ITupleType` and `ITupleElement` move to `Metalama.Framework.Code.Types` so that they sit with that
+family.
 
-A facet describes the other thing: the structure that a named type has because of what its declaration says. A
-delegate, an enum, a record and a union are declared. A tuple is not, so `ITupleType`, `ITupleElement`,
-`TypeKind.Tuple` and `TypeFactory.CreateTupleType` are unchanged, and `ITypeFacetCollection` has no tuple property.
-
-The cost of this decision is that a consumer that wants the structure of an arbitrary type has to know two
-mechanisms: a type test for a type that a type expression forms, and the facet collection for a declared one. An
-earlier revision of this document proposed the alternative, which is to declare `ITupleFacet` with the members of
-`ITupleType`, to make `ITupleType` obsolete and forward its members to the facet, and to change the return type of
-`TypeFactory.CreateTupleType` to `INamedType`. That alternative removes the second mechanism at the price of a
-user-facing breaking change, sixty-three references to convert inside the repository, and a facet that describes a
-type that nobody declared.
+`ITypeFacetCollection` has no tuple property in this proposal, and `INamedType.IsTuple` is the flag. An
+`ITupleFacet` declaring the members of `ITupleType` may be added later for completeness, which would make the
+collection a complete index of the structure of a type. That addition is not required by any consumer known today,
+and it is deliberately left out of the pull requests that section 6 lists.
 
 ## 5. Implementation guidelines
 
 These are constraints on the implementation, not a design of it.
 
-1. `Facets` is one member on `INamedType`, for any number of facets. The number of members to implement does not
-   grow when a facet is added. That is the difference from the flat design, which needs one member per exposed
-   value.
+1. `Facets` is one member on `INamedType`, for any number of facets. The structure does not add a member per kind.
+   The flags of section 4.4 do add one member per kind, and they are Boolean and non-allocating.
 2. The collection constructs the facets. No facet type declares a static factory method that returns `null`. A facet
    reference that a consumer holds is never `null`, and nullability is expressed only by the properties of the
    collection.
-3. A type that has no facet returns a shared empty collection. Generic code that walks the model reads `Facets` on
+3. Every member of a facet is a lazy expression cached with `[Memo]`, and the facet resolves no member that a
+   consumer does not read.
+4. A type that has no facet returns a shared empty collection. Generic code that walks the model reads `Facets` on
    every type, so the common case must not allocate.
-4. The implementations of `INamedType` that back a builder return the empty collection rather than throwing.
+5. The implementations of `INamedType` that back a builder return the empty collection rather than throwing.
    Eligibility rules and advice validation run against builders, so an exception there is reached in normal use.
-5. The facet interfaces name no Roslyn type. `Metalama.Framework` is not built per Roslyn version, while
+6. The facet interfaces name no Roslyn type. `Metalama.Framework` is not built per Roslyn version, while
    `Metalama.Framework.Engine` is, and the union facet reads `ITypeSymbol.IsUnion` and `ITypeSymbol.UnionCaseTypes`,
    which exist only in the latest variant. The conditional compilation is therefore confined to the construction of
    the collection in the engine, under the condition that section 6 of
-   [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) decides. The flat design instead needs a conditional block in
-   each implementation of `INamedType`.
-6. A facet is computed once per type and cached, in the manner of the other collection members of `INamedType`.
+   [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) decides.
 
 ## 6. Order of implementation
 
@@ -463,11 +500,13 @@ behaviour before anything that cannot be revised is public.
 
 | Pull request | Content | Depends on |
 | --- | --- | --- |
-| 1 | `TypeFacetKind`, `ITypeFacet`, `ITypeFacetCollection`, `INamedType.Facets`, `IDelegateFacet`. Conversion of the `Invoke` lookups and of `IEvent.Signature`. | — |
-| 2 | `IEnumFacet`. | 1 |
+| 1 | `TypeFacetKind`, `ITypeFacet`, `ITypeFacetCollection`, `INamedType.Facets`, `INamedType.IsDelegate`, `IDelegateFacet`. Conversion of the `Invoke` lookups and of `IEvent.Signature`. | — |
+| 2 | `IEnumFacet` and `INamedType.IsEnum`. | 1 |
 | 3 | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | 1 |
-| 4 | `IUnionFacet`, `IUnionCase`, `UnionForm`. | 1, and the move to the stable Roslyn |
-| 5 | `IUnionBuilder`, and the builder shapes of the other kinds. | 4, and the union introduction story |
+| 4 | `INamedType.IsTuple`, and the move of `ITupleType` and `ITupleElement` to `Metalama.Framework.Code.Types`. Takes the `breaking` label. | — |
+| 5 | `IMethodBaseInvoker` on `IMethodBase`. | — |
+| 6 | `IUnionFacet`, `IUnionCase`, `UnionKind`, `INamedType.IsUnion`. | 1, 5, and the move to the stable Roslyn |
+| 7 | `IUnionBuilder`, and the builder shapes of the other kinds. | 6, and the union introduction story |
 
 Pull request 1 changes one shipped behaviour: `EligibilityRuleFactory` currently throws `InvalidOperationException`
 when the type of an event is not a well-formed delegate, and it returns `false` after the conversion.
@@ -479,20 +518,29 @@ the design has to be revised before the union facet is built on it.
 
 ## 7. Open questions
 
-1. Whether `IDelegateFacet` exposes `BeginInvoke` and `EndInvoke`. They exist for a delegate compiled for .NET
-   Framework and not for one compiled for .NET. Exposing them adds two nullable members for a case that no known
-   consumer needs.
-2. Whether `IRecordFacet` is worth its nullable members. `EqualityContract`, `CloneMethod` and `CopyConstructor` are
-   all `null` for a record struct. Splitting the interface in two would remove the nullability and add a type.
-3. Whether the enum members deserve an abstraction of their own, in the manner of `ITupleElement`, carrying the
-   constant value and the index, rather than `IReadOnlyList<IField>`.
-4. Whether the `Delegate`, `Enum` and `Record` property names of `ITypeFacetCollection` pass the naming analyzers of
-   this repository.
-5. Whether the union facet is populated for a union read from a referenced assembly. The compiled form does not
-   record the authoring form, so `Form` would report `Attribute` for a type that the author wrote with the `union`
-   keyword.
+1. Whether `IUnionFacet.Kind` shadows `ITypeFacet.Kind` or the base member is renamed. `ITypeFacet.Kind` returns
+   `TypeFacetKind` and `IUnionFacet.Kind` returns `UnionKind`, so the derived member has to be declared `new`, and a
+   consumer sees a different type depending on the interface through which it reads the property. Renaming the base
+   member to `FacetKind` removes the shadowing at the price of a name that is less uniform with the rest of the code
+   model.
+2. Whether `IMethodInvoker` and `IConstructorInvoker` derive from `IMethodBaseInvoker`, or keep their members
+   independently. See section 2.3.
+3. Whether the move of `ITupleType` and `ITupleElement` to `Metalama.Framework.Code.Types` ships as a plain
+   namespace change or with a compatibility measure, and in which release.
 
-## 8. References
+## 8. Resolved questions
+
+These were open in the first revision of this document and are settled.
+
+- `IDelegateFacet` does not expose `BeginInvoke` and `EndInvoke`. They are the asynchronous pattern that preceded
+  `async`.
+- `IRecordFacet` keeps its nullable members and is not split in two.
+- The members of an enum stay `IReadOnlyList<IField>`, and no interface of their own is declared for them.
+- `UnionKind` gains an `External` member for a union read from a referenced assembly, whose authoring form the
+  compiled form does not record.
+- The property names `Delegate`, `Enum` and `Record` on `ITypeFacetCollection` are not a concern.
+
+## 9. References
 
 - [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 3, 4 and 6.
 - [`../2027.0/03-code-model-unions-closed.md`](../2027.0/03-code-model-unions-closed.md), finding CM-1.

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -47,12 +47,16 @@ The caller has to know the kind of the type to know what the property returned.
 and is reached by a type test. `IExtensionBlock` follows the same pattern. Both have a value of their own in
 `TypeKind`.
 
-This mechanism works, and the tuple case is the closest existing analogue of the union case. Roslyn models a tuple
-as `INamedTypeSymbol.IsTupleType` plus `TupleElements`, with `TypeKind` remaining `Struct`, which is exactly how it
-models a union as `ITypeSymbol.IsUnion` plus `UnionCaseTypes`. Metalama departed from Roslyn for tuples and
-introduced `TypeKind.Tuple`.
+The mechanism gives correct answers, and the tuple case is the closest existing analogue of the union case. Roslyn
+models a tuple as `INamedTypeSymbol.IsTupleType` plus `TupleElements`, with `TypeKind` remaining `Struct`, which is
+exactly how it models a union as `ITypeSymbol.IsUnion` plus `UnionCaseTypes`. Metalama departed from Roslyn for
+tuples and introduced `TypeKind.Tuple`.
 
-The mechanism does not extend to unions, for two reasons. First, a value `TypeKind.Union` would require a new arm in
+The defect is that the mechanism is a second one. The structure of a tuple is reached by a type test, while the
+structure of a delegate, an enum, a record or a union is reached in one of the other three ways, so a consumer has
+to know which kind uses which mechanism. Section 4.5 replaces it for tuples.
+
+The mechanism also does not extend to unions, for two reasons. First, a value `TypeKind.Union` would require a new arm in
 the seventeen switches over `TypeKind` that the analysis in
 [`../2027.0/03-code-model-unions-closed.md`](../2027.0/03-code-model-unions-closed.md) inventoried, and the union
 design depends on a union continuing to behave as a struct. Second, a tuple is constructed and a union is declared.
@@ -103,8 +107,7 @@ public interface ITypeFacet
     TypeFacetKind Kind { get; }
 
     /// <summary>
-    /// Gets the type to which the facet belongs. A tuple facet returns the tuple type itself, because a tuple is
-    /// modelled as an interface derived from <see cref="INamedType"/>.
+    /// Gets the type to which the facet belongs.
     /// </summary>
     INamedType Type { get; }
 }
@@ -120,11 +123,7 @@ public interface ITypeFacetCollection : IReadOnlyCollection<ITypeFacet>
 
     IRecordFacet? Record { get; }
 
-    /// <summary>
-    /// Gets the type as a tuple type, or <c>null</c> when the type is not a tuple. Unlike the other facets, a tuple
-    /// is modelled as an interface derived from <see cref="INamedType"/>, so this property returns the type itself.
-    /// </summary>
-    ITupleType? Tuple { get; }
+    ITupleFacet? Tuple { get; }
 
     IUnionFacet? Union { get; }
 }
@@ -239,6 +238,31 @@ public interface IRecordFacet : ITypeFacet
 ```
 
 ```csharp
+// Metalama.Framework/Code/ITupleFacet.cs
+[CompileTime]
+public interface ITupleFacet : ITypeFacet
+{
+    /// <summary>
+    /// Gets the elements of the tuple.
+    /// </summary>
+    IReadOnlyList<ITupleElement> TupleElements { get; }
+
+    /// <summary>
+    /// Gets the number of elements in the tuple.
+    /// </summary>
+    int TupleLength { get; }
+
+    /// <summary>
+    /// Creates an expression that creates an instance of the tuple with the specified values.
+    /// </summary>
+    IExpression CreateCreateInstanceExpression( params IEnumerable<IExpression> values );
+}
+```
+
+The members of `ITupleFacet` are those of the existing `ITupleType`. Section 4.5 explains why the proposal
+duplicates them rather than deriving `ITupleType` from `ITypeFacet`.
+
+```csharp
 // Metalama.Framework/Code/IUnionFacet.cs
 [CompileTime]
 public interface IUnionFacet : ITypeFacet
@@ -311,9 +335,10 @@ invoker through the member, and no facet declares an invoker member of its own.
 var call = eventType.Facets.Delegate!.InvokeMethod.With( handler ).Invoke( args );
 ```
 
-A facet declares a method that creates an expression only where no member of the type carries the operation. The
-precedent is `ITupleType.CreateCreateInstanceExpression`, which exists because a tuple is created by a syntactic
-construct and not by calling a member. `IUnionCase.CreateCreateInstanceExpression` exists for the same reason: the
+A facet declares a method that creates an expression only where no member of the type carries the operation.
+`ITupleFacet.CreateCreateInstanceExpression` is such a method, and it is the precedent, because a tuple is created
+by a syntactic construct and not by calling a member. `IUnionCase.CreateCreateInstanceExpression` exists for the
+same reason: the
 creation member differs by form, so the consumer would otherwise have to test whether it is a constructor or a
 static method.
 
@@ -354,11 +379,16 @@ members are not yet resolvable.
 | `INamedType.IsRecord` | Kept. It is shipped, widely used, and cheap. The documentation gains a reference to `Facets.Record`. |
 | `INamedType.UnderlyingType` | Kept. It is shipped and it also serves nullable reference types. `IEnumFacet.UnderlyingType` is the member with one meaning, and the documentation of both says so. |
 | `IEvent.Signature` | Kept, and defined as `Type.Facets.Delegate!.InvokeMethod`. The four duplicate implementations are removed. The member currently has no documentation and gains it. |
-| `ITupleType`, `ITupleElement` | Kept, and `ITupleType` gains `ITypeFacet` as a base interface, which is a source-compatible and binary-compatible change. |
+| `ITupleType` | Made obsolete, and kept working. Its members forward to `Facets.Tuple`. See section 4.5. |
+| `ITupleElement` | Kept and unchanged. It is the element type of `ITupleFacet.TupleElements`, and nothing about it is superseded. |
+| `TypeFactory.CreateTupleType` | The return type changes from `ITupleType` to `INamedType`, so that the factory does not return an obsolete type. See section 4.5. |
+| `TypeKind.Tuple` | Kept. See section 4.5. |
 | `INamedType.PrimaryConstructor` | Kept. A primary constructor is not specific to records since C# 12, so it does not move to `IRecordFacet`. |
 | `IExtensionBlock` | Unchanged, and deliberately not a facet. See section 4.1. |
 
-No member is made obsolete by this proposal.
+`ITupleType` is the only member that this proposal makes obsolete. The change to the return type of
+`TypeFactory.CreateTupleType` is a user-facing break, so the pull request that carries it takes the `breaking`
+label.
 
 ## 4. Decisions
 
@@ -418,6 +448,36 @@ The counter-argument is that `IsUnion` is the cheap first test, that it is what 
 `type.Facets.Union is not null` is longer to write in a predicate over a collection of types. The proposal accepts
 that cost, on the ground that a second way to ask the same question is the defect this document exists to remove.
 
+### 4.5. The tuple facet is a new interface, and `ITupleType` is made obsolete
+
+The alternative is to derive `ITupleType` from `ITypeFacet` and let `ITypeFacetCollection.Tuple` return the type
+itself. That alternative is rejected for two reasons.
+
+The first is that the tuple would be the only facet that is not a distinct object. Every other facet describes a
+type. A tuple facet obtained that way would be the type, `ITypeFacet.Type` would return the object it was reached
+from, and a consumer that descends from a type into its facets would reach the same object. The interface would have
+one member whose meaning differs from the same member on every other facet.
+
+The second is that the model would keep two mechanisms for the structure of a tuple, the type test and the
+collection, which is the defect described in section 1.3.
+
+`ITupleFacet` therefore declares the three members of `ITupleType`, and `ITupleType` is made obsolete with a
+warning. It keeps deriving from `INamedType`, it keeps its members, and each member forwards to the facet, so code
+written against it compiles with a warning and behaves as before. The release in which the warning becomes an error
+is not decided here.
+
+`TypeFactory.CreateTupleType` returns `ITupleType` today. A factory that returns an obsolete type raises a warning
+at every call site, so the return type changes to `INamedType`. The change is source-compatible for a caller that
+uses `var` or that passes the result where an `IType` or an `INamedType` is expected, and it is a binary break. It
+is a user-facing break and is labelled as one.
+
+`TypeKind.Tuple` is kept. The property `Facets.Tuple is not null` is equivalent to `TypeKind == TypeKind.Tuple`, but
+the same equivalence holds between `Facets.Delegate` and `TypeKind.Delegate`, and between `Facets.Enum` and
+`TypeKind.Enum`. `TypeKind` is the kind discriminator of `IType`, and a facet is the structure of those kinds that
+have structure, so the two answer different questions. Section 4.4 rejects `IsUnion` for a reason that does not
+apply here: a union has no value in `TypeKind`, so `IsUnion` would be a second discriminator invented beside
+`Facets.Union` rather than the one that already exists.
+
 ## 5. Implementation guidelines
 
 These are constraints on the implementation, not a design of it.
@@ -450,7 +510,7 @@ behaviour before anything that cannot be revised is public.
 | --- | --- | --- |
 | 1 | `TypeFacetKind`, `ITypeFacet`, `ITypeFacetCollection`, `INamedType.Facets`, `IDelegateFacet`. Conversion of the `Invoke` lookups and of `IEvent.Signature`. | — |
 | 2 | `IEnumFacet`. | 1 |
-| 3 | `ITupleType` gains `ITypeFacet`, and `ITypeFacetCollection.Tuple`. | 1 |
+| 3 | `ITupleFacet` and `ITypeFacetCollection.Tuple`. `ITupleType` is made obsolete and bridged, and the return type of `TypeFactory.CreateTupleType` changes. Takes the `breaking` label. | 1 |
 | 4 | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | 1 |
 | 5 | `IUnionFacet`, `IUnionCase`, `UnionForm`. | 1, and the move to the stable Roslyn |
 | 6 | `IUnionBuilder`, and the builder shapes of the other kinds. | 5, and the union introduction story |
@@ -472,13 +532,13 @@ the design has to be revised before the union facet is built on it.
    all `null` for a record struct. Splitting the interface in two would remove the nullability and add a type.
 3. Whether the enum members deserve an abstraction of their own, in the manner of `ITupleElement`, carrying the
    constant value and the index, rather than `IReadOnlyList<IField>`.
-4. Whether `ITypeFacet.Type` is worth its self-reference on a tuple facet. A generic walker that descends from a
-   type into its facets and back reaches the same object.
-5. Whether the `Delegate`, `Enum` and `Record` property names of `ITypeFacetCollection` pass the naming analyzers of
+4. Whether the `Delegate`, `Enum` and `Record` property names of `ITypeFacetCollection` pass the naming analyzers of
    this repository.
-6. Whether the union facet is populated for a union read from a referenced assembly. The compiled form does not
+5. Whether the union facet is populated for a union read from a referenced assembly. The compiled form does not
    record the authoring form, so `Form` would report `Attribute` for a type that the author wrote with the `union`
    keyword.
+6. In which release the obsoletion of `ITupleType` becomes an error, and whether the sixty-three references to it
+   inside the repository are converted in the pull request that introduces `ITupleFacet` or over several.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -92,7 +92,7 @@ have. A type has a collection of facets, which is empty for an ordinary class, s
 public enum TypeFacetKind
 {
     /// <summary>The type has no facet.</summary>
-    None,
+    None = 0,
 
     Delegate,
 
@@ -287,17 +287,17 @@ public interface IUnionFacet : ITypeFacet
 [CompileTime]
 public enum UnionKind
 {
+    /// <summary>
+    /// The kind of the union is not known. This is the case for a union declared in a referenced assembly, because
+    /// the compiled form does not record the authoring form, so the two kinds below cannot be told apart there.
+    /// </summary>
+    None = 0,
+
     /// <summary>The type is declared with the <c>union</c> keyword.</summary>
     Declaration,
 
     /// <summary>The type is a class or a struct that carries <c>UnionAttribute</c>.</summary>
-    Attribute,
-
-    /// <summary>
-    /// The type is a union declared in a referenced assembly. The compiled form does not record the authoring form,
-    /// so the two forms above cannot be told apart there.
-    /// </summary>
-    External
+    Attribute
 }
 
 [CompileTime]
@@ -533,8 +533,8 @@ These were open in an earlier revision of this document and are settled. No ques
   `async`.
 - `IRecordFacet` keeps its nullable members and is not split in two.
 - The members of an enum stay `IReadOnlyList<IField>`, and no interface of their own is declared for them.
-- `UnionKind` gains an `External` member for a union read from a referenced assembly, whose authoring form the
-  compiled form does not record.
+- `UnionKind` gains a `None` member, of value zero, for a union read from a referenced assembly, whose authoring
+  form the compiled form does not record.
 - The property names `Delegate`, `Enum` and `Record` on `ITypeFacetCollection` are not a concern.
 - The two kind properties are named apart rather than shadowed: `ITypeFacet.FacetKind` returns `TypeFacetKind` and
   `IUnionFacet.UnionKind` returns `UnionKind`.

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -78,6 +78,9 @@ The facet types are declared in the namespace `Metalama.Framework.Code.Types`, b
 `ITypeFacetCollection` is declared in `Metalama.Framework.Code.Collections`, beside `IExtensionBlockCollection`,
 because it is a collection.
 
+Every interface below carries `[InternalImplement]`. Adding a member to such an interface, including an inherited
+one, is not a user-facing breaking change, so a facet can gain a member in a later release.
+
 ### 2.1. One collection of facets
 
 A facet is the structure that a declared named type has because of its kind, and that other named types do not
@@ -104,12 +107,13 @@ public enum TypeFacetKind
 ```csharp
 // Metalama.Framework/Code/Types/ITypeFacet.cs
 [CompileTime]
+[InternalImplement]
 public interface ITypeFacet
 {
     /// <summary>
     /// Gets the kind of the facet.
     /// </summary>
-    TypeFacetKind Kind { get; }
+    TypeFacetKind FacetKind { get; }
 
     /// <summary>
     /// Gets the type to which the facet belongs.
@@ -120,6 +124,7 @@ public interface ITypeFacet
 
 ```csharp
 // Metalama.Framework/Code/Collections/ITypeFacetCollection.cs
+[InternalImplement]
 public interface ITypeFacetCollection : IReadOnlyCollection<ITypeFacet>
 {
     IDelegateFacet? Delegate { get; }
@@ -171,6 +176,7 @@ member does not pay for resolving the others.
 ```csharp
 // Metalama.Framework/Code/Types/IDelegateFacet.cs
 [CompileTime]
+[InternalImplement]
 public interface IDelegateFacet : ITypeFacet
 {
     /// <summary>
@@ -190,6 +196,7 @@ are the asynchronous pattern that preceded `async`.
 ```csharp
 // Metalama.Framework/Code/Types/IEnumFacet.cs
 [CompileTime]
+[InternalImplement]
 public interface IEnumFacet : ITypeFacet
 {
     /// <summary>
@@ -217,6 +224,7 @@ more cumbersome than the property it would replace.
 ```csharp
 // Metalama.Framework/Code/Types/IRecordFacet.cs
 [CompileTime]
+[InternalImplement]
 public interface IRecordFacet : ITypeFacet
 {
     /// <summary>
@@ -256,12 +264,13 @@ record struct interface. Three of its members are `null` for a record struct, an
 ```csharp
 // Metalama.Framework/Code/Types/IUnionFacet.cs
 [CompileTime]
+[InternalImplement]
 public interface IUnionFacet : ITypeFacet
 {
     /// <summary>
     /// Gets the kind of the union.
     /// </summary>
-    new UnionKind Kind { get; }
+    UnionKind UnionKind { get; }
 
     /// <summary>
     /// Gets the cases of the union, in the order in which the compiler reports them.
@@ -292,6 +301,7 @@ public enum UnionKind
 }
 
 [CompileTime]
+[InternalImplement]
 public interface IUnionCase
 {
     IType Type { get; }
@@ -326,19 +336,16 @@ invoker through the member, and no facet declares an invoker member of its own.
 var call = eventType.Facets.Delegate!.InvokeMethod.With( handler ).Invoke( args );
 ```
 
-`IUnionCase.CreationMember` is typed as `IMethodBase`, which today derives from no invoker, because the creation
-member is a constructor for one form of union and a static method for another. The proposal therefore adds
-`IMethodBaseInvoker`, declaring the operations that `IMethodInvoker` and `IConstructorInvoker` have in common, and
-makes `IMethodBase` derive from it. Creating an instance of a union case is then the invocation of its creation
-member, and no facet declares a method to create an expression:
+`IUnionCase.CreationMember` is typed as `IMethodBase`, which derives from no invoker, because the creation member is
+a constructor for one form of union and a static method for another. No facet declares a method to create an
+expression for it.
 
-```csharp
-var instance = unionCase.CreationMember.CreateInvokeExpression( value );
-```
-
-The relationship between the three invoker interfaces has to be settled during implementation. `IMethod` and
-`IConstructor` already derive from the two specific invokers, so `IMethodInvoker` and `IConstructorInvoker` either
-derive from `IMethodBaseInvoker` or keep their members independently.
+The member that this calls for is `IMethodBaseInvoker`, declaring the operations that `IMethodInvoker` and
+`IConstructorInvoker` have in common, with `IMethodBase` deriving from it. Creating an instance of a union case
+would then be the invocation of its creation member. That is a story of its own, because it changes `IMethodBase`
+and because the relationship between the three invoker interfaces has to be settled: `IMethod` and `IConstructor`
+already derive from the two specific invokers. It is not part of this proposal, and until it exists a consumer that
+invokes a creation member tests whether it is an `IMethod` or an `IConstructor`.
 
 ### 2.4. Writing is on builders, not on facets
 
@@ -377,14 +384,15 @@ members are not yet resolvable.
 | `INamedType.IsRecord` | Kept, and joined by `IsDelegate`, `IsEnum`, `IsTuple` and `IsUnion`. See section 4.4. |
 | `INamedType.UnderlyingType` | Kept. It is shipped and it also serves nullable reference types. `IEnumFacet.UnderlyingType` is the member with one meaning, and the documentation of both says so. |
 | `IEvent.Signature` | Kept, and defined as `Type.Facets.Delegate!.InvokeMethod`. The four duplicate implementations are removed. The member currently has no documentation and gains it. |
-| `IMethodBase` | Gains `IMethodBaseInvoker` as a base interface. See section 2.3. |
+| `IMethodBase` | Unchanged. `IMethodBaseInvoker` is a story of its own. See section 2.3. |
 | `ITupleType`, `ITupleElement` | Moved from `Metalama.Framework.Code` to `Metalama.Framework.Code.Types`. Otherwise unchanged. A tuple has no facet today. See section 4.5. |
 | `TypeKind.Tuple`, `TypeFactory.CreateTupleType` | Unchanged. |
 | `INamedType.PrimaryConstructor` | Kept. A primary constructor is not specific to records since C# 12, so it does not move to `IRecordFacet`. |
 | `IExtensionBlock` | Unchanged, and deliberately not a facet. See section 4.1. |
 
 No member is made obsolete by this proposal. It carries one user-facing breaking change, the namespace of
-`ITupleType` and `ITupleElement`, so the pull request that carries it takes the `breaking` label.
+`ITupleType` and `ITupleElement`, so the pull request that carries it takes the `breaking` label. The change ships
+in 2027.0 as a plain namespace change, with no compatibility measure.
 
 ## 4. Decisions
 
@@ -504,9 +512,10 @@ behaviour before anything that cannot be revised is public.
 | 2 | `IEnumFacet` and `INamedType.IsEnum`. | 1 |
 | 3 | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | 1 |
 | 4 | `INamedType.IsTuple`, and the move of `ITupleType` and `ITupleElement` to `Metalama.Framework.Code.Types`. Takes the `breaking` label. | — |
-| 5 | `IMethodBaseInvoker` on `IMethodBase`. | — |
-| 6 | `IUnionFacet`, `IUnionCase`, `UnionKind`, `INamedType.IsUnion`. | 1, 5, and the move to the stable Roslyn |
-| 7 | `IUnionBuilder`, and the builder shapes of the other kinds. | 6, and the union introduction story |
+| 5 | `IUnionFacet`, `IUnionCase`, `UnionKind`, `INamedType.IsUnion`. | 1, and the move to the stable Roslyn |
+| 6 | `IUnionBuilder`, and the builder shapes of the other kinds. | 5, and the union introduction story |
+
+`IMethodBaseInvoker` is a story of its own, described in section 2.3, and it is not one of these pull requests.
 
 Pull request 1 changes one shipped behaviour: `EligibilityRuleFactory` currently throws `InvalidOperationException`
 when the type of an event is not a well-formed delegate, and it returns `false` after the conversion.
@@ -516,21 +525,9 @@ Pull request 1 is also the acceptance test of the design. Fourteen of the fiftee
 asserting that the facet is not `null`, the nullable collection property is the wrong shape for those consumers, and
 the design has to be revised before the union facet is built on it.
 
-## 7. Open questions
+## 7. Resolved questions
 
-1. Whether `IUnionFacet.Kind` shadows `ITypeFacet.Kind` or the base member is renamed. `ITypeFacet.Kind` returns
-   `TypeFacetKind` and `IUnionFacet.Kind` returns `UnionKind`, so the derived member has to be declared `new`, and a
-   consumer sees a different type depending on the interface through which it reads the property. Renaming the base
-   member to `FacetKind` removes the shadowing at the price of a name that is less uniform with the rest of the code
-   model.
-2. Whether `IMethodInvoker` and `IConstructorInvoker` derive from `IMethodBaseInvoker`, or keep their members
-   independently. See section 2.3.
-3. Whether the move of `ITupleType` and `ITupleElement` to `Metalama.Framework.Code.Types` ships as a plain
-   namespace change or with a compatibility measure, and in which release.
-
-## 8. Resolved questions
-
-These were open in the first revision of this document and are settled.
+These were open in an earlier revision of this document and are settled. No question is open.
 
 - `IDelegateFacet` does not expose `BeginInvoke` and `EndInvoke`. They are the asynchronous pattern that preceded
   `async`.
@@ -539,8 +536,12 @@ These were open in the first revision of this document and are settled.
 - `UnionKind` gains an `External` member for a union read from a referenced assembly, whose authoring form the
   compiled form does not record.
 - The property names `Delegate`, `Enum` and `Record` on `ITypeFacetCollection` are not a concern.
+- The two kind properties are named apart rather than shadowed: `ITypeFacet.FacetKind` returns `TypeFacetKind` and
+  `IUnionFacet.UnionKind` returns `UnionKind`.
+- `IMethodBaseInvoker` is a story of its own and is not part of this proposal.
+- The namespace of `ITupleType` and `ITupleElement` changes in 2027.0 with no compatibility measure.
 
-## 9. References
+## 8. References
 
 - [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 3, 4 and 6.
 - [`../2027.0/03-code-model-unions-closed.md`](../2027.0/03-code-model-unions-closed.md), finding CM-1.

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -1,0 +1,491 @@
+# Type facets
+
+This document proposes an addition to the public code model: a uniform way to expose the structure that is specific
+to a kind of named type. It covers delegates, enums, records, tuples and C# 15 unions. It is a design proposal.
+Nothing described here is implemented.
+
+## 1. The problem
+
+A named type of some kinds carries structure that other named types do not have. A delegate has a signature. An
+enum has an underlying type and a set of members. A record has an equality contract and a set of synthesized
+members. A tuple has elements. A C# 15 union has case types and a `Value` property. The code model exposes that
+structure in four different ways today, and three of them are defective.
+
+### 1.1. A member reached by a string literal
+
+The `Invoke` method of a delegate has no name in the code model, so it is reached by its identifier. The repository
+contains about fifteen such lookups. Two of them are in `Metalama.Framework`, the public application programming
+interface assembly:
+
+```csharp
+// Metalama.Framework/src/Metalama.Framework/Eligibility/EligibilityRuleFactory.cs:98
+e => e.Type.Methods.OfName( "Invoke" ).Single().ReturnType.SpecialType == SpecialType.Void,
+```
+
+Four of them are the same body of `IEvent.Signature`, repeated in four implementations, and they do not agree with
+each other on whether a missing `Invoke` method is `null` or an exception.
+
+The synthesized members of a record and of a union have the same shape of problem. No public member names
+`EqualityContract`, `PrintMembers` or the clone method. The `Value` property of a union would have to be reached as
+`type.Properties.OfName( "Value" ).Single()`, which throws when a union written with the union attribute declares a
+member of that name.
+
+### 1.2. One member with several meanings
+
+`INamedType.UnderlyingType` is documented as follows.
+
+```csharp
+/// Gets the underlying type of an enum, the non-nullable type of a nullable reference type, or the current type.
+INamedType UnderlyingType { get; }
+```
+
+The caller has to know the kind of the type to know what the property returned.
+
+### 1.3. A derived interface keyed on a type kind
+
+`ITupleType` derives from `INamedType`, adds `TupleElements`, `TupleLength` and `CreateCreateInstanceExpression`,
+and is reached by a type test. `IExtensionBlock` follows the same pattern. Both have a value of their own in
+`TypeKind`.
+
+This mechanism works, and the tuple case is the closest existing analogue of the union case. Roslyn models a tuple
+as `INamedTypeSymbol.IsTupleType` plus `TupleElements`, with `TypeKind` remaining `Struct`, which is exactly how it
+models a union as `ITypeSymbol.IsUnion` plus `UnionCaseTypes`. Metalama departed from Roslyn for tuples and
+introduced `TypeKind.Tuple`.
+
+The mechanism does not extend to unions, for two reasons. First, a value `TypeKind.Union` would require a new arm in
+the seventeen switches over `TypeKind` that the analysis in
+[`../2027.0/03-code-model-unions-closed.md`](../2027.0/03-code-model-unions-closed.md) inventoried, and the union
+design depends on a union continuing to behave as a struct. Second, a tuple is constructed and a union is declared.
+A tuple reaches the model through one construction path, `TypeFactory.CreateTupleType`, which can decide to return
+an `ITupleType`. A union reaches the model through source symbols, metadata symbols, generic instantiation,
+builders, introduced types and the design-time partial pipeline, and for the attribute form its identity depends on
+an attribute that Roslyn synthesizes at emit time. Deciding the runtime type of the code model object correctly at
+every one of those sites is not reliable.
+
+### 1.4. Flat members on `INamedType`
+
+`IsRecord` is a flag on `INamedType`. Adding `IsUnion`, `IsUnionDeclaration` and `UnionCaseTypes` beside it, which
+is what pull request #1991 proposes, continues that pattern. The count grows: the union introduction story adds the
+`Value` property and the case constructors, which would be two more members. Each one is meaningless for the great
+majority of named types.
+
+## 2. The public interfaces
+
+### 2.1. One collection of facets
+
+A facet is the structure that a kind of type has and that other types do not have. A type has a collection of
+facets, which is empty for an ordinary class, struct or interface.
+
+```csharp
+// Metalama.Framework/Code/TypeFacetKind.cs
+[CompileTime]
+public enum TypeFacetKind
+{
+    Delegate,
+    Enum,
+    Record,
+    Tuple,
+    Union
+}
+```
+
+The enum has no `None` member. A facet that exists has a kind, and the absence of a facet is represented by a `null`
+property of the collection.
+
+```csharp
+// Metalama.Framework/Code/ITypeFacet.cs
+[CompileTime]
+public interface ITypeFacet
+{
+    /// <summary>
+    /// Gets the kind of the facet.
+    /// </summary>
+    TypeFacetKind Kind { get; }
+
+    /// <summary>
+    /// Gets the type to which the facet belongs. A tuple facet returns the tuple type itself, because a tuple is
+    /// modelled as an interface derived from <see cref="INamedType"/>.
+    /// </summary>
+    INamedType Type { get; }
+}
+```
+
+```csharp
+// Metalama.Framework/Code/Collections/ITypeFacetCollection.cs
+public interface ITypeFacetCollection : IReadOnlyCollection<ITypeFacet>
+{
+    IDelegateFacet? Delegate { get; }
+
+    IEnumFacet? Enum { get; }
+
+    IRecordFacet? Record { get; }
+
+    /// <summary>
+    /// Gets the type as a tuple type, or <c>null</c> when the type is not a tuple. Unlike the other facets, a tuple
+    /// is modelled as an interface derived from <see cref="INamedType"/>, so this property returns the type itself.
+    /// </summary>
+    ITupleType? Tuple { get; }
+
+    IUnionFacet? Union { get; }
+}
+```
+
+```csharp
+// Metalama.Framework/Code/INamedType.cs
+/// <summary>
+/// Gets the facets of the type, that is, the structure that is specific to its kind. The collection is empty for a
+/// type that has no such structure. Enumerating the collection yields exactly the facets that are not <c>null</c>,
+/// in the order of the members of <see cref="TypeFacetKind"/>.
+/// </summary>
+ITypeFacetCollection Facets { get; }
+```
+
+The collection follows the precedent of `IExtensionBlockCollection`, which derives from
+`IReadOnlyCollection<IExtensionBlock>` and is reached by `INamedType.ExtensionBlocks`.
+
+Consumer code:
+
+```csharp
+if ( type.Facets.Union is { } union )
+{
+    foreach ( var unionCase in union.Cases ) { /* ... */ }
+}
+
+var returnType = eventType.Facets.Delegate?.InvokeMethod.ReturnType;
+```
+
+The invariant is that the collection contains exactly the typed properties that are not `null`, and that `Count` is
+their number. The invariant is not that `Count` is at most one. Section 4.2 gives the case where two facets
+coexist.
+
+### 2.2. Facets expose the special members as properties
+
+A facet names every member that the compiler synthesizes for that kind of type, so that no consumer has to reach a
+member by a string literal.
+
+```csharp
+// Metalama.Framework/Code/IDelegateFacet.cs
+[CompileTime]
+public interface IDelegateFacet : ITypeFacet
+{
+    /// <summary>
+    /// Gets the <c>Invoke</c> method, which carries the signature of the delegate.
+    /// </summary>
+    IMethod InvokeMethod { get; }
+
+    IType ReturnType { get; }
+
+    IParameterList Parameters { get; }
+}
+```
+
+```csharp
+// Metalama.Framework/Code/IEnumFacet.cs
+[CompileTime]
+public interface IEnumFacet : ITypeFacet
+{
+    /// <summary>
+    /// Gets the underlying integral type of the enum. Unlike <see cref="INamedType.UnderlyingType"/>, this property
+    /// has one meaning.
+    /// </summary>
+    INamedType UnderlyingType { get; }
+
+    /// <summary>
+    /// Gets the members of the enum, in the order in which they are declared.
+    /// </summary>
+    IReadOnlyList<IField> Members { get; }
+
+    /// <summary>
+    /// Gets a value indicating whether the enum has the <see cref="System.FlagsAttribute"/> attribute.
+    /// </summary>
+    bool IsFlags { get; }
+}
+```
+
+```csharp
+// Metalama.Framework/Code/IRecordFacet.cs
+[CompileTime]
+public interface IRecordFacet : ITypeFacet
+{
+    /// <summary>
+    /// Gets the <c>EqualityContract</c> property, or <c>null</c> when the type is a record struct, which has none.
+    /// </summary>
+    IProperty? EqualityContract { get; }
+
+    IMethod PrintMembersMethod { get; }
+
+    /// <summary>
+    /// Gets the clone method, whose metadata name is <c>&lt;Clone&gt;$</c>, or <c>null</c> when the type is a record
+    /// struct, which has none.
+    /// </summary>
+    IMethod? CloneMethod { get; }
+
+    /// <summary>
+    /// Gets the copy constructor, or <c>null</c> when the type is a record struct, which has none.
+    /// </summary>
+    IConstructor? CopyConstructor { get; }
+
+    /// <summary>
+    /// Gets the <c>Deconstruct</c> method, or <c>null</c> when the record is not positional.
+    /// </summary>
+    IMethod? DeconstructMethod { get; }
+
+    /// <summary>
+    /// Gets the properties that the positional parameters of the record declare, or an empty list when the record is
+    /// not positional.
+    /// </summary>
+    IReadOnlyList<IProperty> PositionalProperties { get; }
+}
+```
+
+```csharp
+// Metalama.Framework/Code/IUnionFacet.cs
+[CompileTime]
+public interface IUnionFacet : ITypeFacet
+{
+    /// <summary>
+    /// Gets the form in which the union is written.
+    /// </summary>
+    UnionForm Form { get; }
+
+    /// <summary>
+    /// Gets the cases of the union, in the order in which the compiler reports them.
+    /// </summary>
+    IReadOnlyList<IUnionCase> Cases { get; }
+
+    /// <summary>
+    /// Gets the <c>Value</c> property, which the compiler synthesizes for a union declaration and which the author
+    /// writes for the attribute form.
+    /// </summary>
+    IProperty ValueProperty { get; }
+}
+
+[CompileTime]
+public enum UnionForm
+{
+    /// <summary>The type is declared with the <c>union</c> keyword.</summary>
+    Declaration,
+
+    /// <summary>The type is a class or a struct that carries <c>UnionAttribute</c>.</summary>
+    Attribute
+}
+
+[CompileTime]
+public interface IUnionCase
+{
+    IType Type { get; }
+
+    /// <summary>
+    /// Gets the zero-based index of the case, in the order in which the compiler reports the cases.
+    /// </summary>
+    int Index { get; }
+
+    /// <summary>
+    /// Gets the creation member of the case: the constructor synthesized for a union declaration, the union
+    /// constructor of the attribute form, or the static <c>Create</c> method of the union member provider.
+    /// </summary>
+    IMethodBase CreationMember { get; }
+
+    /// <summary>
+    /// Creates an expression that creates an instance of the union holding a value of this case.
+    /// </summary>
+    IExpression CreateCreateInstanceExpression( IExpression value );
+}
+```
+
+`IUnionCase` follows `ITupleElement`, which is richer than the type of the element and carries `Index`,
+`HasFriendlyName` and `CorrespondingTupleField`. The richer abstraction is required rather than convenient: Roslyn
+collapses duplicate case types through a set, so the index of a case is not recoverable from its type, and the
+creation member of the attribute form may be a static method rather than a constructor, which `IConstructor` cannot
+express.
+
+### 2.3. Facets expose invokers
+
+The members that a facet exposes are typed as `IMethod`, `IProperty`, `IConstructor` and `IField`. Those interfaces
+derive from the invoker interfaces: `IMethod` derives from `IMethodInvoker`, `IConstructor` from
+`IConstructorInvoker`, and `IFieldOrProperty` from `IFieldOrPropertyInvoker`. A consumer therefore reaches the
+invoker through the member, and no facet declares an invoker member of its own.
+
+```csharp
+// Generates a call to the Invoke method of the delegate.
+var call = eventType.Facets.Delegate!.InvokeMethod.With( handler ).Invoke( args );
+```
+
+A facet declares a method that creates an expression only where no member of the type carries the operation. The
+precedent is `ITupleType.CreateCreateInstanceExpression`, which exists because a tuple is created by a syntactic
+construct and not by calling a member. `IUnionCase.CreateCreateInstanceExpression` exists for the same reason: the
+creation member differs by form, so the consumer would otherwise have to test whether it is a constructor or a
+static method.
+
+### 2.4. Writing is on builders, not on facets
+
+A facet is read-only. An aspect that introduces a type of a specific kind uses a builder interface derived from
+`INamedTypeBuilder`.
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IUnionBuilder.cs
+[InternalImplement]
+public interface IUnionBuilder : INamedTypeBuilder
+{
+    /// <summary>
+    /// Adds a case to the union.
+    /// </summary>
+    IUnionCase AddCase( IType caseType );
+}
+```
+
+The precedent is `IExtensionBlockBuilder`, which derives from `INamedTypeBuilder` and from `IExtensionBlock`, and
+whose documentation lists the inherited operations that are not valid for an extension block. Those operations throw
+`NotSupportedException`. A union builder does the same: `BaseType` cannot be set, because a union declaration is a
+struct, and an instance field, an automatic property and a field-like event cannot be introduced, because the
+compiler reports CS9373 for them in a union declaration.
+
+`IDelegateBuilder`, `IEnumBuilder` and `IRecordBuilder` follow the same shape. They are not part of this proposal
+beyond the shape, because the introduction of those kinds is not currently supported.
+
+The reason for keeping the writing surface off the facet is that the reader and the writer have different
+lifetimes. A facet describes a type that exists. A builder describes a type that is being constructed and whose
+members are not yet resolvable.
+
+## 3. What this replaces, and what it leaves in place
+
+| Existing member | Disposition |
+| --- | --- |
+| `INamedType.IsRecord` | Kept. It is shipped, widely used, and cheap. The documentation gains a reference to `Facets.Record`. |
+| `INamedType.UnderlyingType` | Kept. It is shipped and it also serves nullable reference types. `IEnumFacet.UnderlyingType` is the member with one meaning, and the documentation of both says so. |
+| `IEvent.Signature` | Kept, and defined as `Type.Facets.Delegate!.InvokeMethod`. The four duplicate implementations are removed. The member currently has no documentation and gains it. |
+| `ITupleType`, `ITupleElement` | Kept, and `ITupleType` gains `ITypeFacet` as a base interface, which is a source-compatible and binary-compatible change. |
+| `INamedType.PrimaryConstructor` | Kept. A primary constructor is not specific to records since C# 12, so it does not move to `IRecordFacet`. |
+| `IExtensionBlock` | Unchanged, and deliberately not a facet. See section 4.1. |
+
+No member is made obsolete by this proposal.
+
+## 4. Decisions
+
+### 4.1. An extension block is not a facet
+
+A facet describes the structure of a type that a program can use. A tuple is such a type: a variable can be declared
+of it. An extension block is not: it has no usable name, no variable can be declared of it, and it is reached from
+its containing type through `INamedType.ExtensionBlocks`, where it is a member rather than a facet of itself.
+`IExtensionBlock` derives from `INamedType` for the convenience of the implementation, not because an extension
+block is a type in the sense of the language.
+
+### 4.2. A type may have more than one facet
+
+A record can be a union. The C# 15 proposal resolves that `record union` is not supported, but it also states that
+"any class or struct type with a `System.Runtime.CompilerServices.UnionAttribute` attribute is considered a union
+type", and Roslyn implements exactly that:
+
+```csharp
+internal bool IsUnionType
+    => TypeKind is TypeKind.Class or TypeKind.Struct && IsUnionTypeCore;
+```
+
+A record class is `TypeKind.Class` and a record struct is `TypeKind.Struct`, and no rule excludes them. For the
+attribute form the case set is derived from the signatures: "each constructor with a single parameter is a union
+constructor". The primary constructor of a record with one positional parameter is such a constructor. The
+declaration `[Union] public record Wrapper( int Value );` is therefore a record and a union with one case of type
+`int`, and both `Facets.Record` and `Facets.Union` are not `null` for it.
+
+The copy constructor of a record does not become a case, because it is protected or private and the rule requires
+the member to be public. A record with two or more positional parameters has no union creation member at all, which
+the proposal makes an error.
+
+This is the reason the collection does not promise that `Count` is at most one, and the reason there is no ordering
+of facets by priority. A test with `[Union] public record Wrapper( int Value );` pins the invariant.
+
+### 4.3. No `TypeKind.Union` and no `IUnionType`
+
+The proposal adds no value to `TypeKind` and no interface derived from `INamedType` for unions. Section 1.3 gives
+the two reasons. Roslyn made the same choice: `IsUnion` and `UnionCaseTypes` are declared on `ITypeSymbol`, and
+there is no `IUnionTypeSymbol`.
+
+### 4.4. No flat union members on `INamedType`
+
+Pull request #1991 proposes `INamedType.IsUnion`, `INamedType.IsUnionDeclaration` and
+`INamedType.UnionCaseTypes`. This proposal replaces all three with `Facets.Union`. The recommendation is to hold
+them back from #1991 rather than ship them and duplicate them later, because a shipped public member cannot be
+withdrawn and the repository already carries two members in that situation, `UnderlyingType` and `IsRecord`.
+
+Two of the three would be wrong as specified in any case. `UnionCaseTypes` is documented there as empty when
+`IsUnionDeclaration` is false, which describes the current implementation from syntax rather than the contract:
+Roslyn documents `ITypeSymbol.UnionCaseTypes` as returning the case types "when `IsUnion` is true", and it is
+defined for the attribute form. `IsUnionDeclaration` reads as a question about a declaration, on an object that is
+already an `IDeclaration`. `UnionForm` states the distinction with the vocabulary of the language proposal, which
+defines "union type" and "union declaration" as two terms, and it does so without that collision.
+
+The counter-argument is that `IsUnion` is the cheap first test, that it is what `ITypeSymbol` exposes, and that
+`type.Facets.Union is not null` is longer to write in a predicate over a collection of types. The proposal accepts
+that cost, on the ground that a second way to ask the same question is the defect this document exists to remove.
+
+## 5. Implementation guidelines
+
+These are constraints on the implementation, not a design of it.
+
+1. `Facets` is one member on `INamedType`, for any number of facets. The number of members to implement does not
+   grow when a facet is added. That is the difference from the flat design, which needs one member per exposed
+   value.
+2. The collection constructs the facets. No facet type declares a static factory method that returns `null`. A facet
+   reference that a consumer holds is never `null`, and nullability is expressed only by the properties of the
+   collection.
+3. A type that has no facet returns a shared empty collection. Generic code that walks the model reads `Facets` on
+   every type, so the common case must not allocate.
+4. The implementations of `INamedType` that back a builder return the empty collection rather than throwing.
+   Eligibility rules and advice validation run against builders, so an exception there is reached in normal use.
+5. The facet interfaces name no Roslyn type. `Metalama.Framework` is not built per Roslyn version, while
+   `Metalama.Framework.Engine` is, and the union facet reads `ITypeSymbol.IsUnion` and `ITypeSymbol.UnionCaseTypes`,
+   which exist only in the latest variant. The conditional compilation is therefore confined to the construction of
+   the collection in the engine, under the condition that section 6 of
+   [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) decides. The flat design instead needs a conditional block in
+   each implementation of `INamedType`.
+6. A facet is computed once per type and cached, in the manner of the other collection members of `INamedType`.
+
+## 6. Order of implementation
+
+The delegate facet is implemented first, and deliberately. It requires no C# 15, no Roslyn variant and no preview
+language version, and it has about fifteen call sites to convert, so the shape is exercised against shipped
+behaviour before anything that cannot be revised is public.
+
+| Pull request | Content | Depends on |
+| --- | --- | --- |
+| 1 | `TypeFacetKind`, `ITypeFacet`, `ITypeFacetCollection`, `INamedType.Facets`, `IDelegateFacet`. Conversion of the `Invoke` lookups and of `IEvent.Signature`. | — |
+| 2 | `IEnumFacet`. | 1 |
+| 3 | `ITupleType` gains `ITypeFacet`, and `ITypeFacetCollection.Tuple`. | 1 |
+| 4 | `IRecordFacet`, and the conversion of the synthesized-member lookups of the linker. | 1 |
+| 5 | `IUnionFacet`, `IUnionCase`, `UnionForm`. | 1, and the move to the stable Roslyn |
+| 6 | `IUnionBuilder`, and the builder shapes of the other kinds. | 5, and the union introduction story |
+
+Pull request 1 changes one shipped behaviour: `EligibilityRuleFactory` currently throws `InvalidOperationException`
+when the type of an event is not a well-formed delegate, and it returns `false` after the conversion.
+
+Pull request 1 is also the acceptance test of the design. Fourteen of the fifteen call sites assert that the
+`Invoke` method exists, while `Facets.Delegate` is `null` for a malformed type. If several converted sites end up
+asserting that the facet is not `null`, the nullable collection property is the wrong shape for those consumers, and
+the design has to be revised before the union facet is built on it.
+
+## 7. Open questions
+
+1. Whether `IDelegateFacet` exposes `BeginInvoke` and `EndInvoke`. They exist for a delegate compiled for .NET
+   Framework and not for one compiled for .NET. Exposing them adds two nullable members for a case that no known
+   consumer needs.
+2. Whether `IRecordFacet` is worth its nullable members. `EqualityContract`, `CloneMethod` and `CopyConstructor` are
+   all `null` for a record struct. Splitting the interface in two would remove the nullability and add a type.
+3. Whether the enum members deserve an abstraction of their own, in the manner of `ITupleElement`, carrying the
+   constant value and the index, rather than `IReadOnlyList<IField>`.
+4. Whether `ITypeFacet.Type` is worth its self-reference on a tuple facet. A generic walker that descends from a
+   type into its facets and back reaches the same object.
+5. Whether the `Delegate`, `Enum` and `Record` property names of `ITypeFacetCollection` pass the naming analyzers of
+   this repository.
+6. Whether the union facet is populated for a union read from a referenced assembly. The compiled form does not
+   record the authoring form, so `Form` would report `Attribute` for a type that the author wrote with the `union`
+   keyword.
+
+## 8. References
+
+- [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 3, 4 and 6.
+- [`../2027.0/03-code-model-unions-closed.md`](../2027.0/03-code-model-unions-closed.md), finding CM-1.
+- [`../2027.0/analysis-reports/12-csharp15-api-drafts.md`](../2027.0/analysis-reports/12-csharp15-api-drafts.md),
+  which drafts the flat design and a bundle named `IUnionInfo`, and recommends the flat design.
+- [`../2027.0/analysis-reports/11-introducing-unions-design.md`](../2027.0/analysis-reports/11-introducing-unions-design.md),
+  which records the derivation of the case set of the attribute form.
+- The C# 15 unions proposal, `dotnet/csharplang`, `proposals/csharp-15.0/unions.md`.


### PR DESCRIPTION
Design proposal only. No production code is changed, and nothing described in the document is implemented.

The document proposes a uniform way to expose the structure that is specific to a kind of declared named type: a
delegate signature, an enum underlying type and members, the synthesized members of a record, and the cases and
`Value` property of a C# 15 union. The code model exposes that structure in four different ways today. Two are
defective: a member reached by a string literal, and one member with several meanings. The third is a derived
interface reached by a type test, which is correct for a type that a type expression forms and does not extend to a
declared type. The fourth is flat members on `INamedType`, which is what this proposal replaces.

### The proposal

- `INamedType.Facets`, of type `ITypeFacetCollection : IReadOnlyCollection<ITypeFacet>`, with one nullable read-only
  property per facet, and a `TypeFacetKind` enum. `INamedType` gains one member for any number of facets.
- `IDelegateFacet`, `IEnumFacet`, `IRecordFacet`, `IUnionFacet` and `IUnionCase`. Each facet names the members that
  the compiler synthesizes, so that no consumer reaches one by its identifier.
- Facets expose invokers through the type of their members, because `IMethod`, `IConstructor` and `IFieldOrProperty`
  already derive from the invoker interfaces. A facet declares a method that creates an expression only where no
  member carries the operation, following `ITupleType.CreateCreateInstanceExpression`.
- Writing stays on builder interfaces derived from `INamedTypeBuilder`, following `IExtensionBlockBuilder`, and not
  on the facets.

No member is made obsolete, and the proposal carries no user-facing breaking change.

### Three decisions worth reviewing first

Section 4.4 recommends holding `IsUnion`, `IsUnionDeclaration` and `UnionCaseTypes` back from #1991 rather than
shipping them and duplicating them in `Facets.Union` later. It also records why two of the three would be wrong as
specified there.

Section 4.5 excludes tuples. A tuple is not declared: the type is formed by a type expression at the place where it
is used, which is why `TupleType` sits in `CodeModel/Source/ConstructedTypes/` beside the array and the pointer.
`ITupleType` belongs to the family of `IArrayType` and `IPointerType`, where the type test is the correct
mechanism. The section records the alternative that an earlier revision proposed, which was an `ITupleFacet` with
`ITupleType` obsoleted, and the price it carried.

Section 4.2 establishes that a type can have two facets at once. `record union` is not supported, but the attribute
form of a union accepts a record, and `[Union] public record Wrapper( int Value );` is a record and a union with one
case of type `int`. The collection therefore does not promise that `Count` is at most one, and there is no ordering
of facets by priority.

Section 7 lists five open questions.

### Next steps

The document is written to be reviewed and then split. Section 6 proposes five implementation pull requests,
starting with the delegate facet, which needs no C# 15, no Roslyn variant and no preview language version, and which
has about fifteen call sites to convert. That conversion is the acceptance test of the shape, before the union facet
is built on it.

— Claude for @gfraiteur
