### PR TITLE
Design the application programming interface for introducing structs, enums, delegates, records and unions

### DIFF
--- a/Metalama.Framework/docs/future/introducing-delegates.md
+++ b/Metalama.Framework/docs/future/introducing-delegates.md
@@ -5,16 +5,14 @@ This document designs the introduction of a delegate, which is issue
 implemented.
 
 The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md), which this document does not
-repeat. The one that shapes the interface below is section 2.3 of that document: a delegate builder is the builder
-of the `Invoke` method of the delegate, and it derives from `IMethodBuilder`.
+repeat. The one that shapes the interface below is section 2.3 of that document: a delegate declaration is a method
+signature with the `delegate` keyword in front of it, so `IDelegateBuilder` derives from `IMethodBuilder` and adds
+no member of its own.
 
 The read side of a delegate is `IDelegateFacet`, which is delivered. The design below mirrors it member for member,
 and section 5 states the mapping.
 
 ## 1. What the aspect author writes
-
-A delegate declaration is a method signature with the `delegate` keyword in front of it, so the builder is the
-builder of a method. The delegate type itself is reached through `DeclaringType`.
 
 ```csharp
 public class GenerateChangedEventAttribute : TypeAspect
@@ -25,8 +23,7 @@ public class GenerateChangedEventAttribute : TypeAspect
             "ValueChangedHandler",
             buildDelegate: d =>
             {
-                d.DeclaringType.Accessibility = Accessibility.Public;
-
+                d.Accessibility = Accessibility.Public;
                 d.ReturnType = TypeFactory.GetType( SpecialType.Void );
                 d.AddParameter( "sender", builder.Target );
                 d.AddParameter( "oldValue", typeof(object) );
@@ -41,20 +38,19 @@ public class GenerateChangedEventAttribute : TypeAspect
 The introduced delegate is read from `handler.Declaration`, which is an `INamedType`, and is used there as the type
 of an introduced field.
 
-The type parameters of a delegate belong to the type and not to its `Invoke` method, so they are added through
-`DeclaringType` as well, and they may declare variance:
+A generic delegate adds type parameters, and may give them variance:
 
 ```csharp
 builder.IntroduceDelegate(
     "Transformer",
     buildDelegate: d =>
     {
-        d.DeclaringType.Accessibility = Accessibility.Public;
+        d.Accessibility = Accessibility.Public;
 
-        var input = d.DeclaringType.AddTypeParameter( "TInput" );
+        var input = d.AddTypeParameter( "TInput" );
         input.Variance = VarianceKind.In;
 
-        var output = d.DeclaringType.AddTypeParameter( "TOutput" );
+        var output = d.AddTypeParameter( "TOutput" );
         output.Variance = VarianceKind.Out;
 
         d.ReturnType = output;
@@ -84,29 +80,34 @@ public delegate TOutput Transformer<in TInput, out TOutput>( TInput value );
 namespace Metalama.Framework.Code.DeclarationBuilders;
 
 /// <summary>
-/// Allows to complete the construction of a delegate that has been created by an advice. This interface builds the
-/// <c>Invoke</c> method of the delegate, which carries its signature, and the delegate type itself is reached
-/// through <see cref="DeclaringType"/>.
+/// Allows to complete the construction of a delegate that has been created by an advice.
 /// </summary>
 /// <remarks>
 /// <para>
-/// A delegate declaration is a method signature with the <c>delegate</c> keyword in front of it, so the members
-/// that configure it are the members that configure a method, and this interface derives from
-/// <see cref="IMethodBuilder"/> rather than declaring them again. The return type, the parameters and the custom
-/// attributes of the return value are set through the inherited members.
+/// A delegate declaration is a method signature with the <c>delegate</c> keyword in front of it, so this interface
+/// derives from <see cref="IMethodBuilder"/> and declares no member of its own. The return type, the return
+/// parameter and the parameters are the signature of the delegate. The name, the accessibility, the custom
+/// attributes and the type parameters are the delegate's, because the <c>Invoke</c> method that the compiler
+/// synthesizes has no choice about any of them: it is named <c>Invoke</c>, it is public, it carries no attribute
+/// and it is never generic.
 /// </para>
 /// <para>
-/// What belongs to the type and not to the method is set through <see cref="DeclaringType"/>: the name of the
-/// delegate, its accessibility, its custom attributes and its type parameters. The corresponding inherited members
-/// describe the <c>Invoke</c> method, whose name is <c>Invoke</c> and whose accessibility is public, and the
-/// language fixes both, so their setter throws a <see cref="NotSupportedException"/>. The operations that are not
-/// valid are listed in the design document.
+/// The following inherited members are not valid for a delegate, and their setter throws a
+/// <see cref="NotSupportedException"/>: <see cref="IMemberOrNamedTypeBuilder.IsStatic"/>,
+/// <see cref="IMemberOrNamedTypeBuilder.IsSealed"/>, <see cref="IMemberOrNamedTypeBuilder.IsAbstract"/>,
+/// <see cref="IMemberOrNamedTypeBuilder.IsPartial"/>, <see cref="IMemberBuilder.IsVirtual"/>,
+/// <see cref="IMemberBuilder.IsExtern"/>, <see cref="IMethodBuilder.IsReadOnly"/> and
+/// <see cref="IMethodBuilder.OperatorKind"/>. The design document lists them with the reason for each.
 /// </para>
 /// <para>
-/// A delegate builder is not an <see cref="INamedType"/>, so it may not be used where an <see cref="IType"/> is
-/// expected, and neither may <see cref="DeclaringType"/> be used as the finished type. The introduced delegate is
-/// read from <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>, which is how an
-/// aspect gives it as the type of a field, of a property or of an event.
+/// <see cref="IMember.DeclaringType"/> reports the delegate type and is read-only. It is not how the delegate is
+/// configured, and an aspect has no reason to reach it: everything an author chooses is on this interface.
+/// </para>
+/// <para>
+/// This interface is not an <see cref="INamedType"/>, so it may not be used where an <see cref="IType"/> is
+/// expected. The introduced delegate is read from
+/// <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>, which is how an aspect gives
+/// it as the type of a field, of a property or of an event.
 /// </para>
 /// <para>
 /// The <c>BeginInvoke</c> and <c>EndInvoke</c> methods are not exposed and are not built. They exist only for a
@@ -116,29 +117,13 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet"/>
 /// <seealso href="@introducing-types"/>
 [InternalImplement]
-public interface IDelegateBuilder : IMethodBuilder
-{
-    /// <summary>
-    /// Gets the builder of the delegate type that declares this <c>Invoke</c> method. The name of the delegate, its
-    /// accessibility, its custom attributes and its type parameters are set through this property.
-    /// </summary>
-    /// <remarks>
-    /// <para>
-    /// This property narrows <see cref="IMember.DeclaringType"/>, which reports an <see cref="INamedType"/>, to the
-    /// builder of that type, so that the type can be configured while it is being built.
-    /// </para>
-    /// <para>
-    /// The following members of the returned builder are not valid for a delegate, and their setter throws a
-    /// <see cref="NotSupportedException"/>: <see cref="INamedTypeBuilder.BaseType"/>, because a delegate derives
-    /// from <see cref="System.MulticastDelegate"/> and the language allows no other base;
-    /// <see cref="INamedTypeBuilder.IsClosed"/>; and
-    /// <see cref="IMemberOrNamedTypeBuilder.IsStatic"/>, <see cref="IMemberOrNamedTypeBuilder.IsSealed"/>,
-    /// <see cref="IMemberOrNamedTypeBuilder.IsAbstract"/> and <see cref="IMemberOrNamedTypeBuilder.IsPartial"/>.
-    /// </para>
-    /// </remarks>
-    new INamedTypeBuilder DeclaringType { get; }
-}
+public interface IDelegateBuilder : IMethodBuilder;
 ```
+
+The interface adds no member, in the manner of `IFieldBuilder`, which is also a name for a combination of
+interfaces that carries nothing of its own. It exists so that the advice method has a parameter type of its own,
+so that the restrictions above have a place to be documented, and so that a member can be added later without a
+breaking change.
 
 ### 3.2. The advice method
 
@@ -151,9 +136,8 @@ public interface IDelegateBuilder : IMethodBuilder
 /// <param name="name">The name of the introduced delegate.</param>
 /// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
 ///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
-/// <param name="buildDelegate">An optional callback that allows you to configure the introduced delegate. The
-///     callback receives the builder of the <c>Invoke</c> method of the delegate, which carries its signature, and
-///     reaches the delegate type itself through <see cref="IDelegateBuilder.DeclaringType"/>. A delegate that the
+/// <param name="buildDelegate">An optional callback that allows you to configure the introduced delegate, which
+///     means its accessibility, its custom attributes, its type parameters and its signature. A delegate that the
 ///     callback leaves unconfigured is internal, returns <c>void</c> and takes no parameter.</param>
 /// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
 /// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced delegate.
@@ -177,10 +161,8 @@ IIntroductionAdviceResult<INamedType> IntroduceDelegate(
 /// <param name="name">The delegate name.</param>
 /// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
 ///     in the target type or namespace. The default strategy is to fail with a compile-time error.</param>
-/// <param name="buildDelegate">An optional delegate that modifies the <see cref="IDelegateBuilder"/>, which is
-///     the builder of the <c>Invoke</c> method of the introduced delegate. The signature of the delegate is given
-///     through this callback, and the delegate type is reached through
-///     <see cref="IDelegateBuilder.DeclaringType"/>.</param>
+/// <param name="buildDelegate">An optional delegate that modifies the <see cref="IDelegateBuilder"/> that
+///     represents the introduced delegate. Its signature is given through this callback.</param>
 /// <returns>An <see cref="IIntroductionAdviceResult{T}"/> that exposes the outcome of the operation and the
 /// introduced <see cref="INamedType"/>.</returns>
 /// <seealso href="@introducing-types"/>
@@ -196,22 +178,23 @@ public static IIntroductionAdviceResult<INamedType> IntroduceDelegate(
         buildDelegate );
 ```
 
-## 4. The inherited operations that are not valid
+## 4. The inherited operations, and which of them are not valid
 
-`IDelegateBuilder` inherits the whole of `IMethodBuilder`. The members that describe a signature are valid, and the
-members that describe a method as a member of a type are not, because the `Invoke` method of a delegate is
-synthesized and the language fixes every one of them.
+`IDelegateBuilder` inherits the whole of `IMethodBuilder` and adds nothing. Most of it is valid. The members that
+describe a signature describe the signature of the delegate, and the members that describe a declaration describe
+the delegate, because the `Invoke` method has no choice about any of them.
 
 | Member | State |
 | --- | --- |
 | `ReturnType`, `ReturnParameter` | Valid. `ReturnParameter` also carries the reference kind of a `ref` return and the custom attributes of the return value. |
 | `Parameters`, `AddParameter`, `InsertParameter` | Valid. These are the parameters of the delegate. |
-| `Name` | The setter throws a `NotSupportedException`. The getter reports `Invoke`. The name of the delegate is `DeclaringType.Name`. |
-| `Accessibility` | The setter throws a `NotSupportedException`. The `Invoke` method of a delegate is public. The accessibility of the delegate is `DeclaringType.Accessibility`. |
-| `AddTypeParameter` | The setter throws a `NotSupportedException`. The `Invoke` method of a delegate is never generic, and the type parameters of the delegate are added through `DeclaringType.AddTypeParameter`. |
-| `AddAttribute`, `AddAttributes`, `RemoveAttributes` | The methods throw a `NotSupportedException`. A delegate declaration has no place to write an attribute on the `Invoke` method. An attribute on the delegate is added through `DeclaringType`, and an attribute on the return value through `ReturnParameter`. |
+| `Name` | Valid. It is the name of the delegate, which the advice method also takes. |
+| `Accessibility` | Valid. It is the accessibility of the delegate. |
+| `AddTypeParameter` | Valid. The type parameters belong to the delegate, and a delegate is one of the two kinds of type whose type parameters may declare variance. |
+| `AddAttribute`, `AddAttributes`, `RemoveAttributes` | Valid. The attributes are those of the delegate. An attribute on the return value is added through `ReturnParameter`. |
+| `DeclaringType` | Read-only, and reports the delegate type. Section 6.2 states what it is for. |
+| `IsStatic`, `IsSealed`, `IsAbstract`, `IsPartial` | The setter throws a `NotSupportedException`. A delegate is implicitly sealed, and it is never static, abstract or partial. |
 | `IsVirtual`, `IsExtern` | The setter throws a `NotSupportedException`. |
-| `IsStatic`, `IsSealed`, `IsAbstract`, `IsPartial` | The setter throws a `NotSupportedException`. |
 | `IsReadOnly` | The setter throws a `NotSupportedException`. It applies to a member of a struct. |
 | `OperatorKind` | The setter throws a `NotSupportedException`. |
 
@@ -220,23 +203,18 @@ usable while the delegate is being built, because the type does not exist yet, a
 method that the facet of the introduced type reports. `MethodBuilder`, which backs every introduced method, already
 faces that question, so this design adds nothing to it.
 
-Every operation of `INamedTypeBuilder` is reached through `DeclaringType` rather than being absent, which is the
-difference between this kind and the enum. The members of that builder that a delegate does not accept are listed
-in the documentation of `DeclaringType` in section 3.1.
-
 ## 5. What the facet of the introduced delegate reports
 
 A delegate builder declares no `Facets` member, because `IDelegateBuilder` derives from `IMethodBuilder` and a
-method has no facet. `DeclaringType`, which is the delegate type under construction, does declare one, and it
-throws a `NotSupportedException`, which section 5.1 of [`introducing-types.md`](introducing-types.md) states for
-every builder. The kind of a builder is read from `IsDelegate`, which answers without allocating and does not
-throw.
+method has no facet. `DeclaringType`, which reports the delegate type while it is being built, does declare one,
+and it throws a `NotSupportedException`, which section 5.1 of [`introducing-types.md`](introducing-types.md) states
+for every builder. The kind is read from `IsDelegate`, which answers without allocating and does not throw.
 
-That neither object is usable as a finished type bounds the risk of the exception. Section 5.1 lists
-`EventBuilder.Signature` and the eligibility rule of `AdviceKind.OverrideEventInvoke` as the readers that take the
-type of an event from the aspect. An aspect cannot give a delegate builder as the type of an event, because it is
-not an `IType` at all, and it does not give `DeclaringType` either, because the finished delegate is the result of
-the advice. Neither reader meets a builder in the course an aspect actually takes.
+That no object reachable during construction is usable as a finished type bounds the risk of the exception. Section
+5.1 lists `EventBuilder.Signature` and the eligibility rule of `AdviceKind.OverrideEventInvoke` as the readers that
+take the type of an event from the aspect. A delegate builder cannot be given as the type of an event, because it
+is not an `IType` at all, and an aspect has no reason to reach `DeclaringType`, because the finished delegate is
+the result of the advice. Neither reader meets a builder in the course an aspect actually takes.
 
 The introduced type reports an `IDelegateFacet`.
 
@@ -275,52 +253,74 @@ same parameters.
 
 ## 6. Decisions
 
-### 6.1. The builder is the `Invoke` method, and it derives from `IMethodBuilder`
+### 6.1. The builder derives from `IMethodBuilder` and adds no member
 
 A delegate declaration is a method signature with the `delegate` keyword in front of it. Everything an author
-chooses about the signature is what an author chooses about a method, so `IDelegateBuilder` derives from
-`IMethodBuilder` and declares one member of its own.
+chooses about it is something an author chooses about a method, so `IDelegateBuilder` derives from `IMethodBuilder`
+and declares nothing of its own. The precedent for an interface that is a name for a combination and carries no
+member is `IFieldBuilder`.
 
-An earlier revision of this document rejected that base and gave a reason that does not hold. The reason was that
+An earlier revision of this document rejected that base, and the reason it gave does not hold. The reason was that
 `IMethodBuilder` reaches `IMember`, whose `DeclaringType` is not nullable, and that a delegate declared in a
-namespace has no declaring type. That confuses the delegate with its `Invoke` method. The builder is the `Invoke`
-method, its declaring type is the delegate, and a delegate always has one, so the obstacle that section 2.1 of
+namespace has no declaring type. That confuses the delegate with its `Invoke` method. The declaring type of that
+method is the delegate, and a delegate always has one, so the obstacle that section 2.1 of
 [`introducing-types.md`](introducing-types.md) records against `IMemberBuilder` for an enum does not arise here.
 The same revision objected that `IMethod` derives from `IMethodInvoker`. That is not a cost either: generating a
 call to the `Invoke` method of a delegate is what `IDelegateFacet` exists for, and the facet documents it.
 
-Two alternatives were weighed against this one.
+Two alternatives were weighed and both are rejected.
 
-Declaring the signature members on a builder of the type, which is what the earlier revision did, restates
-`ReturnType`, `ReturnParameter`, `Parameters`, `AddParameter` and `InsertParameter` on an interface that is not a
-method. It carries no member that `IMethodBuilder` does not already carry, and an aspect that copies a signature
-from an existing method has to transfer it member by member instead of using the operations it already knows.
+Declaring the signature members on a builder of the type restates `ReturnType`, `ReturnParameter`, `Parameters`,
+`AddParameter` and `InsertParameter` on an interface that is not a method. It carries no member that
+`IMethodBuilder` does not already carry, and an aspect that copies a signature from an existing method has to
+transfer it member by member instead of using the operations it already knows.
 
-Exposing an `InvokeMethod` property typed as `IMethodBuilder`, which a revision before that one did, gives the same
-operations through one more indirection, and leaves the builder of the type carrying a name and an accessibility
-beside a method that has its own.
+Exposing an `InvokeMethod` property typed as `IMethodBuilder` gives the same operations through one more
+indirection, and leaves the builder of the type carrying a name and an accessibility beside a method that has its
+own.
 
-The cost of the decision is that what belongs to the type is set through `DeclaringType`, so making a delegate
-public is `d.DeclaringType.Accessibility = Accessibility.Public` rather than `d.Accessibility = ...`. That is
-accepted rather than hidden. Reinterpreting the inherited `Name` and `Accessibility` as the delegate's would make
-the builder report, while it is an `IMethod`, a name that is not the name of the method it is, and the code model
-does not say two things with one member.
+### 6.2. The inherited members describe the delegate, and `DeclaringType` is not used
 
-### 6.2. The type parameters belong to the type, so they are added through `DeclaringType`
+`Name`, `Accessibility`, `AddAttribute` and `AddTypeParameter` describe the delegate and not the `Invoke` method.
+The reason they can is that the `Invoke` method has no choice about any of them: the language names it `Invoke`,
+makes it public, gives it no attribute and forbids it to be generic. A setter that would otherwise be refused as
+invalid therefore carries one meaning and not two.
+
+The alternative, which a revision of this document took, is to define those members as the method's, to refuse
+their setter, and to expose `DeclaringType` narrowed to an `INamedTypeBuilder` so that the type can be configured
+through it. It is rejected on two grounds.
+
+The first is that it is not more honest, only more indirect. A builder is an authoring object and not a projection
+of the code model, and every other builder of the namespace already names the declaration the advice introduces.
+`IDelegateBuilder.Name` naming the delegate is what a reader of the other four documents expects.
+
+The second is the cost. Making a delegate public would be
+`d.DeclaringType.Accessibility = Accessibility.Public`, and adding a type parameter would be
+`d.DeclaringType.AddTypeParameter( "T" )`. That is paid on every delegate an aspect introduces, in exchange for a
+distinction that has no consequence, because the two objects can never disagree: the `Invoke` method has exactly
+one possible name, accessibility and attribute set.
+
+`DeclaringType` therefore stays as `IMember` declares it, reports the delegate type, and is read-only. The
+implementation supplies a read-only named type rather than a second builder, and the configuration flows from the
+method builder into it when the builder is frozen. An aspect has no reason to reach it, and the documentation of
+the interface says so.
+
+The one residue is that `Name` reports the name of the delegate on an object that is an `IMethod`, whose
+`Invoke` method is named `Invoke`. The introduced model does not inherit that: `IDelegateFacet.InvokeMethod.Name`
+is `Invoke`, as it is for a delegate read from source. The divergence is confined to the authoring object, and a
+unit test pins it.
+
+### 6.3. The type parameters belong to the delegate
 
 The language places the type parameters of a delegate on the type: `Func<T, TResult>` is a generic type whose
-`Invoke` method is not generic. `DeclaringType.AddTypeParameter` therefore adds them, and the inherited
-`IMethodBuilder.AddTypeParameter`, which would add one to the `Invoke` method, throws.
-
-Shadowing the inherited method and redefining it as the type's was considered and rejected. Two methods of the same
-name and signature, one of which silently means something the other does not, is harder to read than one that
-throws and one that is reached through the type.
+`Invoke` method is not generic. `AddTypeParameter` therefore adds them to the delegate, which is section 6.2, and
+there is no operation that adds one to the `Invoke` method, because none is valid.
 
 The consequence that the documentation states is that a delegate is the one kind of type, besides an interface,
 whose type parameters may declare variance, so `ITypeParameterBuilder.Variance` is meaningful here and nowhere
 else among the five kinds.
 
-### 6.3. A delegate is introduced by its own advice method
+### 6.4. A delegate is introduced by its own advice method
 
 The reasoning is that of section 6.2 of [`introducing-structs.md`](introducing-structs.md). A delegate accepts a
 configuration that no other kind accepts, which is a signature, and it accepts almost nothing that the other kinds
@@ -328,19 +328,12 @@ accept.
 
 ## 7. Open questions
 
-### 7.1. Is `DeclaringType` the right way to configure the type?
+None.
 
-Section 6.1 accepts that making a delegate public is `d.DeclaringType.Accessibility = Accessibility.Public`. That is
-the price of a builder that is honestly the `Invoke` method, and it is paid on every delegate an aspect introduces,
-because a delegate that is not public is rarely what the author wants.
-
-What would settle whether the price is too high is the set of aspects written against this interface once it
-exists. If it is, the remedy is a second callback on the advice method, typed `Action<INamedTypeBuilder>`, for the
-type, rather than reinterpreting a member of the method builder as the type's.
-
-A `ref` return and a pointer parameter are in scope and are not open. A delegate may return by reference and may
-take a pointer parameter in an unsafe context, `ReturnParameter` and `AddParameter` express both, and each is
-covered by a test rather than refused.
+Whether the type-level members should describe the delegate or the `Invoke` method was open in an earlier revision
+and is answered by section 6.2. A `ref` return and a pointer parameter are in scope: a delegate may return by
+reference and may take a pointer parameter in an unsafe context, `ReturnParameter` and `AddParameter` express both,
+and each is covered by a test rather than refused.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/introducing-delegates.md
+++ b/Metalama.Framework/docs/future/introducing-delegates.md
@@ -71,6 +71,15 @@ private ValueChangedHandler _onValueChanged;
 public delegate TOutput Transformer<in TInput, out TOutput>( TInput value );
 ```
 
+A delegate cannot be partial, so the design-time path needs one guard that section 4.1 of
+[`introducing-types.md`](introducing-types.md) describes.
+`DesignTimeSyntaxTreeGenerator.ProcessTransformationsOnNamespace` routes an introduced type that carries no
+transformation of its own into `ProcessTransformationsOnType`, which calls `CreatePartialType` on it. That method
+returns a `TypeDeclarationSyntax` and emits the `partial` modifier, so an introduced delegate reaching it falls to the
+default arm of its switch and throws. The routing skips a kind that cannot be partial and cannot contain a member,
+and `CreatePartialType` gains no arm. The delegate itself is emitted at design time by
+`IntroduceNamedTypeTransformation.GetInjectedMembers`, which is the same method the build uses.
+
 ## 3. The interfaces
 
 ### 3.1. `IDelegateBuilder`
@@ -310,6 +319,20 @@ The one residue is that `Name` reports the name of the delegate on an object tha
 `Invoke` method is named `Invoke`. The introduced model does not inherit that: `IDelegateFacet.InvokeMethod.Name`
 is `Invoke`, as it is for a delegate read from source. The divergence is confined to the authoring object, and a
 unit test pins it.
+
+The objection to that residue is broader than the name, and it is recorded here because it is formally correct and
+was overruled deliberately. Deriving from `IMethodBuilder` makes `IDelegateBuilder` an `IMethod`, so the inherited
+members that describe a method as an object, which are `DeclarationKind`, `Definition`, `ToRef`, the conversion to
+a reflection object and the invoker, have no coherent method to describe while the builder carries the name and the
+accessibility of the delegate. A builder of the type with composed signature operations, or a builder that exposes
+an `InvokeMethod`, has no such object.
+
+It is overruled because the alternative costs more than it buys. Both alternatives restate five signature members
+that `IMethodBuilder` already declares, and the second adds an object whose name, accessibility and modifiers are
+all invalid. The members the objection names are not reached by an aspect that configures a delegate, and the
+authoring object lives until the advice completes, after which the code model reports the `Invoke` method
+correctly. The convenience of one object, with no duplicated surface, is the property this design optimises for,
+and this paragraph is here so that a later reader knows the trade was seen rather than missed.
 
 ### 6.3. The type parameters belong to the delegate
 

--- a/Metalama.Framework/docs/future/introducing-delegates.md
+++ b/Metalama.Framework/docs/future/introducing-delegates.md
@@ -1,0 +1,394 @@
+# Introducing a delegate
+
+This document designs the introduction of a delegate, which is issue
+[#865](https://github.com/metalama/Metalama/issues/865). It is a design proposal. Nothing described here is
+implemented.
+
+The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md), which this document does not
+repeat. The one that shapes the interface below is section 2 of that document: a delegate builder derives from
+`IMemberOrNamedTypeBuilder` and not from `INamedTypeBuilder`, because a delegate declaration has no member list.
+
+The read side of a delegate is `IDelegateFacet`, which is delivered. The design below mirrors it member for member,
+and section 5 states the mapping.
+
+## 1. What the aspect author writes
+
+```csharp
+public class GenerateChangedEventAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var handler = builder.IntroduceDelegate(
+            "ValueChangedHandler",
+            buildDelegate: d =>
+            {
+                d.Accessibility = Accessibility.Public;
+                d.ReturnType = TypeFactory.GetType( SpecialType.Void );
+                d.AddParameter( "sender", builder.Target );
+                d.AddParameter( "oldValue", typeof(object) );
+                d.AddParameter( "newValue", typeof(object) );
+            } );
+
+        builder.IntroduceField( "_onValueChanged", handler.Declaration );
+    }
+}
+```
+
+The introduced delegate is reached through `handler.Declaration`, which is an `INamedType`, and is used there as the
+type of an introduced field. The builder itself could not be used in that position, for the reason that section 2.4
+of [`introducing-types.md`](introducing-types.md) gives.
+
+A generic delegate adds type parameters to the type, and may give them variance:
+
+```csharp
+builder.IntroduceDelegate(
+    "Transformer",
+    buildDelegate: d =>
+    {
+        d.Accessibility = Accessibility.Public;
+
+        var input = d.AddTypeParameter( "TInput" );
+        input.Variance = VarianceKind.In;
+
+        var output = d.AddTypeParameter( "TOutput" );
+        output.Variance = VarianceKind.Out;
+
+        d.ReturnType = output;
+        d.AddParameter( "value", input );
+    } );
+```
+
+## 2. What Metalama produces
+
+```csharp
+public delegate void ValueChangedHandler( TargetType sender, object oldValue, object newValue );
+
+// and, in the target type:
+private ValueChangedHandler _onValueChanged;
+```
+
+```csharp
+public delegate TOutput Transformer<in TInput, out TOutput>( TInput value );
+```
+
+## 3. The interfaces
+
+### 3.1. `IDelegateBuilder`
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IDelegateBuilder.cs
+namespace Metalama.Framework.Code.DeclarationBuilders;
+
+/// <summary>
+/// Allows to complete the construction of a delegate that has been created by an advice.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface derives from <see cref="IMemberOrNamedTypeBuilder"/> and not from
+/// <see cref="INamedTypeBuilder"/>, because a delegate declaration has no member list and no base type that an
+/// author may choose. The operations that a delegate does not have are therefore absent rather than present and
+/// failing. The operations that it inherits and does not have are listed below.
+/// </para>
+/// <para>
+/// The following inherited properties are not valid for a delegate, and their setter throws a
+/// <see cref="NotSupportedException"/>: <see cref="IMemberOrNamedTypeBuilder.IsStatic"/>,
+/// <see cref="IMemberOrNamedTypeBuilder.IsSealed"/>, <see cref="IMemberOrNamedTypeBuilder.IsAbstract"/> and
+/// <see cref="IMemberOrNamedTypeBuilder.IsPartial"/>. A delegate is implicitly sealed, it may not be abstract or
+/// static, and the language has no partial delegate.
+/// </para>
+/// <para>
+/// A delegate builder is not an <see cref="INamedType"/>, so it may not be used where an <see cref="IType"/> is
+/// expected. The introduced delegate is read from
+/// <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>, which is how an aspect gives
+/// the introduced delegate as the type of a field, of a property or of an event.
+/// </para>
+/// </remarks>
+/// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet"/>
+/// <seealso href="@introducing-types"/>
+[InternalImplement]
+public interface IDelegateBuilder : IMemberOrNamedTypeBuilder
+{
+    /// <summary>
+    /// Gets the builder of the <c>Invoke</c> method, which carries the signature of the delegate.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// This property is the complete signature of the delegate, and
+    /// <see cref="ReturnType"/>, <see cref="Parameters"/> and
+    /// <see cref="AddParameter(string,IType,Code.RefKind,TypedConstant?)"/>
+    /// are shortcuts onto it. It is exposed so that an aspect that already has an <see cref="IMethod"/> to copy, in
+    /// particular the <c>Invoke</c> method of another delegate, can configure the signature by the same operations
+    /// it would use on any method.
+    /// </para>
+    /// <para>
+    /// The following operations of the method builder are not valid on the <c>Invoke</c> method of a delegate, and
+    /// each of them throws a <see cref="NotSupportedException"/>:
+    /// <see cref="IMethodBuilder.AddTypeParameter"/>, because the type parameters of a delegate belong to the type
+    /// and are added by <see cref="AddTypeParameter"/> on this interface;
+    /// <see cref="IMemberOrNamedTypeBuilder.Name"/> and
+    /// <see cref="IMemberOrNamedTypeBuilder.Accessibility"/>, which the language fixes;
+    /// <see cref="IMethodBuilder.OperatorKind"/>; <see cref="IMethodBuilder.IsReadOnly"/>; and every modifier that
+    /// <see cref="IMemberBuilder"/> and <see cref="IMemberOrNamedTypeBuilder"/> declare.
+    /// </para>
+    /// <para>
+    /// The <c>BeginInvoke</c> and <c>EndInvoke</c> methods are not exposed and are not built. They exist only for a
+    /// delegate compiled for .NET Framework, and they are the asynchronous pattern that preceded <c>async</c>.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.InvokeMethod"/>
+    IMethodBuilder InvokeMethod { get; }
+
+    /// <summary>
+    /// Gets or sets the return type of the delegate, which is the return type of <see cref="InvokeMethod"/>. The
+    /// default value is <c>void</c>.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.ReturnType"/>
+    IType ReturnType { get; set; }
+
+    /// <summary>
+    /// Gets the parameters of the delegate, which are the parameters of <see cref="InvokeMethod"/>.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.Parameters"/>
+    IParameterBuilderList Parameters { get; }
+
+    /// <summary>
+    /// Appends a parameter to the delegate.
+    /// </summary>
+    /// <param name="name">The name of the parameter.</param>
+    /// <param name="type">The type of the parameter.</param>
+    /// <param name="refKind">The reference kind of the parameter.</param>
+    /// <param name="defaultValue">The default value of the parameter, or <c>null</c> when it has none.</param>
+    /// <returns>An <see cref="IParameterBuilder"/> that allows you to further build the new parameter.</returns>
+    IParameterBuilder AddParameter(
+        string name,
+        IType type,
+        RefKind refKind = RefKind.None,
+        TypedConstant? defaultValue = default );
+
+    /// <summary>
+    /// Appends a parameter to the delegate.
+    /// </summary>
+    /// <param name="name">The name of the parameter.</param>
+    /// <param name="type">The type of the parameter.</param>
+    /// <param name="refKind">The reference kind of the parameter.</param>
+    /// <param name="defaultValue">The default value of the parameter, or <c>null</c> when it has none.</param>
+    /// <returns>An <see cref="IParameterBuilder"/> that allows you to further build the new parameter.</returns>
+    IParameterBuilder AddParameter(
+        string name,
+        Type type,
+        RefKind refKind = RefKind.None,
+        TypedConstant? defaultValue = null );
+
+    /// <summary>
+    /// Adds a type parameter to the delegate.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The type parameters of a delegate belong to the type and not to its <c>Invoke</c> method, so they are added
+    /// here. A delegate is the one kind of type whose type parameters may declare variance, through
+    /// <see cref="ITypeParameterBuilder.Variance"/>.
+    /// </para>
+    /// </remarks>
+    /// <param name="name">The name of the type parameter.</param>
+    /// <returns>An <see cref="ITypeParameterBuilder"/> that allows you to further configure the new type
+    ///     parameter, including its constraints and its variance.</returns>
+    ITypeParameterBuilder AddTypeParameter( string name );
+}
+```
+
+### 3.2. The advice method
+
+```csharp
+// Metalama.Framework/Advising/IAdviceFactory.cs
+/// <summary>
+/// Introduces a new delegate to the target namespace or type.
+/// </summary>
+/// <param name="targetNamespaceOrType">The namespace or type into which the delegate must be introduced.</param>
+/// <param name="name">The name of the introduced delegate.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildDelegate">An optional callback that allows you to configure the introduced delegate, in
+///     particular to give it a return type and parameters. A delegate that the callback leaves unconfigured
+///     returns <c>void</c> and takes no parameter.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
+/// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced delegate.
+/// Unlike the result of introducing a class, this result must not be used to introduce members, because a delegate
+/// accepts none.</returns>
+IIntroductionAdviceResult<INamedType> IntroduceDelegate(
+    INamespaceOrNamedType targetNamespaceOrType,
+    string name,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<IDelegateBuilder>? buildDelegate = null );
+```
+
+```csharp
+// Metalama.Framework/Aspects/AdviserExtensions.cs
+/// <summary>
+/// Introduces a new delegate into the current namespace (as a top-level type) or type (as a nested type).
+/// Use the <see cref="IAdviser.With{TNewDeclaration}"/> or <see cref="WithNamespace"/> method to introduce the
+/// delegate to a different type or namespace than the current one.
+/// </summary>
+/// <param name="adviser">An adviser for a named type or namespace.</param>
+/// <param name="name">The delegate name.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target type or namespace. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildDelegate">An optional delegate that modifies the <see cref="IDelegateBuilder"/> that
+///     represents the introduced delegate. The signature of the delegate is given through this callback.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> that exposes the outcome of the operation and the
+/// introduced <see cref="INamedType"/>.</returns>
+/// <seealso href="@introducing-types"/>
+public static IIntroductionAdviceResult<INamedType> IntroduceDelegate(
+    this IAdviser<INamespaceOrNamedType> adviser,
+    string name,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<IDelegateBuilder>? buildDelegate = null )
+    => ((IAdviserInternal) adviser).AdviceFactory.IntroduceDelegate(
+        adviser.Target,
+        name,
+        whenExists,
+        buildDelegate );
+```
+
+## 4. The inherited operations that are not valid
+
+`IDelegateBuilder` inherits six settable properties from `IMemberOrNamedTypeBuilder`. Two are valid and four are
+not.
+
+| Member | State |
+| --- | --- |
+| `Accessibility` | Valid. |
+| `Name` | Valid. |
+| `IsStatic` | The setter throws a `NotSupportedException`. A delegate is neither static nor an instance type. |
+| `IsSealed` | The setter throws a `NotSupportedException`. A delegate is implicitly sealed. |
+| `IsAbstract` | The setter throws a `NotSupportedException`. A delegate may not be abstract. |
+| `IsPartial` | The setter throws a `NotSupportedException`. The language has no partial delegate. |
+
+The operations of `IDeclarationBuilder` are all valid: a delegate carries attributes.
+
+The restrictions on `InvokeMethod` are listed in the documentation of that property in section 3.1, and they exist
+because `IMethodBuilder` is reused whole rather than narrowed. Section 6.2 states why reuse is preferred to a
+narrower interface here and not for the members of an enum.
+
+Every operation of `INamedTypeBuilder` is absent rather than failing, because `IDelegateBuilder` does not derive
+from that interface. The one operation of `INamedTypeBuilder` that a delegate genuinely needs is
+`AddTypeParameter`, which section 3.1 declares again.
+
+## 5. What the facet of the introduced delegate reports
+
+The introduced type reports an `IDelegateFacet` rather than the empty collection, which replaces implementation
+guideline 5 of [`type-facets.md`](type-facets.md) for this kind.
+
+| `IDelegateFacet` member | Source |
+| --- | --- |
+| `InvokeMethod` | The method that `IDelegateBuilder.InvokeMethod` built, materialized as a builder so that the facet can name it without re-reading the model from Roslyn. |
+| `ReturnType` | The return type of that method. |
+| `Parameters` | The parameters of that method. |
+| `FacetKind` | `TypeFacetKind.Delegate`. |
+| `Type` | The introduced type. |
+
+`INamedType.IsDelegate` reports `true`, and `INamedType.Methods` contains the `Invoke` method, which is what it
+contains for a delegate read from source.
+
+`DelegateFacet` resolves the `Invoke` method by name today, through
+`this.Type.Methods.OfName( "Invoke" ).Single()`. That continues to work for an introduced delegate, because the
+method is a member of the type like any other. The facet needs no branch for an introduced delegate.
+
+`BeginInvoke` and `EndInvoke` are not materialized. The facet does not expose them, no consumer reaches them, and
+an introduced delegate is compiled for the target framework of the project rather than for .NET Framework
+specifically.
+
+## 6. Decisions
+
+### 6.1. The signature is the `Invoke` method and not a flat surface on the type
+
+`IDelegateBuilder` could declare a return type and a parameter list of its own, with no `InvokeMethod` property.
+The design exposes the method instead, for two reasons.
+
+The first is symmetry with the reader. `IDelegateFacet` declares `InvokeMethod`, `ReturnType` and `Parameters`, in
+that order, with the second and the third documented as being those of the first. A writer that inverted the
+relation, making the flat members the truth and offering no method, would describe the same delegate by a different
+structure on each side.
+
+The second is that an aspect that introduces a delegate usually has a signature to copy, and the thing it is
+copying from is an `IMethod`. Exposing an `IMethodBuilder` lets it use the operations it already knows, including
+`AddParameter` with a `RefKind` and a default value, and `ReturnParameter` for the attributes of the return value,
+which a flat surface would have to declare again.
+
+The shortcuts are declared nevertheless, because the common case is an aspect that writes a short signature by
+hand, and `d.ReturnType = ...` reads better than `d.InvokeMethod.ReturnType = ...` when repeated. The facet makes
+the same trade and for the same reason.
+
+### 6.2. `IMethodBuilder` is reused whole, and the members of an enum are not
+
+Section 6.1 of [`introducing-enums.md`](introducing-enums.md) rejects `IFieldBuilder` as the return type of
+`AddMember`, and this document accepts `IMethodBuilder` as the type of `InvokeMethod`. The two decisions are
+consistent, because the ratio of valid to invalid operations is not the same.
+
+Of the operations of `IFieldBuilder`, one is valid for a member of an enum. Of the operations of `IMethodBuilder`,
+the parameters, the return type, the return parameter and the attributes are all valid, which is most of the
+interface, and the ones that are not are the name, the accessibility, the modifiers, the operator kind and the
+addition of a type parameter. An `Invoke` method genuinely is a method, with a signature that an author chooses
+freely. A member of an enum is a name and a number.
+
+### 6.3. The type parameters belong to the type
+
+`IDelegateBuilder.AddTypeParameter` adds a type parameter to the delegate, and
+`IDelegateBuilder.InvokeMethod.AddTypeParameter` throws. The language places the type parameters of a delegate on
+the type: `Func<T, TResult>` is a generic type whose `Invoke` method is not generic.
+
+The consequence that the documentation states is that a delegate is the one kind of type whose type parameters may
+declare variance, so `ITypeParameterBuilder.Variance` is meaningful here and on an interface, and nowhere else.
+
+### 6.4. A delegate is introduced by its own advice method
+
+The reasoning is that of section 6.2 of [`introducing-structs.md`](introducing-structs.md). A delegate accepts a
+configuration that no other kind accepts, which is a signature, and it accepts almost nothing that the other kinds
+accept.
+
+## 7. Open questions
+
+### 7.1. Does the `Invoke` method need to be reachable before the advice completes?
+
+The design exposes `InvokeMethod` as an `IMethodBuilder` during construction, and the introduced delegate exposes
+it as an `IMethod` afterwards. Whether an aspect needs to hold the eventual `IMethod` while the type is still being
+built is not known. It would matter to an aspect that introduces a delegate and, in the same `BuildAspect`, writes
+a template that calls it.
+
+What would settle it is one sample aspect that introduces a delegate, an event of that type and a method that
+raises the event, written against the interface above. That aspect is worth writing before the interface is
+frozen, because it is the pattern the issue exists for.
+
+### 7.2. Is a `ref` return or a pointer parameter in scope?
+
+A delegate may return by reference and may take a pointer parameter in an unsafe context.
+`IMethodBuilder.ReturnType` and `AddParameter` accept a `RefKind`, so the interface expresses both, and whether the
+emission path handles them is an implementation question rather than a design one.
+
+What would settle it is a test of each. Neither is a reason to change the interface, because the alternative
+would be to refuse a signature that `IMethodBuilder` can already express.
+
+## 8. References
+
+- [`introducing-types.md`](introducing-types.md), sections 2, 3 and 5.
+- [`introducing-enums.md`](introducing-enums.md), section 6.1, which this document contrasts with in section 6.2.
+- [`type-facets.md`](type-facets.md), section 2.2 and implementation guideline 5.
+- `Metalama.Framework/Code/Types/IDelegateFacet.cs`, the interface this design mirrors.
+- `Metalama.Framework.Engine/CodeModel/Facets/DelegateFacet.cs`, which resolves the `Invoke` method by name and is
+  described there as the single site of the code model that does so.
+
+Issues:
+
+- [#865](https://github.com/metalama/Metalama/issues/865), which this document designs.
+- [#1995](https://github.com/metalama/Metalama/issues/1995), code model: type facets and the delegate facet, closed
+  in 2027.0.2-preview. It delivered `ITypeFacetCollection` and `IDelegateFacet`, which section 5 mirrors, and it
+  converted the fifteen call sites that resolved the `Invoke` method by a string literal.
+- [#869](https://github.com/metalama/Metalama/issues/869), type introduction: introduce struct, open. It carries
+  the emission machinery that this issue consumes and it blocks this one.
+- [#863](https://github.com/metalama/Metalama/issues/863), type introduction: reflection wrappers and syntax
+  serialization, open. A delegate is reached through `IEvent.Signature`, which the facet now defines, so the
+  wrappers of an introduced delegate are worth a test in this issue.
+- [#1950](https://github.com/metalama/Metalama/issues/1950), C# 15 closed classes: introducing, closed. The shape
+  of that pull request is the shape this one should have.
+- Section 8.4 of [`introducing-types.md`](introducing-types.md) lists the rest of the type introduction backlog.
+
+— Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/introducing-delegates.md
+++ b/Metalama.Framework/docs/future/introducing-delegates.md
@@ -232,8 +232,9 @@ contains for a delegate read from source.
 Materialized means present in the code model and not emitted as syntax. Metalama generates the delegate
 declaration, which is the `delegate` keyword and the signature, and the compiler synthesizes the `Invoke` method
 and the constructor from it exactly as it does for a delegate the user wrote. A transformation that injected the
-`Invoke` method as well would declare it twice, and a delegate declaration has no member list to put it in.
-Section 5.2 of [`introducing-types.md`](introducing-types.md) states the rule.
+`Invoke` method as well would declare it twice, and a delegate declaration has no member list to put it in at all,
+so the failure would be a syntax error rather than a duplicate member. Section 4.2 of
+[`introducing-types.md`](introducing-types.md) states the rule and the mechanism.
 
 `DelegateFacet` resolves the `Invoke` method by name today, through
 `this.Type.Methods.OfName( "Invoke" ).Single()`. That continues to work for an introduced delegate, because the

--- a/Metalama.Framework/docs/future/introducing-delegates.md
+++ b/Metalama.Framework/docs/future/introducing-delegates.md
@@ -102,6 +102,17 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 /// <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>, which is how an aspect gives
 /// the introduced delegate as the type of a field, of a property or of an event.
 /// </para>
+/// <para>
+/// The members below are the signature of the delegate, which is the signature of the <c>Invoke</c> method that the
+/// compiler synthesizes for it. They are the members of <see cref="IMethodBuilder"/> that apply to a delegate, and
+/// they carry the same names, so an aspect that configures a delegate writes what it would write for a method. The
+/// <c>Invoke</c> method itself is not exposed during construction: it is read from
+/// <see cref="Metalama.Framework.Code.Types.IDelegateFacet.InvokeMethod"/> on the introduced type.
+/// </para>
+/// <para>
+/// The <c>BeginInvoke</c> and <c>EndInvoke</c> methods are not exposed and are not built. They exist only for a
+/// delegate compiled for .NET Framework, and they are the asynchronous pattern that preceded <c>async</c>.
+/// </para>
 /// </remarks>
 /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet"/>
 /// <seealso href="@introducing-types"/>
@@ -109,44 +120,24 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 public interface IDelegateBuilder : IMemberOrNamedTypeBuilder
 {
     /// <summary>
-    /// Gets the builder of the <c>Invoke</c> method, which carries the signature of the delegate.
+    /// Gets or sets the return type of the delegate. The default value is <c>void</c>.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// This property is the complete signature of the delegate, and
-    /// <see cref="ReturnType"/>, <see cref="Parameters"/> and
-    /// <see cref="AddParameter(string,IType,Code.RefKind,TypedConstant?)"/>
-    /// are shortcuts onto it. It is exposed so that an aspect that already has an <see cref="IMethod"/> to copy, in
-    /// particular the <c>Invoke</c> method of another delegate, can configure the signature by the same operations
-    /// it would use on any method.
-    /// </para>
-    /// <para>
-    /// The following operations of the method builder are not valid on the <c>Invoke</c> method of a delegate, and
-    /// each of them throws a <see cref="NotSupportedException"/>:
-    /// <see cref="IMethodBuilder.AddTypeParameter"/>, because the type parameters of a delegate belong to the type
-    /// and are added by <see cref="AddTypeParameter"/> on this interface;
-    /// <see cref="IMemberOrNamedTypeBuilder.Name"/> and
-    /// <see cref="IMemberOrNamedTypeBuilder.Accessibility"/>, which the language fixes;
-    /// <see cref="IMethodBuilder.OperatorKind"/>; <see cref="IMethodBuilder.IsReadOnly"/>; and every modifier that
-    /// <see cref="IMemberBuilder"/> and <see cref="IMemberOrNamedTypeBuilder"/> declare.
-    /// </para>
-    /// <para>
-    /// The <c>BeginInvoke</c> and <c>EndInvoke</c> methods are not exposed and are not built. They exist only for a
-    /// delegate compiled for .NET Framework, and they are the asynchronous pattern that preceded <c>async</c>.
+    /// A delegate may return by reference. The reference kind of the return is set on
+    /// <see cref="ReturnParameter"/>, as it is on a method.
     /// </para>
     /// </remarks>
-    /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.InvokeMethod"/>
-    IMethodBuilder InvokeMethod { get; }
-
-    /// <summary>
-    /// Gets or sets the return type of the delegate, which is the return type of <see cref="InvokeMethod"/>. The
-    /// default value is <c>void</c>.
-    /// </summary>
     /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.ReturnType"/>
     IType ReturnType { get; set; }
 
     /// <summary>
-    /// Gets the parameters of the delegate, which are the parameters of <see cref="InvokeMethod"/>.
+    /// Gets an object allowing to read and modify the return type and the custom attributes of the return value.
+    /// </summary>
+    IParameterBuilder ReturnParameter { get; }
+
+    /// <summary>
+    /// Gets the parameters of the delegate.
     /// </summary>
     /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.Parameters"/>
     IParameterBuilderList Parameters { get; }
@@ -184,9 +175,9 @@ public interface IDelegateBuilder : IMemberOrNamedTypeBuilder
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The type parameters of a delegate belong to the type and not to its <c>Invoke</c> method, so they are added
-    /// here. A delegate is the one kind of type whose type parameters may declare variance, through
-    /// <see cref="ITypeParameterBuilder.Variance"/>.
+    /// The type parameters of a delegate belong to the type and not to its <c>Invoke</c> method, which is why this
+    /// member exists on the builder of the type. A delegate is the one kind of type, besides an interface, whose
+    /// type parameters may declare variance, through <see cref="ITypeParameterBuilder.Variance"/>.
     /// </para>
     /// </remarks>
     /// <param name="name">The name of the type parameter.</param>
@@ -265,9 +256,10 @@ not.
 
 The operations of `IDeclarationBuilder` are all valid: a delegate carries attributes.
 
-The restrictions on `InvokeMethod` are listed in the documentation of that property in section 3.1, and they exist
-because `IMethodBuilder` is reused whole rather than narrowed. Section 6.2 states why reuse is preferred to a
-narrower interface here and not for the members of an enum.
+There is no `Invoke` method builder to restrict, because section 6.1 puts the signature on the builder of the type
+itself. The members that `IMethodBuilder` declares and that a delegate does not accept are therefore absent rather
+than failing: `IsReadOnly`, `OperatorKind`, and the modifiers that `IMemberBuilder` adds, which are `IsVirtual` and
+`IsExtern`.
 
 Every operation of `INamedTypeBuilder` is absent rather than failing, because `IDelegateBuilder` does not derive
 from that interface. That includes `Facets`: a caller that reaches the engine object as an `INamedType` and reads
@@ -291,7 +283,7 @@ The introduced type reports an `IDelegateFacet`.
 
 | `IDelegateFacet` member | Source |
 | --- | --- |
-| `InvokeMethod` | The method that `IDelegateBuilder.InvokeMethod` built, materialized as a builder so that the facet can name it without re-reading the model from Roslyn. |
+| `InvokeMethod` | The `Invoke` method, materialized as a builder from the signature that the aspect gave to `IDelegateBuilder`, so that the facet can name it without re-reading the model from Roslyn. |
 | `ReturnType` | The return type of that method. |
 | `Parameters` | The parameters of that method. |
 | `FacetKind` | `TypeFacetKind.Delegate`. |
@@ -300,9 +292,16 @@ The introduced type reports an `IDelegateFacet`.
 `INamedType.IsDelegate` reports `true`, and `INamedType.Methods` contains the `Invoke` method, which is what it
 contains for a delegate read from source.
 
+Materialized means present in the code model and not emitted as syntax. Metalama generates the delegate
+declaration, which is the `delegate` keyword and the signature, and the compiler synthesizes the `Invoke` method
+and the constructor from it exactly as it does for a delegate the user wrote. A transformation that injected the
+`Invoke` method as well would declare it twice, and a delegate declaration has no member list to put it in.
+Section 5.2 of [`introducing-types.md`](introducing-types.md) states the rule.
+
 `DelegateFacet` resolves the `Invoke` method by name today, through
 `this.Type.Methods.OfName( "Invoke" ).Single()`. That continues to work for an introduced delegate, because the
-method is a member of the type like any other. The facet needs no branch for an introduced delegate.
+method is a member of the type like any other once it is registered in the code model. The facet needs no branch
+for an introduced delegate.
 
 `BeginInvoke` and `EndInvoke` are not materialized. The facet does not expose them, no consumer reaches them, and
 an introduced delegate is compiled for the target framework of the project rather than for .NET Framework
@@ -317,47 +316,44 @@ same parameters.
 
 ## 6. Decisions
 
-### 6.1. The signature is the `Invoke` method and not a flat surface on the type
+### 6.1. The signature is on the builder of the type, and the builder does not derive from `IMethodBuilder`
 
-`IDelegateBuilder` could declare a return type and a parameter list of its own, with no `InvokeMethod` property.
-The design exposes the method instead, for two reasons.
+A delegate declaration is a method signature with the `delegate` keyword in front of it, so the members that
+configure it are the members that configure a method. This design declares them on `IDelegateBuilder` with the
+names that `IMethodBuilder` uses, rather than exposing an `IMethodBuilder` for the `Invoke` method or deriving from
+that interface. Two alternatives were considered and both are rejected.
 
-The first is symmetry with the reader. `IDelegateFacet` declares `InvokeMethod`, `ReturnType` and `Parameters`, in
-that order, with the second and the third documented as being those of the first. A writer that inverted the
-relation, making the flat members the truth and offering no method, would describe the same delegate by a different
-structure on each side.
+The first alternative is `IDelegateBuilder : IMethodBuilder`, with the inapplicable operations made illegal. It
+would add no member of its own, which is what makes it attractive. It cannot be taken, because the chain
+`IMethodBuilder : IMethodBaseBuilder`, `IMethodBaseBuilder : IHasParametersBuilder`,
+`IHasParametersBuilder : IMemberBuilder`, `IMemberBuilder : IMember` ends at the interface that narrows the
+declaring type to a value that is not nullable, and a delegate declared in a namespace has no declaring type. That
+is the same obstacle that section 2.1 of [`introducing-types.md`](introducing-types.md) records against
+`IMemberBuilder`, reached through four interfaces instead of one. `IMethod` also derives from `IMethodInvoker`, so
+the builder of a delegate type would offer the operations that invoke a method.
 
-The second is that an aspect that introduces a delegate usually has a signature to copy, and the thing it is
-copying from is an `IMethod`. Exposing an `IMethodBuilder` lets it use the operations it already knows, including
-`AddParameter` with a `RefKind` and a default value, and `ReturnParameter` for the attributes of the return value,
-which a flat surface would have to declare again.
+The second alternative is an `InvokeMethod` property typed as `IMethodBuilder`, which an earlier revision of this
+document took. The `Invoke` method does not need to be reachable while the delegate is being built: everything an
+author sets on it is the signature, and the signature is what the members below are. Keeping the property would
+mean two ways to write the same thing, and a second object whose name, accessibility and modifiers are all invalid.
 
-The shortcuts are declared nevertheless, because the common case is an aspect that writes a short signature by
-hand, and `d.ReturnType = ...` reads better than `d.InvokeMethod.ReturnType = ...` when repeated. The facet makes
-the same trade and for the same reason.
+What is lost is the symmetry with `IDelegateFacet`, which declares `InvokeMethod` first and documents `ReturnType`
+and `Parameters` as being those of the first. The asymmetry is accepted, and it is the same one that section 6.1 of
+[`introducing-enums.md`](introducing-enums.md) accepts: a reader asks what a delegate is made of, and the answer
+names the method, while a writer chooses a signature and never needs the method as an object. The `Invoke` method
+of an introduced delegate is reached through the facet as soon as the advice completes.
 
-### 6.2. `IMethodBuilder` is reused whole, and the members of an enum are not
+### 6.2. The type parameters belong to the type
 
-Section 6.1 of [`introducing-enums.md`](introducing-enums.md) rejects `IFieldBuilder` as the return type of
-`AddMember`, and this document accepts `IMethodBuilder` as the type of `InvokeMethod`. The two decisions are
-consistent, because the ratio of valid to invalid operations is not the same.
+`IDelegateBuilder.AddTypeParameter` adds a type parameter to the delegate and not to its `Invoke` method. The
+language places the type parameters of a delegate on the type: `Func<T, TResult>` is a generic type whose `Invoke`
+method is not generic.
 
-Of the operations of `IFieldBuilder`, one is valid for a member of an enum. Of the operations of `IMethodBuilder`,
-the parameters, the return type, the return parameter and the attributes are all valid, which is most of the
-interface, and the ones that are not are the name, the accessibility, the modifiers, the operator kind and the
-addition of a type parameter. An `Invoke` method genuinely is a method, with a signature that an author chooses
-freely. A member of an enum is a name and a number.
+The consequence that the documentation states is that a delegate is the one kind of type, besides an interface,
+whose type parameters may declare variance, so `ITypeParameterBuilder.Variance` is meaningful here and nowhere
+else among the five kinds.
 
-### 6.3. The type parameters belong to the type
-
-`IDelegateBuilder.AddTypeParameter` adds a type parameter to the delegate, and
-`IDelegateBuilder.InvokeMethod.AddTypeParameter` throws. The language places the type parameters of a delegate on
-the type: `Func<T, TResult>` is a generic type whose `Invoke` method is not generic.
-
-The consequence that the documentation states is that a delegate is the one kind of type whose type parameters may
-declare variance, so `ITypeParameterBuilder.Variance` is meaningful here and on an interface, and nowhere else.
-
-### 6.4. A delegate is introduced by its own advice method
+### 6.3. A delegate is introduced by its own advice method
 
 The reasoning is that of section 6.2 of [`introducing-structs.md`](introducing-structs.md). A delegate accepts a
 configuration that no other kind accepts, which is a signature, and it accepts almost nothing that the other kinds
@@ -365,25 +361,15 @@ accept.
 
 ## 7. Open questions
 
-### 7.1. Does the `Invoke` method need to be reachable before the advice completes?
+None. Two questions that an earlier revision recorded are answered, and section 6 carries both.
 
-The design exposes `InvokeMethod` as an `IMethodBuilder` during construction, and the introduced delegate exposes
-it as an `IMethod` afterwards. Whether an aspect needs to hold the eventual `IMethod` while the type is still being
-built is not known. It would matter to an aspect that introduces a delegate and, in the same `BuildAspect`, writes
-a template that calls it.
+The `Invoke` method does not need to be reachable while the delegate is being built, which is why section 6.1
+removes the `InvokeMethod` property rather than keeping it for a case that does not arise. The method is reached
+through the facet of the introduced type as soon as the advice completes.
 
-What would settle it is one sample aspect that introduces a delegate, an event of that type and a method that
-raises the event, written against the interface above. That aspect is worth writing before the interface is
-frozen, because it is the pattern the issue exists for.
-
-### 7.2. Is a `ref` return or a pointer parameter in scope?
-
-A delegate may return by reference and may take a pointer parameter in an unsafe context.
-`IMethodBuilder.ReturnType` and `AddParameter` accept a `RefKind`, so the interface expresses both, and whether the
-emission path handles them is an implementation question rather than a design one.
-
-What would settle it is a test of each. Neither is a reason to change the interface, because the alternative
-would be to refuse a signature that `IMethodBuilder` can already express.
+A `ref` return and a pointer parameter are in scope. A delegate may return by reference and may take a pointer
+parameter in an unsafe context, `ReturnParameter` and `AddParameter` express both, and the emission path handles
+them. Each is covered by a test rather than refused.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/introducing-delegates.md
+++ b/Metalama.Framework/docs/future/introducing-delegates.md
@@ -5,13 +5,16 @@ This document designs the introduction of a delegate, which is issue
 implemented.
 
 The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md), which this document does not
-repeat. The one that shapes the interface below is section 2 of that document: a delegate builder derives from
-`IMemberOrNamedTypeBuilder` and not from `INamedTypeBuilder`, because a delegate declaration has no member list.
+repeat. The one that shapes the interface below is section 2.3 of that document: a delegate builder is the builder
+of the `Invoke` method of the delegate, and it derives from `IMethodBuilder`.
 
 The read side of a delegate is `IDelegateFacet`, which is delivered. The design below mirrors it member for member,
 and section 5 states the mapping.
 
 ## 1. What the aspect author writes
+
+A delegate declaration is a method signature with the `delegate` keyword in front of it, so the builder is the
+builder of a method. The delegate type itself is reached through `DeclaringType`.
 
 ```csharp
 public class GenerateChangedEventAttribute : TypeAspect
@@ -22,7 +25,8 @@ public class GenerateChangedEventAttribute : TypeAspect
             "ValueChangedHandler",
             buildDelegate: d =>
             {
-                d.Accessibility = Accessibility.Public;
+                d.DeclaringType.Accessibility = Accessibility.Public;
+
                 d.ReturnType = TypeFactory.GetType( SpecialType.Void );
                 d.AddParameter( "sender", builder.Target );
                 d.AddParameter( "oldValue", typeof(object) );
@@ -34,23 +38,23 @@ public class GenerateChangedEventAttribute : TypeAspect
 }
 ```
 
-The introduced delegate is reached through `handler.Declaration`, which is an `INamedType`, and is used there as the
-type of an introduced field. The builder itself could not be used in that position, for the reason that section 2.4
-of [`introducing-types.md`](introducing-types.md) gives.
+The introduced delegate is read from `handler.Declaration`, which is an `INamedType`, and is used there as the type
+of an introduced field.
 
-A generic delegate adds type parameters to the type, and may give them variance:
+The type parameters of a delegate belong to the type and not to its `Invoke` method, so they are added through
+`DeclaringType` as well, and they may declare variance:
 
 ```csharp
 builder.IntroduceDelegate(
     "Transformer",
     buildDelegate: d =>
     {
-        d.Accessibility = Accessibility.Public;
+        d.DeclaringType.Accessibility = Accessibility.Public;
 
-        var input = d.AddTypeParameter( "TInput" );
+        var input = d.DeclaringType.AddTypeParameter( "TInput" );
         input.Variance = VarianceKind.In;
 
-        var output = d.AddTypeParameter( "TOutput" );
+        var output = d.DeclaringType.AddTypeParameter( "TOutput" );
         output.Variance = VarianceKind.Out;
 
         d.ReturnType = output;
@@ -80,34 +84,29 @@ public delegate TOutput Transformer<in TInput, out TOutput>( TInput value );
 namespace Metalama.Framework.Code.DeclarationBuilders;
 
 /// <summary>
-/// Allows to complete the construction of a delegate that has been created by an advice.
+/// Allows to complete the construction of a delegate that has been created by an advice. This interface builds the
+/// <c>Invoke</c> method of the delegate, which carries its signature, and the delegate type itself is reached
+/// through <see cref="DeclaringType"/>.
 /// </summary>
 /// <remarks>
 /// <para>
-/// This interface derives from <see cref="IMemberOrNamedTypeBuilder"/> and not from
-/// <see cref="INamedTypeBuilder"/>, because a delegate declaration has no member list and no base type that an
-/// author may choose. The operations that a delegate does not have are therefore absent rather than present and
-/// failing. The operations that it inherits and does not have are listed below.
+/// A delegate declaration is a method signature with the <c>delegate</c> keyword in front of it, so the members
+/// that configure it are the members that configure a method, and this interface derives from
+/// <see cref="IMethodBuilder"/> rather than declaring them again. The return type, the parameters and the custom
+/// attributes of the return value are set through the inherited members.
 /// </para>
 /// <para>
-/// The following inherited properties are not valid for a delegate, and their setter throws a
-/// <see cref="NotSupportedException"/>: <see cref="IMemberOrNamedTypeBuilder.IsStatic"/>,
-/// <see cref="IMemberOrNamedTypeBuilder.IsSealed"/>, <see cref="IMemberOrNamedTypeBuilder.IsAbstract"/> and
-/// <see cref="IMemberOrNamedTypeBuilder.IsPartial"/>. A delegate is implicitly sealed, it may not be abstract or
-/// static, and the language has no partial delegate.
+/// What belongs to the type and not to the method is set through <see cref="DeclaringType"/>: the name of the
+/// delegate, its accessibility, its custom attributes and its type parameters. The corresponding inherited members
+/// describe the <c>Invoke</c> method, whose name is <c>Invoke</c> and whose accessibility is public, and the
+/// language fixes both, so their setter throws a <see cref="NotSupportedException"/>. The operations that are not
+/// valid are listed in the design document.
 /// </para>
 /// <para>
 /// A delegate builder is not an <see cref="INamedType"/>, so it may not be used where an <see cref="IType"/> is
-/// expected. The introduced delegate is read from
-/// <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>, which is how an aspect gives
-/// the introduced delegate as the type of a field, of a property or of an event.
-/// </para>
-/// <para>
-/// The members below are the signature of the delegate, which is the signature of the <c>Invoke</c> method that the
-/// compiler synthesizes for it. They are the members of <see cref="IMethodBuilder"/> that apply to a delegate, and
-/// they carry the same names, so an aspect that configures a delegate writes what it would write for a method. The
-/// <c>Invoke</c> method itself is not exposed during construction: it is read from
-/// <see cref="Metalama.Framework.Code.Types.IDelegateFacet.InvokeMethod"/> on the introduced type.
+/// expected, and neither may <see cref="DeclaringType"/> be used as the finished type. The introduced delegate is
+/// read from <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>, which is how an
+/// aspect gives it as the type of a field, of a property or of an event.
 /// </para>
 /// <para>
 /// The <c>BeginInvoke</c> and <c>EndInvoke</c> methods are not exposed and are not built. They exist only for a
@@ -117,73 +116,27 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet"/>
 /// <seealso href="@introducing-types"/>
 [InternalImplement]
-public interface IDelegateBuilder : IMemberOrNamedTypeBuilder
+public interface IDelegateBuilder : IMethodBuilder
 {
     /// <summary>
-    /// Gets or sets the return type of the delegate. The default value is <c>void</c>.
+    /// Gets the builder of the delegate type that declares this <c>Invoke</c> method. The name of the delegate, its
+    /// accessibility, its custom attributes and its type parameters are set through this property.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// A delegate may return by reference. The reference kind of the return is set on
-    /// <see cref="ReturnParameter"/>, as it is on a method.
+    /// This property narrows <see cref="IMember.DeclaringType"/>, which reports an <see cref="INamedType"/>, to the
+    /// builder of that type, so that the type can be configured while it is being built.
     /// </para>
-    /// </remarks>
-    /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.ReturnType"/>
-    IType ReturnType { get; set; }
-
-    /// <summary>
-    /// Gets an object allowing to read and modify the return type and the custom attributes of the return value.
-    /// </summary>
-    IParameterBuilder ReturnParameter { get; }
-
-    /// <summary>
-    /// Gets the parameters of the delegate.
-    /// </summary>
-    /// <seealso cref="Metalama.Framework.Code.Types.IDelegateFacet.Parameters"/>
-    IParameterBuilderList Parameters { get; }
-
-    /// <summary>
-    /// Appends a parameter to the delegate.
-    /// </summary>
-    /// <param name="name">The name of the parameter.</param>
-    /// <param name="type">The type of the parameter.</param>
-    /// <param name="refKind">The reference kind of the parameter.</param>
-    /// <param name="defaultValue">The default value of the parameter, or <c>null</c> when it has none.</param>
-    /// <returns>An <see cref="IParameterBuilder"/> that allows you to further build the new parameter.</returns>
-    IParameterBuilder AddParameter(
-        string name,
-        IType type,
-        RefKind refKind = RefKind.None,
-        TypedConstant? defaultValue = default );
-
-    /// <summary>
-    /// Appends a parameter to the delegate.
-    /// </summary>
-    /// <param name="name">The name of the parameter.</param>
-    /// <param name="type">The type of the parameter.</param>
-    /// <param name="refKind">The reference kind of the parameter.</param>
-    /// <param name="defaultValue">The default value of the parameter, or <c>null</c> when it has none.</param>
-    /// <returns>An <see cref="IParameterBuilder"/> that allows you to further build the new parameter.</returns>
-    IParameterBuilder AddParameter(
-        string name,
-        Type type,
-        RefKind refKind = RefKind.None,
-        TypedConstant? defaultValue = null );
-
-    /// <summary>
-    /// Adds a type parameter to the delegate.
-    /// </summary>
-    /// <remarks>
     /// <para>
-    /// The type parameters of a delegate belong to the type and not to its <c>Invoke</c> method, which is why this
-    /// member exists on the builder of the type. A delegate is the one kind of type, besides an interface, whose
-    /// type parameters may declare variance, through <see cref="ITypeParameterBuilder.Variance"/>.
+    /// The following members of the returned builder are not valid for a delegate, and their setter throws a
+    /// <see cref="NotSupportedException"/>: <see cref="INamedTypeBuilder.BaseType"/>, because a delegate derives
+    /// from <see cref="System.MulticastDelegate"/> and the language allows no other base;
+    /// <see cref="INamedTypeBuilder.IsClosed"/>; and
+    /// <see cref="IMemberOrNamedTypeBuilder.IsStatic"/>, <see cref="IMemberOrNamedTypeBuilder.IsSealed"/>,
+    /// <see cref="IMemberOrNamedTypeBuilder.IsAbstract"/> and <see cref="IMemberOrNamedTypeBuilder.IsPartial"/>.
     /// </para>
     /// </remarks>
-    /// <param name="name">The name of the type parameter.</param>
-    /// <returns>An <see cref="ITypeParameterBuilder"/> that allows you to further configure the new type
-    ///     parameter, including its constraints and its variance.</returns>
-    ITypeParameterBuilder AddTypeParameter( string name );
+    new INamedTypeBuilder DeclaringType { get; }
 }
 ```
 
@@ -198,9 +151,10 @@ public interface IDelegateBuilder : IMemberOrNamedTypeBuilder
 /// <param name="name">The name of the introduced delegate.</param>
 /// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
 ///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
-/// <param name="buildDelegate">An optional callback that allows you to configure the introduced delegate, in
-///     particular to give it a return type and parameters. A delegate that the callback leaves unconfigured
-///     returns <c>void</c> and takes no parameter.</param>
+/// <param name="buildDelegate">An optional callback that allows you to configure the introduced delegate. The
+///     callback receives the builder of the <c>Invoke</c> method of the delegate, which carries its signature, and
+///     reaches the delegate type itself through <see cref="IDelegateBuilder.DeclaringType"/>. A delegate that the
+///     callback leaves unconfigured is internal, returns <c>void</c> and takes no parameter.</param>
 /// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
 /// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced delegate.
 /// Unlike the result of introducing a class, this result must not be used to introduce members, because a delegate
@@ -223,8 +177,10 @@ IIntroductionAdviceResult<INamedType> IntroduceDelegate(
 /// <param name="name">The delegate name.</param>
 /// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
 ///     in the target type or namespace. The default strategy is to fail with a compile-time error.</param>
-/// <param name="buildDelegate">An optional delegate that modifies the <see cref="IDelegateBuilder"/> that
-///     represents the introduced delegate. The signature of the delegate is given through this callback.</param>
+/// <param name="buildDelegate">An optional delegate that modifies the <see cref="IDelegateBuilder"/>, which is
+///     the builder of the <c>Invoke</c> method of the introduced delegate. The signature of the delegate is given
+///     through this callback, and the delegate type is reached through
+///     <see cref="IDelegateBuilder.DeclaringType"/>.</param>
 /// <returns>An <see cref="IIntroductionAdviceResult{T}"/> that exposes the outcome of the operation and the
 /// introduced <see cref="INamedType"/>.</returns>
 /// <seealso href="@introducing-types"/>
@@ -242,48 +198,51 @@ public static IIntroductionAdviceResult<INamedType> IntroduceDelegate(
 
 ## 4. The inherited operations that are not valid
 
-`IDelegateBuilder` inherits six settable properties from `IMemberOrNamedTypeBuilder`. Two are valid and four are
-not.
+`IDelegateBuilder` inherits the whole of `IMethodBuilder`. The members that describe a signature are valid, and the
+members that describe a method as a member of a type are not, because the `Invoke` method of a delegate is
+synthesized and the language fixes every one of them.
 
 | Member | State |
 | --- | --- |
-| `Accessibility` | Valid. |
-| `Name` | Valid. |
-| `IsStatic` | The setter throws a `NotSupportedException`. A delegate is neither static nor an instance type. |
-| `IsSealed` | The setter throws a `NotSupportedException`. A delegate is implicitly sealed. |
-| `IsAbstract` | The setter throws a `NotSupportedException`. A delegate may not be abstract. |
-| `IsPartial` | The setter throws a `NotSupportedException`. The language has no partial delegate. |
+| `ReturnType`, `ReturnParameter` | Valid. `ReturnParameter` also carries the reference kind of a `ref` return and the custom attributes of the return value. |
+| `Parameters`, `AddParameter`, `InsertParameter` | Valid. These are the parameters of the delegate. |
+| `Name` | The setter throws a `NotSupportedException`. The getter reports `Invoke`. The name of the delegate is `DeclaringType.Name`. |
+| `Accessibility` | The setter throws a `NotSupportedException`. The `Invoke` method of a delegate is public. The accessibility of the delegate is `DeclaringType.Accessibility`. |
+| `AddTypeParameter` | The setter throws a `NotSupportedException`. The `Invoke` method of a delegate is never generic, and the type parameters of the delegate are added through `DeclaringType.AddTypeParameter`. |
+| `AddAttribute`, `AddAttributes`, `RemoveAttributes` | The methods throw a `NotSupportedException`. A delegate declaration has no place to write an attribute on the `Invoke` method. An attribute on the delegate is added through `DeclaringType`, and an attribute on the return value through `ReturnParameter`. |
+| `IsVirtual`, `IsExtern` | The setter throws a `NotSupportedException`. |
+| `IsStatic`, `IsSealed`, `IsAbstract`, `IsPartial` | The setter throws a `NotSupportedException`. |
+| `IsReadOnly` | The setter throws a `NotSupportedException`. It applies to a member of a struct. |
+| `OperatorKind` | The setter throws a `NotSupportedException`. |
 
-The operations of `IDeclarationBuilder` are all valid: a delegate carries attributes.
+`IMethod` derives from `IMethodInvoker`, so the builder inherits the operations that generate a call. They are not
+usable while the delegate is being built, because the type does not exist yet, and they are usable on the `Invoke`
+method that the facet of the introduced type reports. `MethodBuilder`, which backs every introduced method, already
+faces that question, so this design adds nothing to it.
 
-There is no `Invoke` method builder to restrict, because section 6.1 puts the signature on the builder of the type
-itself. The members that `IMethodBuilder` declares and that a delegate does not accept are therefore absent rather
-than failing: `IsReadOnly`, `OperatorKind`, and the modifiers that `IMemberBuilder` adds, which are `IsVirtual` and
-`IsExtern`.
-
-Every operation of `INamedTypeBuilder` is absent rather than failing, because `IDelegateBuilder` does not derive
-from that interface. That includes `Facets`: a caller that reaches the engine object as an `INamedType` and reads
-`Facets` on it meets the `NotSupportedException` of section 5.1 of
-[`introducing-types.md`](introducing-types.md). The one operation of `INamedTypeBuilder` that a delegate genuinely
-needs is `AddTypeParameter`, which section 3.1 declares again.
+Every operation of `INamedTypeBuilder` is reached through `DeclaringType` rather than being absent, which is the
+difference between this kind and the enum. The members of that builder that a delegate does not accept are listed
+in the documentation of `DeclaringType` in section 3.1.
 
 ## 5. What the facet of the introduced delegate reports
 
-A delegate builder declares no `Facets` member, because `IDelegateBuilder` does not derive from `INamedType`. The
-engine class behind it does, and it throws a `NotSupportedException`, which section 5.1 of
-[`introducing-types.md`](introducing-types.md) states for every builder. The kind of a builder is read from
-`IsDelegate`, which answers without allocating and does not throw.
+A delegate builder declares no `Facets` member, because `IDelegateBuilder` derives from `IMethodBuilder` and a
+method has no facet. `DeclaringType`, which is the delegate type under construction, does declare one, and it
+throws a `NotSupportedException`, which section 5.1 of [`introducing-types.md`](introducing-types.md) states for
+every builder. The kind of a builder is read from `IsDelegate`, which answers without allocating and does not
+throw.
 
-That the delegate builder is not a type also bounds the risk of the exception. Section 5.1 lists
+That neither object is usable as a finished type bounds the risk of the exception. Section 5.1 lists
 `EventBuilder.Signature` and the eligibility rule of `AdviceKind.OverrideEventInvoke` as the readers that take the
-type of an event from the aspect. An aspect cannot give a delegate builder as the type of an event, because the
-builder is not an `IType`, so neither reader can meet one.
+type of an event from the aspect. An aspect cannot give a delegate builder as the type of an event, because it is
+not an `IType` at all, and it does not give `DeclaringType` either, because the finished delegate is the result of
+the advice. Neither reader meets a builder in the course an aspect actually takes.
 
 The introduced type reports an `IDelegateFacet`.
 
 | `IDelegateFacet` member | Source |
 | --- | --- |
-| `InvokeMethod` | The `Invoke` method, materialized as a builder from the signature that the aspect gave to `IDelegateBuilder`, so that the facet can name it without re-reading the model from Roslyn. |
+| `InvokeMethod` | The `Invoke` method, which is what `IDelegateBuilder` built, materialized so that the facet can name it without re-reading the model from Roslyn. |
 | `ReturnType` | The return type of that method. |
 | `Parameters` | The parameters of that method. |
 | `FacetKind` | `TypeFacetKind.Delegate`. |
@@ -316,38 +275,46 @@ same parameters.
 
 ## 6. Decisions
 
-### 6.1. The signature is on the builder of the type, and the builder does not derive from `IMethodBuilder`
+### 6.1. The builder is the `Invoke` method, and it derives from `IMethodBuilder`
 
-A delegate declaration is a method signature with the `delegate` keyword in front of it, so the members that
-configure it are the members that configure a method. This design declares them on `IDelegateBuilder` with the
-names that `IMethodBuilder` uses, rather than exposing an `IMethodBuilder` for the `Invoke` method or deriving from
-that interface. Two alternatives were considered and both are rejected.
+A delegate declaration is a method signature with the `delegate` keyword in front of it. Everything an author
+chooses about the signature is what an author chooses about a method, so `IDelegateBuilder` derives from
+`IMethodBuilder` and declares one member of its own.
 
-The first alternative is `IDelegateBuilder : IMethodBuilder`, with the inapplicable operations made illegal. It
-would add no member of its own, which is what makes it attractive. It cannot be taken, because the chain
-`IMethodBuilder : IMethodBaseBuilder`, `IMethodBaseBuilder : IHasParametersBuilder`,
-`IHasParametersBuilder : IMemberBuilder`, `IMemberBuilder : IMember` ends at the interface that narrows the
-declaring type to a value that is not nullable, and a delegate declared in a namespace has no declaring type. That
-is the same obstacle that section 2.1 of [`introducing-types.md`](introducing-types.md) records against
-`IMemberBuilder`, reached through four interfaces instead of one. `IMethod` also derives from `IMethodInvoker`, so
-the builder of a delegate type would offer the operations that invoke a method.
+An earlier revision of this document rejected that base and gave a reason that does not hold. The reason was that
+`IMethodBuilder` reaches `IMember`, whose `DeclaringType` is not nullable, and that a delegate declared in a
+namespace has no declaring type. That confuses the delegate with its `Invoke` method. The builder is the `Invoke`
+method, its declaring type is the delegate, and a delegate always has one, so the obstacle that section 2.1 of
+[`introducing-types.md`](introducing-types.md) records against `IMemberBuilder` for an enum does not arise here.
+The same revision objected that `IMethod` derives from `IMethodInvoker`. That is not a cost either: generating a
+call to the `Invoke` method of a delegate is what `IDelegateFacet` exists for, and the facet documents it.
 
-The second alternative is an `InvokeMethod` property typed as `IMethodBuilder`, which an earlier revision of this
-document took. The `Invoke` method does not need to be reachable while the delegate is being built: everything an
-author sets on it is the signature, and the signature is what the members below are. Keeping the property would
-mean two ways to write the same thing, and a second object whose name, accessibility and modifiers are all invalid.
+Two alternatives were weighed against this one.
 
-What is lost is the symmetry with `IDelegateFacet`, which declares `InvokeMethod` first and documents `ReturnType`
-and `Parameters` as being those of the first. The asymmetry is accepted, and it is the same one that section 6.1 of
-[`introducing-enums.md`](introducing-enums.md) accepts: a reader asks what a delegate is made of, and the answer
-names the method, while a writer chooses a signature and never needs the method as an object. The `Invoke` method
-of an introduced delegate is reached through the facet as soon as the advice completes.
+Declaring the signature members on a builder of the type, which is what the earlier revision did, restates
+`ReturnType`, `ReturnParameter`, `Parameters`, `AddParameter` and `InsertParameter` on an interface that is not a
+method. It carries no member that `IMethodBuilder` does not already carry, and an aspect that copies a signature
+from an existing method has to transfer it member by member instead of using the operations it already knows.
 
-### 6.2. The type parameters belong to the type
+Exposing an `InvokeMethod` property typed as `IMethodBuilder`, which a revision before that one did, gives the same
+operations through one more indirection, and leaves the builder of the type carrying a name and an accessibility
+beside a method that has its own.
 
-`IDelegateBuilder.AddTypeParameter` adds a type parameter to the delegate and not to its `Invoke` method. The
-language places the type parameters of a delegate on the type: `Func<T, TResult>` is a generic type whose `Invoke`
-method is not generic.
+The cost of the decision is that what belongs to the type is set through `DeclaringType`, so making a delegate
+public is `d.DeclaringType.Accessibility = Accessibility.Public` rather than `d.Accessibility = ...`. That is
+accepted rather than hidden. Reinterpreting the inherited `Name` and `Accessibility` as the delegate's would make
+the builder report, while it is an `IMethod`, a name that is not the name of the method it is, and the code model
+does not say two things with one member.
+
+### 6.2. The type parameters belong to the type, so they are added through `DeclaringType`
+
+The language places the type parameters of a delegate on the type: `Func<T, TResult>` is a generic type whose
+`Invoke` method is not generic. `DeclaringType.AddTypeParameter` therefore adds them, and the inherited
+`IMethodBuilder.AddTypeParameter`, which would add one to the `Invoke` method, throws.
+
+Shadowing the inherited method and redefining it as the type's was considered and rejected. Two methods of the same
+name and signature, one of which silently means something the other does not, is harder to read than one that
+throws and one that is reached through the type.
 
 The consequence that the documentation states is that a delegate is the one kind of type, besides an interface,
 whose type parameters may declare variance, so `ITypeParameterBuilder.Variance` is meaningful here and nowhere
@@ -361,15 +328,19 @@ accept.
 
 ## 7. Open questions
 
-None. Two questions that an earlier revision recorded are answered, and section 6 carries both.
+### 7.1. Is `DeclaringType` the right way to configure the type?
 
-The `Invoke` method does not need to be reachable while the delegate is being built, which is why section 6.1
-removes the `InvokeMethod` property rather than keeping it for a case that does not arise. The method is reached
-through the facet of the introduced type as soon as the advice completes.
+Section 6.1 accepts that making a delegate public is `d.DeclaringType.Accessibility = Accessibility.Public`. That is
+the price of a builder that is honestly the `Invoke` method, and it is paid on every delegate an aspect introduces,
+because a delegate that is not public is rarely what the author wants.
 
-A `ref` return and a pointer parameter are in scope. A delegate may return by reference and may take a pointer
-parameter in an unsafe context, `ReturnParameter` and `AddParameter` express both, and the emission path handles
-them. Each is covered by a test rather than refused.
+What would settle whether the price is too high is the set of aspects written against this interface once it
+exists. If it is, the remedy is a second callback on the advice method, typed `Action<INamedTypeBuilder>`, for the
+type, rather than reinterpreting a member of the method builder as the type's.
+
+A `ref` return and a pointer parameter are in scope and are not open. A delegate may return by reference and may
+take a pointer parameter in an unsafe context, `ReturnParameter` and `AddParameter` express both, and each is
+covered by a test rather than refused.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/introducing-delegates.md
+++ b/Metalama.Framework/docs/future/introducing-delegates.md
@@ -270,13 +270,24 @@ because `IMethodBuilder` is reused whole rather than narrowed. Section 6.2 state
 narrower interface here and not for the members of an enum.
 
 Every operation of `INamedTypeBuilder` is absent rather than failing, because `IDelegateBuilder` does not derive
-from that interface. The one operation of `INamedTypeBuilder` that a delegate genuinely needs is
-`AddTypeParameter`, which section 3.1 declares again.
+from that interface. That includes `Facets`: a caller that reaches the engine object as an `INamedType` and reads
+`Facets` on it meets the `NotSupportedException` of section 5.1 of
+[`introducing-types.md`](introducing-types.md). The one operation of `INamedTypeBuilder` that a delegate genuinely
+needs is `AddTypeParameter`, which section 3.1 declares again.
 
 ## 5. What the facet of the introduced delegate reports
 
-The introduced type reports an `IDelegateFacet` rather than the empty collection, which replaces implementation
-guideline 5 of [`type-facets.md`](type-facets.md) for this kind.
+A delegate builder declares no `Facets` member, because `IDelegateBuilder` does not derive from `INamedType`. The
+engine class behind it does, and it throws a `NotSupportedException`, which section 5.1 of
+[`introducing-types.md`](introducing-types.md) states for every builder. The kind of a builder is read from
+`IsDelegate`, which answers without allocating and does not throw.
+
+That the delegate builder is not a type also bounds the risk of the exception. Section 5.1 lists
+`EventBuilder.Signature` and the eligibility rule of `AdviceKind.OverrideEventInvoke` as the readers that take the
+type of an event from the aspect. An aspect cannot give a delegate builder as the type of an event, because the
+builder is not an `IType`, so neither reader can meet one.
+
+The introduced type reports an `IDelegateFacet`.
 
 | `IDelegateFacet` member | Source |
 | --- | --- |
@@ -296,6 +307,13 @@ method is a member of the type like any other. The facet needs no branch for an 
 `BeginInvoke` and `EndInvoke` are not materialized. The facet does not expose them, no consumer reaches them, and
 an introduced delegate is compiled for the target framework of the project rather than for .NET Framework
 specifically.
+
+The facet is tested by unit tests and not by aspect tests, for the reason that section 5.3 of
+[`introducing-types.md`](introducing-types.md) gives. Two assertions are specific to this kind. An event whose type
+is an introduced delegate reports the `Invoke` method of that delegate as its `Signature`, which is the shape that
+`TypeFacetTests.SignatureOfIntroducedEventIsTheInvokeMethodOfTheFacet` already tests for a delegate read from
+source. And an introduced delegate and the equivalent delegate read from source report the same return type and the
+same parameters.
 
 ## 6. Decisions
 
@@ -371,7 +389,8 @@ would be to refuse a signature that `IMethodBuilder` can already express.
 
 - [`introducing-types.md`](introducing-types.md), sections 2, 3 and 5.
 - [`introducing-enums.md`](introducing-enums.md), section 6.1, which this document contrasts with in section 6.2.
-- [`type-facets.md`](type-facets.md), section 2.2 and implementation guideline 5.
+- [`type-facets.md`](type-facets.md), section 2.2. Its implementation guideline 5, which makes a builder return
+  the empty facet collection, is superseded by section 5.1 of [`introducing-types.md`](introducing-types.md).
 - `Metalama.Framework/Code/Types/IDelegateFacet.cs`, the interface this design mirrors.
 - `Metalama.Framework.Engine/CodeModel/Facets/DelegateFacet.cs`, which resolves the `Invoke` method by name and is
   described there as the single site of the code model that does so.

--- a/Metalama.Framework/docs/future/introducing-enums.md
+++ b/Metalama.Framework/docs/future/introducing-enums.md
@@ -368,9 +368,12 @@ introduction pipeline never re-reads the final model from Roslyn.
 An enum is the one kind of this set whose members are emitted. The declaration that Metalama generates is
 `enum State { Idle, Running, Stopped = 10 }`, so the members are inside it, and they are registered in the code
 model from the same builders. That is not the case for a record, a union, a delegate or a struct, whose
-synthesized members the compiler creates from the declaration and which section 5.2 of
-[`introducing-types.md`](introducing-types.md) therefore keeps out of the generated code. The members of an enum
-are written by the aspect author rather than synthesized by the compiler, which is why they differ.
+synthesized members the compiler creates from the declaration and which section 4.2 of
+[`introducing-types.md`](introducing-types.md) therefore keeps out of the generated code.
+
+The reason for the difference is the one that section: a member is exempt from emission exactly when the compiler
+creates it. The members of an enum are written by the aspect author, so they are emitted and registered like any
+declared member, and the transformation that carries them is an ordinary injecting one.
 
 The synthetic field whose metadata name is `value__` is the exception, and it is neither emitted nor materialized.
 It is the field that the compiler synthesizes, `IEnumFacet.Members` excludes it by contract, and no consumer of the

--- a/Metalama.Framework/docs/future/introducing-enums.md
+++ b/Metalama.Framework/docs/future/introducing-enums.md
@@ -50,7 +50,8 @@ builder.IntroduceEnum(
     } );
 ```
 
-An aspect that mirrors an enum of the domain copies the value of each member, which is a `TypedConstant`:
+An aspect that mirrors an enum of the domain copies the value of each member, which is a `TypedConstant`, and
+annotates it:
 
 ```csharp
 var source = builder.Target.Facets.Enum!;
@@ -64,7 +65,12 @@ builder.IntroduceEnum(
 
         foreach ( var member in source.Members )
         {
-            e.AddMember( member.Name, member.ConstantValue!.Value );
+            var added = e.AddMember( member.Name, member.ConstantValue!.Value );
+
+            added.AddAttribute(
+                AttributeConstruction.Create(
+                    typeof(DescriptionAttribute),
+                    new object?[] { member.Name } ) );
         }
     } );
 ```
@@ -162,39 +168,49 @@ public interface IEnumBuilder : IMemberOrNamedTypeBuilder
     bool IsFlags { get; set; }
 
     /// <summary>
+    /// Gets the members that have been added so far, in the order in which they were added.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IEnumFacet.Members"/>
+    IReadOnlyList<IEnumMemberBuilder> Members { get; }
+
+    /// <summary>
     /// Adds a member whose value the language assigns, which is zero for the first member and the value of the
     /// preceding member plus one for any other.
     /// </summary>
     /// <param name="name">The name of the member.</param>
-    void AddMember( string name );
+    /// <returns>An <see cref="IEnumMemberBuilder"/> that allows you to add custom attributes to the new
+    ///     member.</returns>
+    IEnumMemberBuilder AddMember( string name );
 
     /// <summary>
     /// Adds a member of the given value.
     /// </summary>
     /// <param name="name">The name of the member.</param>
     /// <param name="value">The value of the member, converted to <see cref="UnderlyingType"/>.</param>
-    void AddMember( string name, sbyte value );
+    /// <returns>An <see cref="IEnumMemberBuilder"/> that allows you to add custom attributes to the new
+    ///     member.</returns>
+    IEnumMemberBuilder AddMember( string name, sbyte value );
 
     /// <inheritdoc cref="AddMember(string,sbyte)"/>
-    void AddMember( string name, byte value );
+    IEnumMemberBuilder AddMember( string name, byte value );
 
     /// <inheritdoc cref="AddMember(string,sbyte)"/>
-    void AddMember( string name, short value );
+    IEnumMemberBuilder AddMember( string name, short value );
 
     /// <inheritdoc cref="AddMember(string,sbyte)"/>
-    void AddMember( string name, ushort value );
+    IEnumMemberBuilder AddMember( string name, ushort value );
 
     /// <inheritdoc cref="AddMember(string,sbyte)"/>
-    void AddMember( string name, int value );
+    IEnumMemberBuilder AddMember( string name, int value );
 
     /// <inheritdoc cref="AddMember(string,sbyte)"/>
-    void AddMember( string name, uint value );
+    IEnumMemberBuilder AddMember( string name, uint value );
 
     /// <inheritdoc cref="AddMember(string,sbyte)"/>
-    void AddMember( string name, long value );
+    IEnumMemberBuilder AddMember( string name, long value );
 
     /// <inheritdoc cref="AddMember(string,sbyte)"/>
-    void AddMember( string name, ulong value );
+    IEnumMemberBuilder AddMember( string name, ulong value );
 
     /// <summary>
     /// Adds a member whose value is given as a <see cref="TypedConstant"/>, which is the form in which the value of
@@ -210,14 +226,48 @@ public interface IEnumBuilder : IMemberOrNamedTypeBuilder
     /// </remarks>
     /// <param name="name">The name of the member.</param>
     /// <param name="value">The value of the member, converted to <see cref="UnderlyingType"/>.</param>
-    void AddMember( string name, TypedConstant value );
-}
+    /// <returns>An <see cref="IEnumMemberBuilder"/> that allows you to add custom attributes to the new
+    ///     member.</returns>
+    IEnumMemberBuilder AddMember( string name, TypedConstant value );}
 ```
 
-There are eight integral overloads and not one, so that the value an author writes keeps the type the author gave
-it. There is no `Members` property either. Section 6.3 states both reasons.
+There are eight integral overloads and not one, and section 6.3 states why.
 
-### 3.2. The advice method
+### 3.2. `IEnumMemberBuilder`
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IEnumMemberBuilder.cs
+namespace Metalama.Framework.Code.DeclarationBuilders;
+
+/// <summary>
+/// Allows to add custom attributes to a member of an enum that has been created by one of the
+/// <c>AddMember</c> methods of <see cref="IEnumBuilder"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface declares no member of its own. It exists for the custom attributes that
+/// <see cref="IDeclarationBuilder"/> declares, which are the only thing about a member of an enum that remains to
+/// be chosen after it is added: its name and its value are arguments of <c>AddMember</c>, and it has nothing else.
+/// </para>
+/// <para>
+/// A member of an enum is a constant field, and the code model reports it as an <see cref="IField"/> once the enum
+/// is introduced. This interface is nevertheless not an <see cref="IFieldBuilder"/>, for the reason that section
+/// 6.1 of the design document gives.
+/// </para>
+/// </remarks>
+/// <seealso cref="IEnumBuilder"/>
+/// <seealso cref="IField"/>
+/// <seealso href="@introducing-types"/>
+[InternalImplement]
+public interface IEnumMemberBuilder : IDeclarationBuilder, INamedDeclaration;
+```
+
+The interface declares no member. `IDeclarationBuilder` carries `AddAttribute`, two overloads of `AddAttributes`,
+`RemoveAttributes`, `Freeze` and `IsFrozen`, and that is the whole of what the interface is for.
+`INamedDeclaration` adds a read-only `Name`, so that a builder an aspect has collected says which member it is;
+`Name` is not on `IDeclaration`, which is why it is named here.
+
+### 3.3. The advice method
 
 ```csharp
 // Metalama.Framework/Advising/IAdviceFactory.cs
@@ -336,24 +386,28 @@ the same members in the same order, the same values, and the same `IsFlags`.
 
 ## 6. Decisions
 
-### 6.1. `AddMember` returns nothing, and there is no builder for a member
+### 6.1. A member of an enum is built by `IEnumMemberBuilder` and not by `IFieldBuilder`
 
-A member of an enum is a name and a value. Both are given to `AddMember`, and nothing about a member remains to be
-chosen after it is added, so the method returns nothing and no interface describes a member under construction.
+`AddMember` returns an `IEnumMemberBuilder`, and that interface exists for one reason: the custom attributes of the
+member. Everything else about a member of an enum is an argument of `AddMember`, so the interface declares no
+member of its own and derives from `IDeclarationBuilder`, which carries the attribute operations.
 
-An earlier revision of this document declared an `IEnumMemberBuilder` carrying a settable name and a settable
-value. It carried nothing that the arguments of `AddMember` do not carry, and it existed only because the value
-could not be expressed in one parameter. The overloads of section 6.3 remove that reason.
+The attributes are not a marginal case. A view model that mirrors an enum of the domain, which is the pattern that
+issue [#866](https://github.com/metalama/Metalama/issues/866) exists for, annotates each member with
+`[Display]`, `[Description]` or `[EnumMember]`, and an aspect that could not do that would be of little use. An
+earlier revision of this document returned nothing from `AddMember` and lost that capability, which is why the
+interface is back.
 
-Returning `IFieldBuilder` was rejected for a different reason, and the reason still holds. `IFieldBuilder` derives
-from `IFieldOrPropertyBuilder`, from `IFieldOrPropertyOrIndexerBuilder`, from `IMemberBuilder` and from
-`IHasTypeBuilder`. A member of an enum has none of what those interfaces offer: its type is the enum and may not be
-set, its accessibility is that of the enum and may not be set, it has no initializer expression, it has no
-writeability to choose, and every modifier that `IMemberBuilder` adds is invalid on it. A field builder would
-present roughly fifteen operations of which one is valid.
+`IFieldBuilder` was rejected as the return type and stays rejected. It derives from `IFieldOrPropertyBuilder`, from
+`IFieldOrPropertyOrIndexerBuilder`, from `IMemberBuilder` and from `IHasTypeBuilder`. A member of an enum has none
+of what those interfaces offer: its type is the enum and may not be set, its accessibility is that of the enum and
+may not be set, it has no initializer expression, it has no writeability to choose, and every modifier that
+`IMemberBuilder` adds is invalid on it. A field builder would present roughly fifteen operations of which one, the
+addition of an attribute, is valid, which is the one this design needs.
 
 The read side is unaffected and reports a member of an enum as an `IField`, which is what it is. The two sides
-answer different questions: a reader asks what a member of an enum is, and a writer chooses a name and a number.
+answer different questions: a reader asks what a member of an enum is, and a writer chooses a name, a value and the
+attributes.
 
 ### 6.2. `IsFlags` is a property and not only an attribute
 
@@ -365,7 +419,7 @@ doing by hand what the reader is explicitly spared.
 The property and the attribute are one state and not two: the setter adds or removes the attribute, and the getter
 reports whether it is present. There is no third state in which they disagree.
 
-### 6.3. There are eight integral overloads, and no `Members` property
+### 6.3. There are eight integral overloads
 
 `AddMember` has one overload per integral type that the language allows as the underlying type of an enum, plus one
 that takes a `TypedConstant` and one that takes no value at all.
@@ -377,14 +431,9 @@ write the value in the type the enum actually has, the compiler picks the overlo
 `UnderlyingType` and checks the range.
 
 The `TypedConstant` overload is the one an aspect uses when it copies from another enum, because
-`IField.ConstantValue` is a `TypedConstant`. It also accepts a constant that
-`TypedConstant.Create(IField)` produced, which renders as a reference to that field rather than as a literal, and
-the language allows a member of an enum to be defined that way.
-
-There is no `Members` property on the builder. A member of an enum is a name and a value, the code model has no
-type for that pair, and inventing one is what removing `IEnumMemberBuilder` avoided. An aspect that adds a member
-knows what it added, a duplicate name is refused by `AddMember` rather than checked by the author, and the
-introduced type reports the members through `IEnumFacet.Members`.
+`IField.ConstantValue` is a `TypedConstant`. It also accepts a constant that `TypedConstant.Create(IField)`
+produced, which renders as a reference to that field rather than as a literal, and the language allows a member of
+an enum to be defined that way.
 
 ### 6.4. The value of a member is validated when it is added
 
@@ -397,22 +446,12 @@ documentation of `UnderlyingType` states that, and the exception names it.
 
 ## 7. Open questions
 
-### 7.1. Can an aspect put a custom attribute on a member of an enum?
+None.
 
-It cannot. `AddMember` returns nothing, so there is no object on which to call `AddAttribute`, and this is the one
-capability that removing `IEnumMemberBuilder` costs. It is not hypothetical: `[Display]`, `[Description]` and
-`[EnumMember]` on a member of an enum are ordinary in the patterns that issue
-[#866](https://github.com/metalama/Metalama/issues/866) exists for, such as a view model that mirrors an enum of
-the domain.
-
-What would settle it is whether an aspect written against this interface needs one. If it does, the remedy is an
-overload of `AddMember` that takes the attribute constructions, in the manner of
-`IAdviceFactory.IntroduceParameter`, which takes an `ImmutableArray<AttributeConstruction>`. It is not a builder:
-a member of an enum still has nothing to configure after it is added, and reintroducing one for attributes alone
-would reverse section 6.1 for a reason it did not weigh.
-
-The attributes of the enum itself are unaffected and are added through `IDeclarationBuilder.AddAttribute` on the
-builder.
+Two questions that earlier revisions recorded are answered. An aspect copies the members of another enum through
+the `TypedConstant` overload of `AddMember`, which section 6.3 describes and section 1 shows. An aspect puts a
+custom attribute on a member through the `IEnumMemberBuilder` that `AddMember` returns, which section 6.1
+describes.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/introducing-enums.md
+++ b/Metalama.Framework/docs/future/introducing-enums.md
@@ -97,6 +97,15 @@ public enum Permissions : byte
 }
 ```
 
+An enum cannot be partial, so the design-time path needs one guard that section 4.1 of
+[`introducing-types.md`](introducing-types.md) describes.
+`DesignTimeSyntaxTreeGenerator.ProcessTransformationsOnNamespace` routes an introduced type that carries no
+transformation of its own into `ProcessTransformationsOnType`, which calls `CreatePartialType` on it. That method
+returns a `TypeDeclarationSyntax` and emits the `partial` modifier, so an introduced enum reaching it falls to the
+default arm of its switch and throws. The routing skips a kind that cannot be partial and cannot contain a member,
+and `CreatePartialType` gains no arm. The enum itself is emitted at design time by
+`IntroduceNamedTypeTransformation.GetInjectedMembers`, which is the same method the build uses.
+
 ## 3. The interfaces
 
 ### 3.1. `IEnumBuilder`
@@ -371,8 +380,8 @@ model from the same builders. That is not the case for a record, a union, a dele
 synthesized members the compiler creates from the declaration and which section 4.2 of
 [`introducing-types.md`](introducing-types.md) therefore keeps out of the generated code.
 
-The reason for the difference is the one that section: a member is exempt from emission exactly when the compiler
-creates it. The members of an enum are written by the aspect author, so they are emitted and registered like any
+The reason for the difference is the one that section gives: a member is exempt from emission exactly when the
+compiler creates it. The members of an enum are written by the aspect author, so they are emitted and registered like any
 declared member, and the transformation that carries them is an ordinary injecting one.
 
 The synthetic field whose metadata name is `value__` is the exception, and it is neither emitted nor materialized.

--- a/Metalama.Framework/docs/future/introducing-enums.md
+++ b/Metalama.Framework/docs/future/introducing-enums.md
@@ -32,8 +32,8 @@ public class GenerateStateEnumAttribute : TypeAspect
 }
 ```
 
-A flags enum sets one more property, and states every value, because the language computes no power of two on the
-author's behalf and neither does Metalama:
+A flags enum sets one more property, and states every value, because neither the language nor Metalama derives a
+power of two from the position of a member:
 
 ```csharp
 builder.IntroduceEnum(
@@ -43,10 +43,29 @@ builder.IntroduceEnum(
         e.Accessibility = Accessibility.Public;
         e.UnderlyingType = TypeFactory.GetType( SpecialType.Byte );
         e.IsFlags = true;
-        e.AddMember( "None", 0 );
-        e.AddMember( "Read", 1 );
-        e.AddMember( "Write", 2 );
-        e.AddMember( "Execute", 4 );
+        e.AddMember( "None", (byte) 0 );
+        e.AddMember( "Read", (byte) 1 );
+        e.AddMember( "Write", (byte) 2 );
+        e.AddMember( "Execute", (byte) 4 );
+    } );
+```
+
+An aspect that mirrors an enum of the domain copies the value of each member, which is a `TypedConstant`:
+
+```csharp
+var source = builder.Target.Facets.Enum!;
+
+builder.IntroduceEnum(
+    builder.Target.Name + "ViewModel",
+    buildEnum: e =>
+    {
+        e.Accessibility = Accessibility.Public;
+        e.UnderlyingType = source.UnderlyingType;
+
+        foreach ( var member in source.Members )
+        {
+            e.AddMember( member.Name, member.ConstantValue!.Value );
+        }
     } );
 ```
 
@@ -88,14 +107,13 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 /// This interface derives from <see cref="IMemberOrNamedTypeBuilder"/> and not from
 /// <see cref="INamedTypeBuilder"/>, because an enum declares no member that an aspect can introduce and has
 /// neither a base type nor type parameters. The operations that an enum does not have are therefore absent rather
-/// than present and failing. The operations that it inherits and does not have are listed below.
+/// than present and failing. The operations that it inherits and does not have are listed in the design document.
 /// </para>
 /// <para>
-/// The following inherited properties are not valid for an enum, and their setter throws a
-/// <see cref="NotSupportedException"/>: <see cref="IMemberOrNamedTypeBuilder.IsStatic"/>,
-/// <see cref="IMemberOrNamedTypeBuilder.IsSealed"/>, <see cref="IMemberOrNamedTypeBuilder.IsAbstract"/> and
-/// <see cref="IMemberOrNamedTypeBuilder.IsPartial"/>. An enum is implicitly sealed, it may not be abstract or
-/// static, and the language has no partial enum.
+/// Every overload of <c>AddMember</c> applies the same three rules. The name must be a valid C# identifier and
+/// must not be the name of a member already added, and a duplicate throws an <see cref="ArgumentException"/>. The
+/// value is converted to <see cref="UnderlyingType"/>, and a value that does not fit in that type throws an
+/// <see cref="ArgumentOutOfRangeException"/>. The members are declared in the order in which they were added.
 /// </para>
 /// <para>
 /// An enum builder is not an <see cref="INamedType"/>, so it may not be used where an <see cref="IType"/> is
@@ -103,7 +121,6 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 /// <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>.
 /// </para>
 /// </remarks>
-/// <seealso cref="IEnumMemberBuilder"/>
 /// <seealso cref="Metalama.Framework.Code.Types.IEnumFacet"/>
 /// <seealso href="@introducing-types"/>
 [InternalImplement]
@@ -145,75 +162,62 @@ public interface IEnumBuilder : IMemberOrNamedTypeBuilder
     bool IsFlags { get; set; }
 
     /// <summary>
-    /// Gets the members that have been added so far, in the order in which they were added.
-    /// </summary>
-    /// <seealso cref="Metalama.Framework.Code.Types.IEnumFacet.Members"/>
-    IReadOnlyList<IEnumMemberBuilder> Members { get; }
-
-    /// <summary>
-    /// Adds a member to the enum.
+    /// Adds a member whose value the language assigns, which is zero for the first member and the value of the
+    /// preceding member plus one for any other.
     /// </summary>
     /// <param name="name">The name of the member.</param>
-    /// <param name="value">The value of the member, or <c>null</c> to let the language assign it, which gives zero
-    ///     to the first member and the value of the preceding member plus one to any other. A value that does not
-    ///     fit in <see cref="UnderlyingType"/> throws an <see cref="ArgumentOutOfRangeException"/>. A value outside
-    ///     the range of <see cref="long"/>, which only an enum whose underlying type is <c>ulong</c> can have, is
-    ///     assigned through <see cref="IEnumMemberBuilder.Value"/> instead.</param>
-    /// <returns>An <see cref="IEnumMemberBuilder"/> that allows you to further build the new member, in particular
-    ///     to add custom attributes to it.</returns>
-    IEnumMemberBuilder AddMember( string name, long? value = null );
-}
-```
+    void AddMember( string name );
 
-### 3.2. `IEnumMemberBuilder`
-
-```csharp
-// Metalama.Framework/Code/DeclarationBuilders/IEnumMemberBuilder.cs
-namespace Metalama.Framework.Code.DeclarationBuilders;
-
-/// <summary>
-/// Allows to complete the construction of a member of an enum that has been created by
-/// <see cref="IEnumBuilder.AddMember"/>.
-/// </summary>
-/// <remarks>
-/// <para>
-/// A member of an enum is a constant field, and the code model reports it as an <see cref="IField"/> once the enum
-/// is introduced. This interface is nevertheless not an <see cref="IFieldBuilder"/>: a member of an enum has no
-/// type of its own, no accessibility of its own, no initializer and no modifier, so almost every operation of a
-/// field builder would be invalid on it. Section 6 of the design document states the decision.
-/// </para>
-/// </remarks>
-/// <seealso cref="IEnumBuilder.AddMember"/>
-/// <seealso cref="IField"/>
-/// <seealso href="@introducing-types"/>
-[InternalImplement]
-public interface IEnumMemberBuilder : IDeclarationBuilder
-{
     /// <summary>
-    /// Gets or sets the name of the member.
+    /// Adds a member of the given value.
     /// </summary>
-    string Name { get; set; }
+    /// <param name="name">The name of the member.</param>
+    /// <param name="value">The value of the member, converted to <see cref="UnderlyingType"/>.</param>
+    void AddMember( string name, sbyte value );
+
+    /// <inheritdoc cref="AddMember(string,sbyte)"/>
+    void AddMember( string name, byte value );
+
+    /// <inheritdoc cref="AddMember(string,sbyte)"/>
+    void AddMember( string name, short value );
+
+    /// <inheritdoc cref="AddMember(string,sbyte)"/>
+    void AddMember( string name, ushort value );
+
+    /// <inheritdoc cref="AddMember(string,sbyte)"/>
+    void AddMember( string name, int value );
+
+    /// <inheritdoc cref="AddMember(string,sbyte)"/>
+    void AddMember( string name, uint value );
+
+    /// <inheritdoc cref="AddMember(string,sbyte)"/>
+    void AddMember( string name, long value );
+
+    /// <inheritdoc cref="AddMember(string,sbyte)"/>
+    void AddMember( string name, ulong value );
 
     /// <summary>
-    /// Gets or sets the value of the member, or <c>null</c> when the language assigns it, which gives zero to the
-    /// first member and the value of the preceding member plus one to any other.
+    /// Adds a member whose value is given as a <see cref="TypedConstant"/>, which is the form in which the value of
+    /// a member of another enum is read.
     /// </summary>
     /// <remarks>
     /// <para>
-    /// The value is converted to <see cref="IEnumBuilder.UnderlyingType"/>. A value that does not fit in that type,
-    /// or whose type is not an integral type, throws an <see cref="ArgumentOutOfRangeException"/>.
-    /// </para>
-    /// <para>
-    /// This property is the way to assign a value outside the range of <see cref="long"/>, which
-    /// <see cref="IEnumBuilder.AddMember"/> cannot express and which an enum whose underlying type is <c>ulong</c>
-    /// can have.
+    /// The type of the constant must be an integral type or an enum, and any other type throws an
+    /// <see cref="ArgumentException"/>. A constant that <see cref="TypedConstant.Create(IField)"/> produced
+    /// references the field rather than its value, and the generated code names that field, which is what the
+    /// language allows in the value of a member of an enum.
     /// </para>
     /// </remarks>
-    TypedConstant? Value { get; set; }
+    /// <param name="name">The name of the member.</param>
+    /// <param name="value">The value of the member, converted to <see cref="UnderlyingType"/>.</param>
+    void AddMember( string name, TypedConstant value );
 }
 ```
 
-### 3.3. The advice method
+There are eight integral overloads and not one, so that the value an author writes keeps the type the author gave
+it. There is no `Members` property either. Section 6.3 states both reasons.
+
+### 3.2. The advice method
 
 ```csharp
 // Metalama.Framework/Advising/IAdviceFactory.cs
@@ -303,7 +307,7 @@ introduction pipeline never re-reads the final model from Roslyn.
 | `IEnumFacet` member | Source |
 | --- | --- |
 | `UnderlyingType` | `IEnumBuilder.UnderlyingType`, or `int` when the aspect set none. |
-| `Members` | One `IField` per `IEnumMemberBuilder`, in the order in which they were added. The value of each field is the value that the builder assigned, or the value the language computes when the builder assigned none. |
+| `Members` | One `IField` per member added to the builder, in the order in which they were added. The value of each field is the value that the aspect assigned, converted to the underlying type, or the value the language computes when the aspect assigned none. |
 | `IsFlags` | Whether the attribute is present, which is what `IsFlags` on the builder sets. |
 | `FacetKind` | `TypeFacetKind.Enum`. |
 | `Type` | The introduced type. |
@@ -332,25 +336,24 @@ the same members in the same order, the same values, and the same `IsFlags`.
 
 ## 6. Decisions
 
-### 6.1. A member of an enum is built by `IEnumMemberBuilder` and not by `IFieldBuilder`
+### 6.1. `AddMember` returns nothing, and there is no builder for a member
 
-The read side reports a member of an enum as an `IField`, and `IEnumFacet` states that no interface of its own is
-declared for it. The write side does not follow, and the asymmetry is deliberate.
+A member of an enum is a name and a value. Both are given to `AddMember`, and nothing about a member remains to be
+chosen after it is added, so the method returns nothing and no interface describes a member under construction.
 
-`IFieldBuilder` derives from `IFieldOrPropertyBuilder`, from `IFieldOrPropertyOrIndexerBuilder`, from
-`IMemberBuilder` and from `IHasTypeBuilder`. A member of an enum has none of what those interfaces offer: its type
-is the enum and may not be set, its accessibility is that of the enum and may not be set, it has no initializer
-expression, it has no writeability to choose, and every modifier that `IMemberBuilder` adds is invalid on it. A
-field builder would present roughly fifteen operations of which one, the addition of an attribute, is valid.
+An earlier revision of this document declared an `IEnumMemberBuilder` carrying a settable name and a settable
+value. It carried nothing that the arguments of `AddMember` do not carry, and it existed only because the value
+could not be expressed in one parameter. The overloads of section 6.3 remove that reason.
 
-The reason the asymmetry is acceptable is that the two sides answer different questions. A reader asks what a
-member of an enum is, and it is a constant field, so `IField` is the right answer and a narrower interface would
-only remove members that the reader may legitimately ask for. A writer asks what may be chosen about a member, and
-the answer is its name, its value and its attributes, which is three things.
+Returning `IFieldBuilder` was rejected for a different reason, and the reason still holds. `IFieldBuilder` derives
+from `IFieldOrPropertyBuilder`, from `IFieldOrPropertyOrIndexerBuilder`, from `IMemberBuilder` and from
+`IHasTypeBuilder`. A member of an enum has none of what those interfaces offer: its type is the enum and may not be
+set, its accessibility is that of the enum and may not be set, it has no initializer expression, it has no
+writeability to choose, and every modifier that `IMemberBuilder` adds is invalid on it. A field builder would
+present roughly fifteen operations of which one is valid.
 
-The alternative, which is to declare `IFieldBuilder` as the return type and to throw on the invalid operations, is
-the shape that section 2 of [`introducing-types.md`](introducing-types.md) rejects at the level of the type. It is
-rejected here for the same reason and at a worse ratio.
+The read side is unaffected and reports a member of an enum as an `IField`, which is what it is. The two sides
+answer different questions: a reader asks what a member of an enum is, and a writer chooses a name and a number.
 
 ### 6.2. `IsFlags` is a property and not only an attribute
 
@@ -362,47 +365,54 @@ doing by hand what the reader is explicitly spared.
 The property and the attribute are one state and not two: the setter adds or removes the attribute, and the getter
 reports whether it is present. There is no third state in which they disagree.
 
-### 6.3. The underlying type is set on the builder and not passed to the advice method
+### 6.3. There are eight integral overloads, and no `Members` property
 
-`IntroduceEnum` takes the name, the conflict strategy and the callback, and nothing else, which is the shape of
-`IntroduceClass` and `IntroduceInterface`. The underlying type is configuration of the type, and configuration of
-the type is what the callback is for. Adding a parameter for it would make `IntroduceEnum` the only introduction
-method whose signature carries a property of the type being built.
+`AddMember` has one overload per integral type that the language allows as the underlying type of an enum, plus one
+that takes a `TypedConstant` and one that takes no value at all.
 
-### 6.4. The value of a member is validated when it is assigned
+One overload taking the widest integral type would not do. `ulong` cannot express a negative value and `long`
+cannot express a value above `long.MaxValue`, so a single overload of either type refuses a value that some enum
+can hold. Taking `object` would move every type error from the compiler to run time. Eight overloads let the author
+write the value in the type the enum actually has, the compiler picks the overload, and the builder converts to
+`UnderlyingType` and checks the range.
 
-`AddMember` and `IEnumMemberBuilder.Value` both validate the value against `UnderlyingType`, and
-`UnderlyingType` may not be set after a member has been added. The alternative is to validate every value when the
-builder is frozen, which reports the error at a place the author did not write.
+The `TypedConstant` overload is the one an aspect uses when it copies from another enum, because
+`IField.ConstantValue` is a `TypedConstant`. It also accepts a constant that
+`TypedConstant.Create(IField)` produced, which renders as a reference to that field rather than as a literal, and
+the language allows a member of an enum to be defined that way.
+
+There is no `Members` property on the builder. A member of an enum is a name and a value, the code model has no
+type for that pair, and inventing one is what removing `IEnumMemberBuilder` avoided. An aspect that adds a member
+knows what it added, a duplicate name is refused by `AddMember` rather than checked by the author, and the
+introduced type reports the members through `IEnumFacet.Members`.
+
+### 6.4. The value of a member is validated when it is added
+
+Every overload of `AddMember` validates the value against `UnderlyingType`, and `UnderlyingType` may not be set
+after a member has been added. The alternative is to validate every value when the builder is frozen, which reports
+the error at a place the author did not write.
 
 The cost is that an author who wants a non-default underlying type sets it before adding any member. The
 documentation of `UnderlyingType` states that, and the exception names it.
 
 ## 7. Open questions
 
-### 7.1. How does an aspect introduce an enum whose members are copied from another enum?
+### 7.1. Can an aspect put a custom attribute on a member of an enum?
 
-The motivating pattern of issue [#866](https://github.com/metalama/Metalama/issues/866) is a view model that
-mirrors an enum of the domain. Such an aspect reads `source.Facets.Enum!.Members` and calls `AddMember` for each,
-and the value of each member is an `IField.ConstantValue`, which is a `TypedConstant`. That works through
-`IEnumMemberBuilder.Value` and not through the `long?` parameter of `AddMember`.
+It cannot. `AddMember` returns nothing, so there is no object on which to call `AddAttribute`, and this is the one
+capability that removing `IEnumMemberBuilder` costs. It is not hypothetical: `[Display]`, `[Description]` and
+`[EnumMember]` on a member of an enum are ordinary in the patterns that issue
+[#866](https://github.com/metalama/Metalama/issues/866) exists for, such as a view model that mirrors an enum of
+the domain.
 
-Whether `AddMember` should take a `TypedConstant?` instead of a `long?`, or an overload of each, is not decided.
-The `long?` reads better for a literal, which is the common case in an aspect that writes the members itself, and
-the `TypedConstant` reads better for a copy. What would settle it is the balance of the two in the aspects that are
-written once the feature ships, which is not known now. The design above takes `long?` and leaves the copy to the
-property, because a property that is needed for `ulong` in any case costs nothing more.
+What would settle it is whether an aspect written against this interface needs one. If it does, the remedy is an
+overload of `AddMember` that takes the attribute constructions, in the manner of
+`IAdviceFactory.IntroduceParameter`, which takes an `ImmutableArray<AttributeConstruction>`. It is not a builder:
+a member of an enum still has nothing to configure after it is added, and reintroducing one for attributes alone
+would reverse section 6.1 for a reason it did not weigh.
 
-### 7.2. Is a member of an enum reachable as an `IFieldBuilder` during construction?
-
-Section 6.1 decides what `AddMember` returns. It does not decide whether the engine object behind an
-`IEnumMemberBuilder` is a `FieldBuilder`, which is an implementation question, nor whether an aspect that holds an
-`IEnumMemberBuilder` can obtain the eventual `IField` from it before the enum is introduced.
-
-The second half matters to an aspect that introduces an enum and then refers to one of its members in a template.
-The member exists as an `IField` once the advice completes, reachable through the introduced type, so the question
-is only whether the shorter path is needed. What would settle it is one sample aspect that does this, written
-against the interface above.
+The attributes of the enum itself are unaffected and are added through `IDeclarationBuilder.AddAttribute` on the
+builder.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/introducing-enums.md
+++ b/Metalama.Framework/docs/future/introducing-enums.md
@@ -286,7 +286,7 @@ that interface. That is `BaseType`, `AddTypeParameter`, `IsClosed`, and the whol
 `Facets`. A caller that reaches the engine object as an `INamedType` and reads `Facets` on it meets the
 `NotSupportedException` of section 5.1 of [`introducing-types.md`](introducing-types.md).
 
-The member introduction advices are refused by the rule of section 3 of
+The member introduction advices are refused by the rule of section 3.1 of
 [`introducing-types.md`](introducing-types.md), because they reach the introduced enum through the adviser and not
 through this interface.
 
@@ -311,9 +311,17 @@ introduction pipeline never re-reads the final model from Roslyn.
 `INamedType.IsEnum` reports `true`, and `INamedType.UnderlyingType` reports the same type as
 `IEnumFacet.UnderlyingType`, which is what it reports for an enum read from source.
 
-The synthetic field whose metadata name is `value__` is not materialized as a builder. `IEnumFacet.Members`
-excludes it by contract, and no consumer of the code model reaches it, so materializing it would add a field to
-`INamedType.Fields` that a source enum does not show there either.
+An enum is the one kind of this set whose members are emitted. The declaration that Metalama generates is
+`enum State { Idle, Running, Stopped = 10 }`, so the members are inside it, and they are registered in the code
+model from the same builders. That is not the case for a record, a union, a delegate or a struct, whose
+synthesized members the compiler creates from the declaration and which section 5.2 of
+[`introducing-types.md`](introducing-types.md) therefore keeps out of the generated code. The members of an enum
+are written by the aspect author rather than synthesized by the compiler, which is why they differ.
+
+The synthetic field whose metadata name is `value__` is the exception, and it is neither emitted nor materialized.
+It is the field that the compiler synthesizes, `IEnumFacet.Members` excludes it by contract, and no consumer of the
+code model reaches it, so materializing it would add a field to `INamedType.Fields` that a source enum does not
+show there either.
 
 The facet is tested by unit tests and not by aspect tests, for the reason that section 5.3 of
 [`introducing-types.md`](introducing-types.md) gives: an aspect test compares generated code and cannot observe the

--- a/Metalama.Framework/docs/future/introducing-enums.md
+++ b/Metalama.Framework/docs/future/introducing-enums.md
@@ -282,7 +282,9 @@ The operations of `IDeclarationBuilder`, which are `AddAttribute`, `AddAttribute
 `Freeze`, are all valid. An enum carries attributes, and `IsFlags` is a shortcut for one of them.
 
 Every operation of `INamedTypeBuilder` is absent rather than failing, because `IEnumBuilder` does not derive from
-that interface. That is `BaseType`, `AddTypeParameter`, `IsClosed`, and the whole of `INamedType`.
+that interface. That is `BaseType`, `AddTypeParameter`, `IsClosed`, and the whole of `INamedType`, which includes
+`Facets`. A caller that reaches the engine object as an `INamedType` and reads `Facets` on it meets the
+`NotSupportedException` of section 5.1 of [`introducing-types.md`](introducing-types.md).
 
 The member introduction advices are refused by the rule of section 3 of
 [`introducing-types.md`](introducing-types.md), because they reach the introduced enum through the adviser and not
@@ -290,9 +292,13 @@ through this interface.
 
 ## 5. What the facet of the introduced enum reports
 
-The introduced type reports an `IEnumFacet` rather than the empty collection, which replaces implementation
-guideline 5 of [`type-facets.md`](type-facets.md) for this kind. Each member of the facet is built from the builder
-data.
+An enum builder declares no `Facets` member, because `IEnumBuilder` does not derive from `INamedType`. The engine
+class behind it does, and it throws a `NotSupportedException`, which section 5.1 of
+[`introducing-types.md`](introducing-types.md) states for every builder. The kind of a builder is read from
+`IsEnum`, which answers without allocating and does not throw.
+
+The introduced type reports an `IEnumFacet`. Each member of the facet is built from the builder data, because the
+introduction pipeline never re-reads the final model from Roslyn.
 
 | `IEnumFacet` member | Source |
 | --- | --- |
@@ -308,6 +314,13 @@ data.
 The synthetic field whose metadata name is `value__` is not materialized as a builder. `IEnumFacet.Members`
 excludes it by contract, and no consumer of the code model reaches it, so materializing it would add a field to
 `INamedType.Fields` that a source enum does not show there either.
+
+The facet is tested by unit tests and not by aspect tests, for the reason that section 5.3 of
+[`introducing-types.md`](introducing-types.md) gives: an aspect test compares generated code and cannot observe the
+code model that the pipeline built. The tests belong beside `EnumFacetTests.cs`, which issue
+[#1996](https://github.com/metalama/Metalama/issues/1996) added for an enum read from source. The assertion that
+matters most is that an introduced enum and the equivalent enum read from source report the same underlying type,
+the same members in the same order, the same values, and the same `IsFlags`.
 
 ## 6. Decisions
 
@@ -386,7 +399,8 @@ against the interface above.
 ## 8. References
 
 - [`introducing-types.md`](introducing-types.md), sections 2, 3 and 5.
-- [`type-facets.md`](type-facets.md), section 2.2 and implementation guideline 5.
+- [`type-facets.md`](type-facets.md), section 2.2. Its implementation guideline 5, which makes a builder return
+  the empty facet collection, is superseded by section 5.1 of [`introducing-types.md`](introducing-types.md).
 - `Metalama.Framework/Code/Types/IEnumFacet.cs`, the interface this design mirrors.
 - `Metalama.Framework/Code/DeclarationBuilders/IDeclarationBuilder.cs`, whose comment at line 35 records that there
   is no way to provide the value of an enum when the enum type exists at run time only. That comment concerns an

--- a/Metalama.Framework/docs/future/introducing-enums.md
+++ b/Metalama.Framework/docs/future/introducing-enums.md
@@ -1,0 +1,410 @@
+# Introducing an enum
+
+This document designs the introduction of an enum, which is issue
+[#866](https://github.com/metalama/Metalama/issues/866). It is a design proposal. Nothing described here is
+implemented.
+
+The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md), which this document does not
+repeat. The one that shapes the interface below is section 2 of that document: an enum builder derives from
+`IMemberOrNamedTypeBuilder` and not from `INamedTypeBuilder`, because an enum declares no member that an aspect can
+introduce.
+
+The read side of an enum is `IEnumFacet`, which is delivered. The design below mirrors it member for member, and
+section 5 states the mapping.
+
+## 1. What the aspect author writes
+
+```csharp
+public class GenerateStateEnumAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.IntroduceEnum(
+            "State",
+            buildEnum: e =>
+            {
+                e.Accessibility = Accessibility.Public;
+                e.AddMember( "Idle" );
+                e.AddMember( "Running" );
+                e.AddMember( "Stopped", 10 );
+            } );
+    }
+}
+```
+
+A flags enum sets one more property, and states every value, because the language computes no power of two on the
+author's behalf and neither does Metalama:
+
+```csharp
+builder.IntroduceEnum(
+    "Permissions",
+    buildEnum: e =>
+    {
+        e.Accessibility = Accessibility.Public;
+        e.UnderlyingType = TypeFactory.GetType( SpecialType.Byte );
+        e.IsFlags = true;
+        e.AddMember( "None", 0 );
+        e.AddMember( "Read", 1 );
+        e.AddMember( "Write", 2 );
+        e.AddMember( "Execute", 4 );
+    } );
+```
+
+## 2. What Metalama produces
+
+```csharp
+public enum State
+{
+    Idle,
+    Running,
+    Stopped = 10
+}
+```
+
+```csharp
+[Flags]
+public enum Permissions : byte
+{
+    None = 0,
+    Read = 1,
+    Write = 2,
+    Execute = 4
+}
+```
+
+## 3. The interfaces
+
+### 3.1. `IEnumBuilder`
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IEnumBuilder.cs
+namespace Metalama.Framework.Code.DeclarationBuilders;
+
+/// <summary>
+/// Allows to complete the construction of an enum that has been created by an advice.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface derives from <see cref="IMemberOrNamedTypeBuilder"/> and not from
+/// <see cref="INamedTypeBuilder"/>, because an enum declares no member that an aspect can introduce and has
+/// neither a base type nor type parameters. The operations that an enum does not have are therefore absent rather
+/// than present and failing. The operations that it inherits and does not have are listed below.
+/// </para>
+/// <para>
+/// The following inherited properties are not valid for an enum, and their setter throws a
+/// <see cref="NotSupportedException"/>: <see cref="IMemberOrNamedTypeBuilder.IsStatic"/>,
+/// <see cref="IMemberOrNamedTypeBuilder.IsSealed"/>, <see cref="IMemberOrNamedTypeBuilder.IsAbstract"/> and
+/// <see cref="IMemberOrNamedTypeBuilder.IsPartial"/>. An enum is implicitly sealed, it may not be abstract or
+/// static, and the language has no partial enum.
+/// </para>
+/// <para>
+/// An enum builder is not an <see cref="INamedType"/>, so it may not be used where an <see cref="IType"/> is
+/// expected. The introduced enum is read from
+/// <see cref="Metalama.Framework.Advising.IIntroductionAdviceResult{T}.Declaration"/>.
+/// </para>
+/// </remarks>
+/// <seealso cref="IEnumMemberBuilder"/>
+/// <seealso cref="Metalama.Framework.Code.Types.IEnumFacet"/>
+/// <seealso href="@introducing-types"/>
+[InternalImplement]
+public interface IEnumBuilder : IMemberOrNamedTypeBuilder
+{
+    /// <summary>
+    /// Gets or sets the underlying integral type of the enum. The default value is <c>int</c>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The language allows one of <c>byte</c>, <c>sbyte</c>, <c>short</c>, <c>ushort</c>, <c>int</c>,
+    /// <c>uint</c>, <c>long</c> and <c>ulong</c>. The setter throws an <see cref="ArgumentOutOfRangeException"/>
+    /// for any other type.
+    /// </para>
+    /// <para>
+    /// Setting this property after a member has been added throws an <see cref="InvalidOperationException"/>,
+    /// because the value of a member is validated against the underlying type when the member is added.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="Metalama.Framework.Code.Types.IEnumFacet.UnderlyingType"/>
+    INamedType UnderlyingType { get; set; }
+
+    /// <summary>
+    /// Gets or sets a value indicating whether the enum is annotated with <see cref="System.FlagsAttribute"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Setting this property to <c>true</c> adds the attribute, and setting it to <c>false</c> removes it. Adding
+    /// the attribute through <see cref="IDeclarationBuilder.AddAttribute"/> has the same effect, and this property
+    /// then reports <c>true</c>.
+    /// </para>
+    /// <para>
+    /// The attribute changes how the value of the enum is formatted and parsed at run time, and it does not change
+    /// the value of any member. An author who sets this property assigns the value of every member explicitly,
+    /// because neither the language nor Metalama derives a power of two from the position of a member.
+    /// </para>
+    /// </remarks>
+    /// <seealso cref="Metalama.Framework.Code.Types.IEnumFacet.IsFlags"/>
+    bool IsFlags { get; set; }
+
+    /// <summary>
+    /// Gets the members that have been added so far, in the order in which they were added.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IEnumFacet.Members"/>
+    IReadOnlyList<IEnumMemberBuilder> Members { get; }
+
+    /// <summary>
+    /// Adds a member to the enum.
+    /// </summary>
+    /// <param name="name">The name of the member.</param>
+    /// <param name="value">The value of the member, or <c>null</c> to let the language assign it, which gives zero
+    ///     to the first member and the value of the preceding member plus one to any other. A value that does not
+    ///     fit in <see cref="UnderlyingType"/> throws an <see cref="ArgumentOutOfRangeException"/>. A value outside
+    ///     the range of <see cref="long"/>, which only an enum whose underlying type is <c>ulong</c> can have, is
+    ///     assigned through <see cref="IEnumMemberBuilder.Value"/> instead.</param>
+    /// <returns>An <see cref="IEnumMemberBuilder"/> that allows you to further build the new member, in particular
+    ///     to add custom attributes to it.</returns>
+    IEnumMemberBuilder AddMember( string name, long? value = null );
+}
+```
+
+### 3.2. `IEnumMemberBuilder`
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IEnumMemberBuilder.cs
+namespace Metalama.Framework.Code.DeclarationBuilders;
+
+/// <summary>
+/// Allows to complete the construction of a member of an enum that has been created by
+/// <see cref="IEnumBuilder.AddMember"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// A member of an enum is a constant field, and the code model reports it as an <see cref="IField"/> once the enum
+/// is introduced. This interface is nevertheless not an <see cref="IFieldBuilder"/>: a member of an enum has no
+/// type of its own, no accessibility of its own, no initializer and no modifier, so almost every operation of a
+/// field builder would be invalid on it. Section 6 of the design document states the decision.
+/// </para>
+/// </remarks>
+/// <seealso cref="IEnumBuilder.AddMember"/>
+/// <seealso cref="IField"/>
+/// <seealso href="@introducing-types"/>
+[InternalImplement]
+public interface IEnumMemberBuilder : IDeclarationBuilder
+{
+    /// <summary>
+    /// Gets or sets the name of the member.
+    /// </summary>
+    string Name { get; set; }
+
+    /// <summary>
+    /// Gets or sets the value of the member, or <c>null</c> when the language assigns it, which gives zero to the
+    /// first member and the value of the preceding member plus one to any other.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The value is converted to <see cref="IEnumBuilder.UnderlyingType"/>. A value that does not fit in that type,
+    /// or whose type is not an integral type, throws an <see cref="ArgumentOutOfRangeException"/>.
+    /// </para>
+    /// <para>
+    /// This property is the way to assign a value outside the range of <see cref="long"/>, which
+    /// <see cref="IEnumBuilder.AddMember"/> cannot express and which an enum whose underlying type is <c>ulong</c>
+    /// can have.
+    /// </para>
+    /// </remarks>
+    TypedConstant? Value { get; set; }
+}
+```
+
+### 3.3. The advice method
+
+```csharp
+// Metalama.Framework/Advising/IAdviceFactory.cs
+/// <summary>
+/// Introduces a new enum to the target namespace or type.
+/// </summary>
+/// <param name="targetNamespaceOrType">The namespace or type into which the enum must be introduced.</param>
+/// <param name="name">The name of the introduced enum.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildEnum">An optional callback that allows you to configure the introduced enum, in particular to
+///     add its members.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
+/// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced enum. Unlike
+/// the result of introducing a class, this result must not be used to introduce members, because an enum accepts
+/// none.</returns>
+IIntroductionAdviceResult<INamedType> IntroduceEnum(
+    INamespaceOrNamedType targetNamespaceOrType,
+    string name,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<IEnumBuilder>? buildEnum = null );
+```
+
+```csharp
+// Metalama.Framework/Aspects/AdviserExtensions.cs
+/// <summary>
+/// Introduces a new enum into the current namespace (as a top-level type) or type (as a nested type).
+/// Use the <see cref="IAdviser.With{TNewDeclaration}"/> or <see cref="WithNamespace"/> method to introduce the enum
+/// to a different type or namespace than the current one.
+/// </summary>
+/// <param name="adviser">An adviser for a named type or namespace.</param>
+/// <param name="name">The enum name.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target type or namespace. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildEnum">An optional delegate that modifies the <see cref="IEnumBuilder"/> that represents the
+///     introduced enum. The members of the enum are added through this delegate.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> that exposes the outcome of the operation and the
+/// introduced <see cref="INamedType"/>.</returns>
+/// <seealso href="@introducing-types"/>
+public static IIntroductionAdviceResult<INamedType> IntroduceEnum(
+    this IAdviser<INamespaceOrNamedType> adviser,
+    string name,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<IEnumBuilder>? buildEnum = null )
+    => ((IAdviserInternal) adviser).AdviceFactory.IntroduceEnum(
+        adviser.Target,
+        name,
+        whenExists,
+        buildEnum );
+```
+
+## 4. The inherited operations that are not valid
+
+`IEnumBuilder` inherits six settable properties from `IMemberOrNamedTypeBuilder`. Two are valid and four are not.
+
+| Member | State |
+| --- | --- |
+| `Accessibility` | Valid. |
+| `Name` | Valid. |
+| `IsStatic` | The setter throws a `NotSupportedException`. An enum is neither static nor an instance type. |
+| `IsSealed` | The setter throws a `NotSupportedException`. An enum is implicitly sealed. |
+| `IsAbstract` | The setter throws a `NotSupportedException`. An enum may not be abstract. |
+| `IsPartial` | The setter throws a `NotSupportedException`. The language has no partial enum. |
+
+The operations of `IDeclarationBuilder`, which are `AddAttribute`, `AddAttributes`, `RemoveAttributes` and
+`Freeze`, are all valid. An enum carries attributes, and `IsFlags` is a shortcut for one of them.
+
+Every operation of `INamedTypeBuilder` is absent rather than failing, because `IEnumBuilder` does not derive from
+that interface. That is `BaseType`, `AddTypeParameter`, `IsClosed`, and the whole of `INamedType`.
+
+The member introduction advices are refused by the rule of section 3 of
+[`introducing-types.md`](introducing-types.md), because they reach the introduced enum through the adviser and not
+through this interface.
+
+## 5. What the facet of the introduced enum reports
+
+The introduced type reports an `IEnumFacet` rather than the empty collection, which replaces implementation
+guideline 5 of [`type-facets.md`](type-facets.md) for this kind. Each member of the facet is built from the builder
+data.
+
+| `IEnumFacet` member | Source |
+| --- | --- |
+| `UnderlyingType` | `IEnumBuilder.UnderlyingType`, or `int` when the aspect set none. |
+| `Members` | One `IField` per `IEnumMemberBuilder`, in the order in which they were added. The value of each field is the value that the builder assigned, or the value the language computes when the builder assigned none. |
+| `IsFlags` | Whether the attribute is present, which is what `IsFlags` on the builder sets. |
+| `FacetKind` | `TypeFacetKind.Enum`. |
+| `Type` | The introduced type. |
+
+`INamedType.IsEnum` reports `true`, and `INamedType.UnderlyingType` reports the same type as
+`IEnumFacet.UnderlyingType`, which is what it reports for an enum read from source.
+
+The synthetic field whose metadata name is `value__` is not materialized as a builder. `IEnumFacet.Members`
+excludes it by contract, and no consumer of the code model reaches it, so materializing it would add a field to
+`INamedType.Fields` that a source enum does not show there either.
+
+## 6. Decisions
+
+### 6.1. A member of an enum is built by `IEnumMemberBuilder` and not by `IFieldBuilder`
+
+The read side reports a member of an enum as an `IField`, and `IEnumFacet` states that no interface of its own is
+declared for it. The write side does not follow, and the asymmetry is deliberate.
+
+`IFieldBuilder` derives from `IFieldOrPropertyBuilder`, from `IFieldOrPropertyOrIndexerBuilder`, from
+`IMemberBuilder` and from `IHasTypeBuilder`. A member of an enum has none of what those interfaces offer: its type
+is the enum and may not be set, its accessibility is that of the enum and may not be set, it has no initializer
+expression, it has no writeability to choose, and every modifier that `IMemberBuilder` adds is invalid on it. A
+field builder would present roughly fifteen operations of which one, the addition of an attribute, is valid.
+
+The reason the asymmetry is acceptable is that the two sides answer different questions. A reader asks what a
+member of an enum is, and it is a constant field, so `IField` is the right answer and a narrower interface would
+only remove members that the reader may legitimately ask for. A writer asks what may be chosen about a member, and
+the answer is its name, its value and its attributes, which is three things.
+
+The alternative, which is to declare `IFieldBuilder` as the return type and to throw on the invalid operations, is
+the shape that section 2 of [`introducing-types.md`](introducing-types.md) rejects at the level of the type. It is
+rejected here for the same reason and at a worse ratio.
+
+### 6.2. `IsFlags` is a property and not only an attribute
+
+`IsFlags` sets an attribute, and an author can add that attribute directly. The property is declared nevertheless,
+for symmetry with `IEnumFacet.IsFlags`, which exists so that no consumer has to search the attributes of a type for
+a well-known name. A writer that had to construct an `AttributeConstruction` for `System.FlagsAttribute` would be
+doing by hand what the reader is explicitly spared.
+
+The property and the attribute are one state and not two: the setter adds or removes the attribute, and the getter
+reports whether it is present. There is no third state in which they disagree.
+
+### 6.3. The underlying type is set on the builder and not passed to the advice method
+
+`IntroduceEnum` takes the name, the conflict strategy and the callback, and nothing else, which is the shape of
+`IntroduceClass` and `IntroduceInterface`. The underlying type is configuration of the type, and configuration of
+the type is what the callback is for. Adding a parameter for it would make `IntroduceEnum` the only introduction
+method whose signature carries a property of the type being built.
+
+### 6.4. The value of a member is validated when it is assigned
+
+`AddMember` and `IEnumMemberBuilder.Value` both validate the value against `UnderlyingType`, and
+`UnderlyingType` may not be set after a member has been added. The alternative is to validate every value when the
+builder is frozen, which reports the error at a place the author did not write.
+
+The cost is that an author who wants a non-default underlying type sets it before adding any member. The
+documentation of `UnderlyingType` states that, and the exception names it.
+
+## 7. Open questions
+
+### 7.1. How does an aspect introduce an enum whose members are copied from another enum?
+
+The motivating pattern of issue [#866](https://github.com/metalama/Metalama/issues/866) is a view model that
+mirrors an enum of the domain. Such an aspect reads `source.Facets.Enum!.Members` and calls `AddMember` for each,
+and the value of each member is an `IField.ConstantValue`, which is a `TypedConstant`. That works through
+`IEnumMemberBuilder.Value` and not through the `long?` parameter of `AddMember`.
+
+Whether `AddMember` should take a `TypedConstant?` instead of a `long?`, or an overload of each, is not decided.
+The `long?` reads better for a literal, which is the common case in an aspect that writes the members itself, and
+the `TypedConstant` reads better for a copy. What would settle it is the balance of the two in the aspects that are
+written once the feature ships, which is not known now. The design above takes `long?` and leaves the copy to the
+property, because a property that is needed for `ulong` in any case costs nothing more.
+
+### 7.2. Is a member of an enum reachable as an `IFieldBuilder` during construction?
+
+Section 6.1 decides what `AddMember` returns. It does not decide whether the engine object behind an
+`IEnumMemberBuilder` is a `FieldBuilder`, which is an implementation question, nor whether an aspect that holds an
+`IEnumMemberBuilder` can obtain the eventual `IField` from it before the enum is introduced.
+
+The second half matters to an aspect that introduces an enum and then refers to one of its members in a template.
+The member exists as an `IField` once the advice completes, reachable through the introduced type, so the question
+is only whether the shorter path is needed. What would settle it is one sample aspect that does this, written
+against the interface above.
+
+## 8. References
+
+- [`introducing-types.md`](introducing-types.md), sections 2, 3 and 5.
+- [`type-facets.md`](type-facets.md), section 2.2 and implementation guideline 5.
+- `Metalama.Framework/Code/Types/IEnumFacet.cs`, the interface this design mirrors.
+- `Metalama.Framework/Code/DeclarationBuilders/IDeclarationBuilder.cs`, whose comment at line 35 records that there
+  is no way to provide the value of an enum when the enum type exists at run time only. That comment concerns an
+  attribute argument rather than a member of an enum, and this design does not close it.
+
+Issues:
+
+- [#866](https://github.com/metalama/Metalama/issues/866), which this document designs.
+- [#1996](https://github.com/metalama/Metalama/issues/1996), code model: the enum facet, closed in
+  2027.0.2-preview. It delivered `IEnumFacet`, which section 5 mirrors, and its unit tests are the baseline against
+  which an introduced enum is compared.
+- [#869](https://github.com/metalama/Metalama/issues/869), type introduction: introduce struct, open. It carries
+  the emission machinery that this issue consumes and it blocks this one.
+- [#863](https://github.com/metalama/Metalama/issues/863), type introduction: reflection wrappers and syntax
+  serialization, open. An enum is the kind most often serialized into a template, so this issue may gain work from
+  this one.
+- [#1950](https://github.com/metalama/Metalama/issues/1950), C# 15 closed classes: introducing, closed. The shape
+  of that pull request is the shape this one should have.
+- Section 8.4 of [`introducing-types.md`](introducing-types.md) lists the rest of the type introduction backlog.
+
+— Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/introducing-records.md
+++ b/Metalama.Framework/docs/future/introducing-records.md
@@ -1,0 +1,411 @@
+# Introducing a record
+
+This document designs the introduction of a record class and of a record struct, which is issue
+[#867](https://github.com/metalama/Metalama/issues/867). It is a design proposal. Nothing described here is
+implemented.
+
+The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md), which this document does not
+repeat. A record declares members that an aspect can introduce, so `IRecordBuilder` derives from
+`INamedTypeBuilder` and section 2 of that document does not revise it.
+
+A record struct is designed here and not in [`introducing-structs.md`](introducing-structs.md), and it shares one
+application programming interface with a record class. Section 6.1 records that decision.
+
+This is the largest of the five designs, for the reason that section 5 of
+[`introducing-types.md`](introducing-types.md) gives: the introduction pipeline never re-reads the final model from
+Roslyn, so the six members that `IRecordFacet` names have to exist as builders. Section 5 below states which.
+
+## 1. What the aspect author writes
+
+```csharp
+public class GenerateSnapshotAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.IntroduceRecord(
+            "Snapshot",
+            buildRecord: r =>
+            {
+                r.Accessibility = Accessibility.Public;
+
+                foreach ( var property in builder.Target.Properties )
+                {
+                    r.AddPositionalParameter( property.Name, property.Type );
+                }
+            } );
+    }
+}
+```
+
+A record struct differs by one argument, and by nothing else:
+
+```csharp
+builder.IntroduceRecord(
+    "Point",
+    RecordKind.Struct,
+    buildRecord: r =>
+    {
+        r.Accessibility = Accessibility.Public;
+        r.IsReadOnly = true;
+        r.AddPositionalParameter( "X", typeof(double) );
+        r.AddPositionalParameter( "Y", typeof(double) );
+    } );
+```
+
+## 2. What Metalama produces
+
+```csharp
+public record Snapshot( string Name, int Count );
+```
+
+```csharp
+public readonly record struct Point( double X, double Y );
+```
+
+## 3. The interfaces
+
+### 3.1. `RecordKind`
+
+```csharp
+// Metalama.Framework/Code/RecordKind.cs
+namespace Metalama.Framework.Code;
+
+/// <summary>
+/// Authoring forms of a record, given to
+/// <see cref="Metalama.Framework.Advising.IAdviceFactory.IntroduceRecord"/>.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This enumeration names what an author chooses when introducing a record. It is not reported by the code model:
+/// a record read from source is a class or a struct according to <see cref="IType.TypeKind"/>, and
+/// <see cref="INamedType.IsRecord"/> states that it is a record. The obsolete members
+/// <c>TypeKind.RecordClass</c> and <c>TypeKind.RecordStruct</c> are not revived by this enumeration.
+/// </para>
+/// </remarks>
+[CompileTime]
+public enum RecordKind
+{
+    /// <summary>
+    /// The record is a reference type, declared as <c>record</c> or <c>record class</c>. This is the default
+    /// value.
+    /// </summary>
+    Class = 0,
+
+    /// <summary>
+    /// The record is a value type, declared as <c>record struct</c>.
+    /// </summary>
+    Struct
+}
+```
+
+### 3.2. `IRecordBuilder`
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IRecordBuilder.cs
+namespace Metalama.Framework.Code.DeclarationBuilders;
+
+/// <summary>
+/// Allows to complete the construction of a record that has been created by an advice. One interface serves a
+/// record class and a record struct.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The authoring form is chosen when the advice is called and is reported by <see cref="RecordKind"/>. The members
+/// of this interface that a record struct does not accept are documented individually.
+/// </para>
+/// <para>
+/// The members that the compiler synthesizes for a record are not set through this interface. They are created by
+/// the advice and are read through
+/// <see cref="Metalama.Framework.Code.INamedType.Facets"/> on the introduced type, as they are for a record that
+/// the user wrote.
+/// </para>
+/// </remarks>
+/// <seealso cref="Metalama.Framework.Code.Types.IRecordFacet"/>
+/// <seealso href="@introducing-types"/>
+[InternalImplement]
+public interface IRecordBuilder : INamedTypeBuilder
+{
+    /// <summary>
+    /// Gets the authoring form of the record, which was chosen when the advice was called.
+    /// </summary>
+    RecordKind RecordKind { get; }
+
+    /// <summary>
+    /// Gets the positional parameters that have been added so far, in the order in which they were added.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IRecordFacet.PositionalProperties"/>
+    IParameterBuilderList PositionalParameters { get; }
+
+    /// <summary>
+    /// Appends a positional parameter to the record, which declares a parameter of the primary constructor and a
+    /// public init-only property of the same name and type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// A record that has at least one positional parameter is a positional record, and the compiler synthesizes a
+    /// <c>Deconstruct</c> method for it. A record that has none declares no parameter list, and
+    /// <see cref="Metalama.Framework.Code.Types.IRecordFacet.DeconstructMethod"/> is then <c>null</c> on the
+    /// introduced type.
+    /// </para>
+    /// <para>
+    /// A positional parameter whose name is that of a member already declared by the record, or by one of its base
+    /// records, declares no property, which is the rule of the language. The advice reports an error instead of
+    /// generating a declaration that the compiler would reject.
+    /// </para>
+    /// </remarks>
+    /// <param name="name">The name of the parameter, which is also the name of the property it declares.</param>
+    /// <param name="type">The type of the parameter.</param>
+    /// <param name="defaultValue">The default value of the parameter, or <c>null</c> when it has none.</param>
+    /// <returns>An <see cref="IParameterBuilder"/> that allows you to further build the new parameter, in
+    ///     particular to add custom attributes to it.</returns>
+    IParameterBuilder AddPositionalParameter( string name, IType type, TypedConstant? defaultValue = default );
+
+    /// <summary>
+    /// Appends a positional parameter to the record.
+    /// </summary>
+    /// <param name="name">The name of the parameter, which is also the name of the property it declares.</param>
+    /// <param name="type">The type of the parameter.</param>
+    /// <param name="defaultValue">The default value of the parameter, or <c>null</c> when it has none.</param>
+    /// <returns>An <see cref="IParameterBuilder"/> that allows you to further build the new parameter.</returns>
+    IParameterBuilder AddPositionalParameter( string name, Type type, TypedConstant? defaultValue = null );
+}
+```
+
+### 3.3. The advice method
+
+```csharp
+// Metalama.Framework/Advising/IAdviceFactory.cs
+/// <summary>
+/// Introduces a new record to the target namespace or type.
+/// </summary>
+/// <param name="targetNamespaceOrType">The namespace or type into which the record must be introduced.</param>
+/// <param name="name">The name of the introduced record.</param>
+/// <param name="recordKind">Whether the record is a record class or a record struct. The default is a record
+///     class.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildRecord">An optional callback that allows you to configure the introduced record, such as
+///     adding positional parameters, members, base types, or custom attributes.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
+/// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced record.
+/// The <see cref="IIntroductionAdviceResult{T}"/> interface itself implements <see cref="IAdviser{T}"/> and can be
+/// used to introduce members to the record.</returns>
+IIntroductionAdviceResult<INamedType> IntroduceRecord(
+    INamespaceOrNamedType targetNamespaceOrType,
+    string name,
+    RecordKind recordKind = RecordKind.Class,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<IRecordBuilder>? buildRecord = null );
+```
+
+```csharp
+// Metalama.Framework/Aspects/AdviserExtensions.cs
+/// <summary>
+/// Introduces a new record into the current namespace (as a top-level type) or type (as a nested type).
+/// Use the <see cref="IAdviser.With{TNewDeclaration}"/> or <see cref="WithNamespace"/> method to introduce the
+/// record to a different type or namespace than the current one.
+/// </summary>
+/// <param name="adviser">An adviser for a named type or namespace.</param>
+/// <param name="name">The record name.</param>
+/// <param name="recordKind">Whether the record is a record class or a record struct. The default is a record
+///     class.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target type or namespace. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildRecord">An optional delegate that modifies the <see cref="IRecordBuilder"/> that represents
+///     the introduced record.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> that exposes the outcome of the operation and the
+/// introduced <see cref="INamedType"/>.</returns>
+/// <seealso href="@introducing-types"/>
+public static IIntroductionAdviceResult<INamedType> IntroduceRecord(
+    this IAdviser<INamespaceOrNamedType> adviser,
+    string name,
+    RecordKind recordKind = RecordKind.Class,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<IRecordBuilder>? buildRecord = null )
+    => ((IAdviserInternal) adviser).AdviceFactory.IntroduceRecord(
+        adviser.Target,
+        name,
+        recordKind,
+        whenExists,
+        buildRecord );
+```
+
+## 4. The inherited operations that are not valid
+
+`IRecordBuilder` derives from `INamedTypeBuilder`, so it inherits the whole type-building surface. Most of it is
+valid, and what is not depends on the authoring form.
+
+| Member | Record class | Record struct |
+| --- | --- | --- |
+| `Accessibility`, `Name`, `IsPartial` | Valid. | Valid. |
+| `AddTypeParameter` | Valid. | Valid. |
+| `BaseType` | Valid, and the base must itself be a record class. The setter throws an `InvalidOperationException` for a base that is not a record, which is the rule of the language. | The setter throws a `NotSupportedException`. A record struct derives from `System.ValueType` and the language allows no other base. |
+| `IsAbstract` | Valid. | The setter throws a `NotSupportedException`. |
+| `IsSealed` | Valid. | The setter throws a `NotSupportedException`. A record struct is implicitly sealed. |
+| `IsStatic` | The setter throws a `NotSupportedException`. A record is never static. | Same. |
+| `IsReadOnly` | The setter throws an `InvalidOperationException`, as it does for any class. | Valid, and produces a `readonly record struct`. |
+| `IsRef` | The setter throws an `InvalidOperationException`, as it does for any class. | The setter throws a `NotSupportedException`. The language has no `ref record struct`. |
+| `IsClosed` | See section 7.1, which records this as open. | The setter throws an `InvalidOperationException`, as it does for any type that is not a class. |
+
+`IsReadOnly` and `IsRef` are the two properties that [`introducing-structs.md`](introducing-structs.md) adds to
+`INamedTypeBuilder`, so this issue depends on that one for them as well as for the emission machinery.
+
+Member introduction is valid on a record, unlike on an enum and on a delegate. The rule of section 3 of
+[`introducing-types.md`](introducing-types.md) does not apply here, and an aspect may add methods, properties and
+constructors to an introduced record through the adviser in the ordinary way.
+
+## 5. The synthesized members, and what the facet reports
+
+The introduced type reports an `IRecordFacet` rather than the empty collection, which replaces implementation
+guideline 5 of [`type-facets.md`](type-facets.md) for this kind. Every member the facet names has to be
+materialized as a builder, because the facet of an introduced type is built from the builder data. This is the
+substance of the issue, and it is the reason the issue is sized larger than the other three.
+
+| `IRecordFacet` member | Record class | Record struct |
+| --- | --- | --- |
+| `EqualityContractProperty` | A protected virtual property named `EqualityContract`, materialized. | `null`. A record struct has none. |
+| `PrintMembersMethod` | A method named `PrintMembers`, materialized. | Materialized. Its accessibility differs: private on a record struct, protected on a record class that is sealed, protected virtual otherwise. |
+| `CloneMethod` | A method whose metadata name is `<Clone>$`, materialized. | `null`. A record struct has none. |
+| `CopyConstructor` | A constructor taking the record type, materialized. | `null`. A record struct has none. |
+| `DeconstructMethod` | Materialized when the record has at least one positional parameter, and `null` otherwise. | Same. |
+| `PositionalProperties` | One public init-only property per positional parameter, in order. | Same. |
+| `FacetKind` | `TypeFacetKind.Record`. | Same. |
+| `Type` | The introduced type. | Same. |
+
+Three members that the compiler also synthesizes are not part of the facet and are materialized nevertheless,
+because `INamedType.Methods` has to report them: `Equals`, `GetHashCode` and `ToString`, together with the `==` and
+`!=` operators. `IRecordFacet` documents them as reached through the ordinary member collections.
+
+The primary constructor is materialized and is reported by `INamedType.PrimaryConstructor`, which is where
+`IRecordFacet` says it is reached, because a primary constructor is not specific to a record since C# 12. This
+answers the comment `// TODO: Primary constructor handling.` on `INamedTypeBuilder`, for the record at least; that
+comment concerns a primary constructor on any type, and the rest of it is out of scope here.
+
+The name of the clone method is not a C# identifier, so it is absent from `INamedType.Methods` and is reached
+through `IRecordFacet.CloneMethod` alone. The builder that materializes it is registered so that the facet can name
+it and so that the linker can emit it, and not so that a member collection can list it.
+
+The engine already carries the record flag from the builder to the introduced type: `NamedTypeBuilder` takes an
+`isRecord` constructor parameter, `NamedTypeBuilderData` stores it and `IntroducedNamedType` reports it. What
+blocks the flag today is the assertion `Invariant.Assert( !isRecord )` beside it, and the missing arm in the
+transformation. This design therefore says what the existing flag becomes and adds no second flag.
+
+## 6. Decisions
+
+### 6.1. A record struct uses the same application programming interface as a record class
+
+One builder interface and one advice method serve both forms, and the form is an argument.
+
+The reason is symmetry with the reader, which has already taken this decision. `IRecordFacet` is one interface
+whose `EqualityContractProperty`, `CloneMethod` and `CopyConstructor` are `null` for a record struct, and section
+2.2 of [`type-facets.md`](type-facets.md) records that it is deliberately not split in two. Splitting the writer
+while the reader is unsplit would describe the same type by one structure when reading it and by two when writing
+it.
+
+The second reason is that the two forms differ in what they refuse rather than in what they offer. The table of
+section 4 has one row per inherited member, and the rows that differ are those in which a record struct refuses
+something a record class accepts. An interface per form would have the same rows, expressed as absent members
+instead of throwing ones, at the cost of a second interface, a second advice method, and a decision for every
+future member about whether it belongs to one form or to both.
+
+This differs from the decision of section 2 of [`introducing-types.md`](introducing-types.md), which splits the
+hierarchy for the enum and the delegate, and the difference is one of proportion. An enum shares almost nothing
+with a class. A record struct shares almost everything with a record class.
+
+### 6.2. The authoring form is an argument and not a property of the builder
+
+`RecordKind` is read-only on `IRecordBuilder` and is chosen when the advice is called. The alternative is a
+settable property that the callback assigns.
+
+The form decides which inherited members are valid, which the table of section 4 shows, so a settable property
+would mean that the validity of `BaseType` depends on the order in which the callback assigns two properties.
+Making it an argument means every validation in the callback has a definite answer.
+
+The engine takes the same shape already: `NamedTypeBuilder` receives its `typeKind` and its `isRecord` as
+constructor parameters and asserts them there.
+
+### 6.3. `RecordKind` is a new enumeration and not `TypeKind`
+
+`TypeKind` has `RecordClass` and `RecordStruct` members, and both are marked obsolete as errors. The code model
+represents a record as `TypeKind.Class` or `TypeKind.Struct` with `INamedType.IsRecord` set, and this design does
+not revive the obsolete members.
+
+Passing `TypeKind` itself, restricted to `Class` and `Struct`, was considered. It reuses a shipped type, and it
+admits thirteen values that the method has to reject at run time. A two-member enumeration rejects them at compile
+time, and its documentation states its relation to `TypeKind` so that a reader does not take it for a second
+representation of a record in the code model.
+
+### 6.4. The synthesized members are materialized rather than discovered
+
+The pipeline never re-reads the final model from Roslyn, so a member that an aspect must see has to exist as a
+builder. The precedent is `IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which materializes the
+implicit constructor of an introduced class for the same reason.
+
+The alternative is to let the facet of an introduced record report `null` for the synthesized members, and to
+document that an introduced record is less complete than one the user wrote. That is rejected because the facet is
+the interface through which an aspect reads a record, and a facet that answers differently according to the origin
+of the type is a defect rather than a limitation.
+
+## 7. Open questions
+
+### 7.1. May an introduced record class be closed?
+
+`INamedTypeBuilder.IsClosed` is documented as valid on a class, and as throwing on a sealed class and on a static
+class. A record class is a class, so the property appears to apply, and the language rule for a `closed record` was
+not read against the C# 15 specification while this document was written.
+
+What would settle it is the section of the C# 15 unions and closed hierarchies proposal that lists the declarations
+the `closed` modifier accepts. The row of section 4 is left open rather than guessed, because a wrong answer there
+either forbids something the language allows or emits a modifier the compiler rejects.
+
+### 7.2. How does an aspect override a synthesized member of an introduced record?
+
+Pull request metalama/Metalama#1879 makes `meta.Proceed()` work in an aspect that overrides a
+compiler-synthesized member of a record, and every gate of that mechanism is keyed on whether the type is a record.
+That work targets a record the user wrote.
+
+Whether the same mechanism serves a record that an aspect introduced is not decided here. The two differ in where
+the body of the synthesized member comes from: for a record read from source it is reproduced from the symbol, and
+for an introduced record there is no symbol. What would settle it is a test that overrides `PrintMembers` on an
+introduced record, which is worth writing early because the answer may add work to this issue.
+
+### 7.3. Does a positional parameter accept an attribute target?
+
+The language allows an attribute on a positional parameter of a record to be directed at the parameter, at the
+property or at the field, through `[property: ...]` and `[field: ...]`. `AddPositionalParameter` returns an
+`IParameterBuilder`, whose `AddAttribute` targets the parameter.
+
+Reaching the property instead is possible through the introduced type once the advice completes, so nothing is
+unreachable. Whether the shorter path is worth a member on the builder is not decided, and what would settle it is
+an aspect that needs it.
+
+## 8. References
+
+- [`introducing-types.md`](introducing-types.md), sections 2, 4 and 5.
+- [`introducing-structs.md`](introducing-structs.md), section 3.2, which adds `IsReadOnly` and `IsRef` to
+  `INamedTypeBuilder`.
+- [`type-facets.md`](type-facets.md), section 2.2 and implementation guideline 5.
+- `Metalama.Framework/Code/Types/IRecordFacet.cs`, the interface this design mirrors.
+
+Issues:
+
+- [#867](https://github.com/metalama/Metalama/issues/867), which this document designs.
+- [#1997](https://github.com/metalama/Metalama/issues/1997), code model: the record facet, closed in
+  2027.0.2-preview. It delivered `IRecordFacet`, which section 5 mirrors, and it converted the
+  synthesized-member lookups of the linker.
+- [#1343](https://github.com/metalama/Metalama/issues/1343), support `meta.Proceed()` for compiler-synthesized
+  record members, closed in 2027.0.1-preview through pull request metalama/Metalama#1879. It materializes the
+  synthesized members of a record read from source, and section 7.2 asks whether an introduced record can reuse the
+  mechanism. Every gate of that mechanism is keyed on whether the type is a record, so this is the issue to read
+  before starting.
+- [#868](https://github.com/metalama/Metalama/issues/868), type introduction: introduce primary constructor, open.
+  This issue materializes the primary constructor of a record, which is part of that one. The rest of it, which is
+  a primary constructor on a class or a struct that is not a record, stays open, and the comment
+  `// TODO: Primary constructor handling.` on `INamedTypeBuilder` belongs to it.
+- [#869](https://github.com/metalama/Metalama/issues/869), type introduction: introduce struct, open. It carries
+  the emission machinery and the two properties of its section 3.2, and it blocks this one.
+- [#1950](https://github.com/metalama/Metalama/issues/1950), C# 15 closed classes: introducing, closed. Section 7.1
+  asks whether a record class may be closed, and that issue is where `IsClosed` and its validation were written.
+- Section 8.4 of [`introducing-types.md`](introducing-types.md) lists the rest of the type introduction backlog.
+
+— Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/introducing-records.md
+++ b/Metalama.Framework/docs/future/introducing-records.md
@@ -270,8 +270,13 @@ is the reason the issue is sized larger than the other three.
 Materialized means present in the code model and not emitted as syntax. Metalama generates the record declaration,
 which is the `record` keyword, the name, the positional parameter list and the base list, and the compiler
 synthesizes the six members from it exactly as it does for a record the user wrote. A transformation that injected
-them as well would declare each of them twice. Section 5.2 of [`introducing-types.md`](introducing-types.md) states
-the rule, and the table below is therefore a description of the code model rather than of the generated code.
+them as well would declare each of them twice. Section 4.2 of [`introducing-types.md`](introducing-types.md) states
+the rule and the mechanism, and the table below is therefore a description of the code model rather than of the
+generated code.
+
+This kind registers the most: the six members that `IRecordFacet` names, the primary constructor, and `Equals`,
+`GetHashCode`, `ToString` and the equality operators, which are not part of the facet but which
+`INamedType.Methods` has to report.
 
 | `IRecordFacet` member | Record class | Record struct |
 | --- | --- | --- |
@@ -370,8 +375,9 @@ of the type is a defect rather than a limitation.
 The materialization stops at the code model. The generated code is the record declaration and nothing more, because
 the compiler synthesizes the six members from the `record` keyword. An implementation that emitted them would
 produce a duplicate declaration for each, and the failure would appear as a compiler error on generated code rather
-than as a defect in the code model, which is why the distinction is recorded as a decision rather than left to the
-implementer.
+than as a defect in the code model, which is why section 4.2 of
+[`introducing-types.md`](introducing-types.md) records the distinction as a decision with its mechanism rather than
+leaving it to the implementer.
 
 ## 7. Open questions
 

--- a/Metalama.Framework/docs/future/introducing-records.md
+++ b/Metalama.Framework/docs/future/introducing-records.md
@@ -246,6 +246,7 @@ valid, and what is not depends on the authoring form.
 | `IsReadOnly` | The setter throws an `InvalidOperationException`, as it does for any class. | Valid, and produces a `readonly record struct`. |
 | `IsRef` | The setter throws an `InvalidOperationException`, as it does for any class. | The setter throws a `NotSupportedException`. The language has no `ref record struct`. |
 | `IsClosed` | See section 7.1, which records this as open. | The setter throws an `InvalidOperationException`, as it does for any type that is not a class. |
+| `Facets` | The getter throws a `NotSupportedException`, as it does on every builder. | Same. |
 
 `IsReadOnly` and `IsRef` are the two properties that [`introducing-structs.md`](introducing-structs.md) adds to
 `INamedTypeBuilder`, so this issue depends on that one for them as well as for the emission machinery.
@@ -256,10 +257,14 @@ constructors to an introduced record through the adviser in the ordinary way.
 
 ## 5. The synthesized members, and what the facet reports
 
-The introduced type reports an `IRecordFacet` rather than the empty collection, which replaces implementation
-guideline 5 of [`type-facets.md`](type-facets.md) for this kind. Every member the facet names has to be
-materialized as a builder, because the facet of an introduced type is built from the builder data. This is the
-substance of the issue, and it is the reason the issue is sized larger than the other three.
+A record builder throws a `NotSupportedException` from `Facets`, which section 5.1 of
+[`introducing-types.md`](introducing-types.md) states for every builder. Unlike an enum builder and a delegate
+builder, `IRecordBuilder` derives from `INamedType` and therefore declares the member, so the exception is reached
+through the public interface here. The kind of a builder is read from `IsRecord`, which does not throw.
+
+The introduced type reports an `IRecordFacet`. Every member the facet names has to be materialized as a builder,
+because the facet of an introduced type is built from the builder data. This is the substance of the issue, and it
+is the reason the issue is sized larger than the other three.
 
 | `IRecordFacet` member | Record class | Record struct |
 | --- | --- | --- |
@@ -289,6 +294,15 @@ The engine already carries the record flag from the builder to the introduced ty
 `isRecord` constructor parameter, `NamedTypeBuilderData` stores it and `IntroducedNamedType` reports it. What
 blocks the flag today is the assertion `Invariant.Assert( !isRecord )` beside it, and the missing arm in the
 transformation. This design therefore says what the existing flag becomes and adds no second flag.
+
+The facet is tested by unit tests and not by aspect tests, for the reason that section 5.3 of
+[`introducing-types.md`](introducing-types.md) gives, and this kind is the one for which the difference matters
+most. An aspect test shows the declaration that was emitted, and the six synthesized members do not appear in it,
+because the compiler synthesizes them from the `record` keyword rather than Metalama emitting them. Only a unit
+test can assert that they exist in the code model as builders, which is what this issue delivers. The tests belong
+beside `RecordFacetTests.cs`, which issue [#1997](https://github.com/metalama/Metalama/issues/1997) added for a
+record read from source, and the central assertion is that an introduced record and the equivalent record read from
+source report the same six members, with the same three of them null for a record struct.
 
 ## 6. Decisions
 
@@ -384,7 +398,8 @@ an aspect that needs it.
 - [`introducing-types.md`](introducing-types.md), sections 2, 4 and 5.
 - [`introducing-structs.md`](introducing-structs.md), section 3.2, which adds `IsReadOnly` and `IsRef` to
   `INamedTypeBuilder`.
-- [`type-facets.md`](type-facets.md), section 2.2 and implementation guideline 5.
+- [`type-facets.md`](type-facets.md), section 2.2. Its implementation guideline 5, which makes a builder return
+  the empty facet collection, is superseded by section 5.1 of [`introducing-types.md`](introducing-types.md).
 - `Metalama.Framework/Code/Types/IRecordFacet.cs`, the interface this design mirrors.
 
 Issues:

--- a/Metalama.Framework/docs/future/introducing-records.md
+++ b/Metalama.Framework/docs/future/introducing-records.md
@@ -149,8 +149,9 @@ public interface IRecordBuilder : INamedTypeBuilder
     /// </para>
     /// <para>
     /// A positional parameter whose name is that of a member already declared by the record, or by one of its base
-    /// records, declares no property, which is the rule of the language. The advice reports an error instead of
-    /// generating a declaration that the compiler would reject.
+    /// records, declares no property, which is the rule of the language. Metalama does not refuse it, and
+    /// <see cref="Metalama.Framework.Code.Types.IRecordFacet.PositionalProperties"/> then contributes no element
+    /// for that parameter, as it does for a record the user wrote.
     /// </para>
     /// </remarks>
     /// <param name="name">The name of the parameter, which is also the name of the property it declares.</param>
@@ -251,7 +252,7 @@ valid, and what is not depends on the authoring form.
 `IsReadOnly` and `IsRef` are the two properties that [`introducing-structs.md`](introducing-structs.md) adds to
 `INamedTypeBuilder`, so this issue depends on that one for them as well as for the emission machinery.
 
-Member introduction is valid on a record, unlike on an enum and on a delegate. The rule of section 3 of
+Member introduction is valid on a record, unlike on an enum and on a delegate. The rule of section 3.1 of
 [`introducing-types.md`](introducing-types.md) does not apply here, and an aspect may add methods, properties and
 constructors to an introduced record through the adviser in the ordinary way.
 
@@ -265,6 +266,12 @@ through the public interface here. The kind of a builder is read from `IsRecord`
 The introduced type reports an `IRecordFacet`. Every member the facet names has to be materialized as a builder,
 because the facet of an introduced type is built from the builder data. This is the substance of the issue, and it
 is the reason the issue is sized larger than the other three.
+
+Materialized means present in the code model and not emitted as syntax. Metalama generates the record declaration,
+which is the `record` keyword, the name, the positional parameter list and the base list, and the compiler
+synthesizes the six members from it exactly as it does for a record the user wrote. A transformation that injected
+them as well would declare each of them twice. Section 5.2 of [`introducing-types.md`](introducing-types.md) states
+the rule, and the table below is therefore a description of the code model rather than of the generated code.
 
 | `IRecordFacet` member | Record class | Record struct |
 | --- | --- | --- |
@@ -349,7 +356,7 @@ admits thirteen values that the method has to reject at run time. A two-member e
 time, and its documentation states its relation to `TypeKind` so that a reader does not take it for a second
 representation of a record in the code model.
 
-### 6.4. The synthesized members are materialized rather than discovered
+### 6.4. The synthesized members are materialized in the code model and are not emitted
 
 The pipeline never re-reads the final model from Roslyn, so a member that an aspect must see has to exist as a
 builder. The precedent is `IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which materializes the
@@ -359,6 +366,12 @@ The alternative is to let the facet of an introduced record report `null` for th
 document that an introduced record is less complete than one the user wrote. That is rejected because the facet is
 the interface through which an aspect reads a record, and a facet that answers differently according to the origin
 of the type is a defect rather than a limitation.
+
+The materialization stops at the code model. The generated code is the record declaration and nothing more, because
+the compiler synthesizes the six members from the `record` keyword. An implementation that emitted them would
+produce a duplicate declaration for each, and the failure would appear as a compiler error on generated code rather
+than as a defect in the code model, which is why the distinction is recorded as a decision rather than left to the
+implementer.
 
 ## 7. Open questions
 

--- a/Metalama.Framework/docs/future/introducing-records.md
+++ b/Metalama.Framework/docs/future/introducing-records.md
@@ -240,7 +240,7 @@ valid, and what is not depends on the authoring form.
 | --- | --- | --- |
 | `Accessibility`, `Name`, `IsPartial` | Valid. | Valid. |
 | `AddTypeParameter` | Valid. | Valid. |
-| `BaseType` | Valid, and the base must itself be a record class. The setter throws an `InvalidOperationException` for a base that is not a record, which is the rule of the language. | The setter throws a `NotSupportedException`. A record struct derives from `System.ValueType` and the language allows no other base. |
+| `BaseType` | Valid. The language requires the base of a record class to be a record class, and Metalama does not refuse a base that is not one, because a base list is representable and section 3.2 of [`introducing-types.md`](introducing-types.md) leaves such a case to the compiler, which reports CS8867 on the generated declaration. | The setter throws a `NotSupportedException`. A record struct derives from `System.ValueType`, and there is no base list to emit. |
 | `IsAbstract` | Valid. | The setter throws a `NotSupportedException`. |
 | `IsSealed` | Valid. | The setter throws a `NotSupportedException`. A record struct is implicitly sealed. |
 | `IsStatic` | The setter throws a `NotSupportedException`. A record is never static. | Same. |
@@ -265,7 +265,7 @@ through the public interface here. The kind of a builder is read from `IsRecord`
 
 The introduced type reports an `IRecordFacet`. Every member the facet names has to be materialized as a builder,
 because the facet of an introduced type is built from the builder data. This is the substance of the issue, and it
-is the reason the issue is sized larger than the other three.
+is the reason the issue is sized larger than the other four.
 
 Materialized means present in the code model and not emitted as syntax. Metalama generates the record declaration,
 which is the `record` keyword, the name, the positional parameter list and the base list, and the compiler
@@ -281,7 +281,7 @@ This kind registers the most: the six members that `IRecordFacet` names, the pri
 | `IRecordFacet` member | Record class | Record struct |
 | --- | --- | --- |
 | `EqualityContractProperty` | A protected virtual property named `EqualityContract`, materialized. | `null`. A record struct has none. |
-| `PrintMembersMethod` | A method named `PrintMembers`, materialized. | Materialized. Its accessibility differs: private on a record struct, protected on a record class that is sealed, protected virtual otherwise. |
+| `PrintMembersMethod` | A method named `PrintMembers`, materialized. It is `protected virtual` on a record class that is not sealed, and `private` on one that is. | Materialized, and `private`. |
 | `CloneMethod` | A method whose metadata name is `<Clone>$`, materialized. | `null`. A record struct has none. |
 | `CopyConstructor` | A constructor taking the record type, materialized. | `null`. A record struct has none. |
 | `DeconstructMethod` | Materialized when the record has at least one positional parameter, and `null` otherwise. | Same. |

--- a/Metalama.Framework/docs/future/introducing-structs.md
+++ b/Metalama.Framework/docs/future/introducing-structs.md
@@ -155,15 +155,31 @@ the same interface already declares and which throws when the type is not a clas
 - `IsAbstract` and `IsSealed` may not be set to `true`. A struct is implicitly sealed and may not be abstract.
 - `IsClosed` may not be set. The `closed` modifier applies to a class only, which the property already documents.
 - `IsStatic` may not be set to `true`. A static struct is not a language construct.
+- `Facets` may not be read. The getter throws a `NotSupportedException` on every builder, which section 5 states and
+  which this issue introduces.
 
 Implemented interfaces, type parameters, members and attributes are all valid, and no advice is refused on an
 introduced struct beyond what the language refuses on any struct.
 
-## 5. What the facet of the introduced type reports
+## 5. What the facet reports, and what this issue changes about facets
 
-Nothing. A struct has no facet, so `Facets` stays the empty collection and implementation guideline 5 of
-[`type-facets.md`](type-facets.md) is not replaced for this kind. This issue is the one case of the five in which
-the guideline holds unchanged.
+A struct has no facet, so an introduced struct reports the empty collection, as an introduced class and an
+introduced interface do. This is the one of the five kinds that adds no facet.
+
+It is nevertheless the issue that changes how a builder answers `Facets`, because section 4 gives it the machinery
+that the five kinds share and this is part of it. Section 5.1 of [`introducing-types.md`](introducing-types.md)
+states the change: `NamedTypeBuilder.Facets` throws a `NotSupportedException` instead of returning the empty
+collection, and the three readers listed there are guarded before the exception is introduced. Implementation
+guideline 5 of [`type-facets.md`](type-facets.md) is superseded by it.
+
+The flags stay as they are. `IsEnum`, `IsDelegate`, `IsRecord` and `IsUnion` are answered by a builder from its own
+kind, they allocate nothing, and this issue does not change them. That separation is what lets the structure throw
+without breaking a caller that only asks what kind a type is.
+
+The unit tests of this issue are therefore about the exception rather than about a facet:
+`TypeFacetTests.FacetsOfBuilderDoNotThrow` is rewritten to assert that the builder throws and that the four flags
+do not, and a test asserts that an introduced struct reports the empty collection. Section 5.3 of
+[`introducing-types.md`](introducing-types.md) states why these are unit tests and not aspect tests.
 
 ## 6. Decisions
 
@@ -224,7 +240,8 @@ step, and the answer belongs in the implementation rather than in this document.
 ## 8. References
 
 - [`introducing-types.md`](introducing-types.md), sections 2, 4 and 6.
-- [`type-facets.md`](type-facets.md), implementation guideline 5.
+- [`type-facets.md`](type-facets.md), section 2.2. Its implementation guideline 5, which makes a builder return
+  the empty facet collection, is superseded by section 5.1 of [`introducing-types.md`](introducing-types.md).
 - [`../2027.0/analysis-reports/10-introducing-closed-and-unions.md`](../2027.0/analysis-reports/10-introducing-closed-and-unions.md),
   which records that the struct path of the builder and of the transformation is reachable code that no public
   method reaches.

--- a/Metalama.Framework/docs/future/introducing-structs.md
+++ b/Metalama.Framework/docs/future/introducing-structs.md
@@ -1,0 +1,248 @@
+# Introducing a struct
+
+This document designs the introduction of a struct, which is issue
+[#869](https://github.com/metalama/Metalama/issues/869). It is a design proposal. Nothing described here is
+implemented.
+
+The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md), which this document does not
+repeat. A record struct is not designed here: it is a record, and
+[`introducing-records.md`](introducing-records.md) designs it.
+
+This is the smallest of the five designs, because a struct is a named type with no structure of its own. A struct
+has no facet, so no builder interface is added and `INamedTypeBuilder` is used directly. The value of the issue is
+that it carries the emission machinery that section 4 of [`introducing-types.md`](introducing-types.md) describes,
+and which the other four consume.
+
+## 1. What the aspect author writes
+
+```csharp
+public class GeneratePointAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        var point = builder.IntroduceStruct(
+            "Point",
+            buildType: t =>
+            {
+                t.Accessibility = Accessibility.Public;
+                t.IsReadOnly = true;
+            } );
+
+        point.IntroduceAutomaticProperty( "X", typeof(double) );
+        point.IntroduceAutomaticProperty( "Y", typeof(double) );
+    }
+}
+```
+
+## 2. What Metalama produces
+
+```csharp
+public readonly struct Point
+{
+    public double X { get; set; }
+    public double Y { get; set; }
+}
+```
+
+## 3. The interfaces
+
+### 3.1. The advice method
+
+The method follows `IntroduceClass` and `IntroduceInterface`, which it sits beside, and takes the same parameters.
+
+```csharp
+// Metalama.Framework/Advising/IAdviceFactory.cs
+/// <summary>
+/// Introduces a new struct to the target namespace or type.
+/// </summary>
+/// <param name="targetNamespaceOrType">The namespace or type into which the struct must be introduced.</param>
+/// <param name="name">The name of the introduced struct.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildType">An optional callback that allows you to configure the introduced struct, such as adding
+///     members, implemented interfaces, or custom attributes.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
+/// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced struct.
+/// The <see cref="IIntroductionAdviceResult{T}"/> interface itself implements <see cref="IAdviser{T}"/> and can be
+/// used to introduce members to the type.</returns>
+IIntroductionAdviceResult<INamedType> IntroduceStruct(
+    INamespaceOrNamedType targetNamespaceOrType,
+    string name,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<INamedTypeBuilder>? buildType = null );
+```
+
+```csharp
+// Metalama.Framework/Aspects/AdviserExtensions.cs
+/// <summary>
+/// Introduces a new struct into the current namespace (as a top-level type) or type (as a nested type).
+/// Use the <see cref="IAdviser.With{TNewDeclaration}"/> or <see cref="WithNamespace"/> method to introduce the
+/// struct to a different type or namespace than the current one.
+/// </summary>
+/// <param name="adviser">An adviser for a named type or namespace.</param>
+/// <param name="name">The struct name.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target type or namespace. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildType">An optional delegate that modifies the
+///     <see cref="INamedTypeBuilder"/> that represents the introduced struct.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> that exposes the outcome of the operation and the
+/// introduced <see cref="INamedType"/>.</returns>
+/// <seealso href="@introducing-types"/>
+public static IIntroductionAdviceResult<INamedType> IntroduceStruct(
+    this IAdviser<INamespaceOrNamedType> adviser,
+    string name,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<INamedTypeBuilder>? buildType = null )
+    => ((IAdviserInternal) adviser).AdviceFactory.IntroduceStruct(
+        adviser.Target,
+        name,
+        whenExists,
+        buildType );
+```
+
+### 3.2. The members added to `INamedTypeBuilder`
+
+`INamedTypeBuilder` carries two commented-out declarations under the comment `// TODO: Struct introduction`. This
+issue uncomments them and documents them. `INamedType` already declares both as read-only properties, so each is a
+`new` member that adds a setter.
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/INamedTypeBuilder.cs
+/// <summary>
+/// Gets or sets a value indicating whether the type is declared with the <c>readonly</c> modifier.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The language allows the <c>readonly</c> modifier on a struct only. The setter throws an
+/// <see cref="InvalidOperationException"/> when the type being built is not a struct.
+/// </para>
+/// <para>
+/// A readonly struct may declare no settable instance field and no automatic property that has a setter, so an
+/// advice that introduces one into such a type reports an error.
+/// </para>
+/// </remarks>
+new bool IsReadOnly { get; set; }
+
+/// <summary>
+/// Gets or sets a value indicating whether the type is declared with the <c>ref</c> modifier, which makes it a
+/// type that may live on the stack only.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The language allows the <c>ref</c> modifier on a struct only. The setter throws an
+/// <see cref="InvalidOperationException"/> when the type being built is not a struct.
+/// </para>
+/// <para>
+/// A ref struct may not be used as a type argument, may not be a field of a type that is not itself a ref struct,
+/// and may not be boxed. Metalama does not verify those restrictions on the code that an aspect generates, so the
+/// compiler reports them on the generated code.
+/// </para>
+/// </remarks>
+new bool IsRef { get; set; }
+```
+
+The two properties are declared on `INamedTypeBuilder` rather than on a builder interface of their own, because
+there is no struct builder. Setting either on a class or an interface throws, in the manner of `IsClosed`, which
+the same interface already declares and which throws when the type is not a class.
+
+## 4. The inherited operations that are not valid
+
+`INamedTypeBuilder` is used unchanged, so the restrictions are those of the language rather than of the interface.
+
+- `BaseType` may not be set. A struct derives from `System.ValueType` and the language allows no other base. The
+  setter throws an `InvalidOperationException`, in the manner of the existing check that refuses a base type other
+  than `object` on an interface.
+- `IsAbstract` and `IsSealed` may not be set to `true`. A struct is implicitly sealed and may not be abstract.
+- `IsClosed` may not be set. The `closed` modifier applies to a class only, which the property already documents.
+- `IsStatic` may not be set to `true`. A static struct is not a language construct.
+
+Implemented interfaces, type parameters, members and attributes are all valid, and no advice is refused on an
+introduced struct beyond what the language refuses on any struct.
+
+## 5. What the facet of the introduced type reports
+
+Nothing. A struct has no facet, so `Facets` stays the empty collection and implementation guideline 5 of
+[`type-facets.md`](type-facets.md) is not replaced for this kind. This issue is the one case of the five in which
+the guideline holds unchanged.
+
+## 6. Decisions
+
+### 6.1. There is no `IStructBuilder`
+
+A builder interface exists to carry the operations that one kind of type has and others do not. A struct has none:
+every operation it needs is on `INamedTypeBuilder` already, and `IsReadOnly` and `IsRef` are added there because
+`INamedType` declares them there. An `IStructBuilder` that added no member would be a name for the same set of
+operations, and it would force the advice method to return a different callback type for no gain.
+
+The same reasoning gives the answer for a class and an interface, which have `IntroduceClass` and
+`IntroduceInterface` and no builder interface of their own.
+
+### 6.2. The struct is introduced by its own advice method and not by a parameter
+
+`IntroduceStruct` is a method beside `IntroduceClass` and `IntroduceInterface`, and not a parameter of a single
+`IntroduceType` method that takes a kind. The precedent is the pair that already exists: the two shipped methods
+differ only in the kind they pass to `IntroduceNamedTypeAdvice`, and they are nevertheless two methods.
+
+The reason the precedent is right is that the kinds do not accept the same configuration. An interface takes no
+base type, a struct takes neither a base type nor the abstract modifier, and a record takes positional parameters
+that no other kind takes. A single method with a kind parameter would accept every combination and reject most of
+them at run time.
+
+### 6.3. This issue is implemented first
+
+A struct has no facet and adds no public interface, so it exercises the emission machinery of section 4 of
+[`introducing-types.md`](introducing-types.md) alone. Every defect that the first implementation of a new type kind
+meets is found here, where no builder interface and no synthesized member is present to confuse the diagnosis.
+
+The machinery is already half present, which makes this the cheapest place to find those defects: the
+`TypeKind.Struct` arm of `IntroduceNamedTypeTransformation` exists and is correct, and what is missing is the
+public advice method that reaches it, the two properties of section 3.2, and the design-time path.
+
+## 7. Open questions
+
+### 7.1. Does `IsRef` need a diagnostic of its own?
+
+A ref struct carries restrictions that the compiler reports on generated code, which section 3.2 documents rather
+than enforces. Whether Metalama should refuse an advice that introduces a ref struct as a field of a class, which
+is the most likely mistake, is not decided here. What would settle it is the count of such mistakes that reach a
+user, which is not known before the feature ships.
+
+The safe reading is that the compiler error is clear and names the generated declaration, so no Metalama diagnostic
+is added until one is asked for.
+
+### 7.2. Is the implicit parameterless constructor materialized?
+
+`IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded` materializes a public parameterless constructor for
+an introduced class, because the final model is built from builders and is never re-read from Roslyn. A struct also
+has an implicit parameterless constructor, and whether the same treatment applies to it is not decided here.
+
+What would settle it is whether an aspect can observe the difference. The constructor of a struct differs from the
+one of a class in that the language allows a struct to declare one explicitly only since C# 10, and in that it is
+not emitted into metadata. A test that reads `Constructors` on an introduced struct settles the question in one
+step, and the answer belongs in the implementation rather than in this document.
+
+## 8. References
+
+- [`introducing-types.md`](introducing-types.md), sections 2, 4 and 6.
+- [`type-facets.md`](type-facets.md), implementation guideline 5.
+- [`../2027.0/analysis-reports/10-introducing-closed-and-unions.md`](../2027.0/analysis-reports/10-introducing-closed-and-unions.md),
+  which records that the struct path of the builder and of the transformation is reachable code that no public
+  method reaches.
+
+Issues:
+
+- [#869](https://github.com/metalama/Metalama/issues/869), which this document designs.
+- [#1950](https://github.com/metalama/Metalama/issues/1950), C# 15 closed classes: introducing, which is user story
+  S-28 and is closed. It is the most recent change to `INamedTypeBuilder`, it added `IsClosed` beside the two
+  properties of section 3.2, and the pull request that implements this issue should resemble it.
+- [#1869](https://github.com/metalama/Metalama/issues/1869), cannot introduce a partial class, closed. It added
+  `IsPartial` to the named type builder, so the member set of section 3.2 changed in this release.
+- [#868](https://github.com/metalama/Metalama/issues/868), type introduction: introduce primary constructor, open.
+  Section 7.2 asks whether the implicit parameterless constructor of a struct is materialized, and the explicit
+  primary constructor of a struct belongs to that issue.
+- [#863](https://github.com/metalama/Metalama/issues/863), type introduction: reflection wrappers and syntax
+  serialization, open. An introduced struct reaches the same reflection wrappers as an introduced class, and
+  whether they need work for a value type is not answered here.
+- Section 8.4 of [`introducing-types.md`](introducing-types.md) lists the rest of the type introduction backlog.
+
+— Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/introducing-structs.md
+++ b/Metalama.Framework/docs/future/introducing-structs.md
@@ -117,8 +117,9 @@ issue uncomments them and documents them. `INamedType` already declares both as 
 /// <see cref="InvalidOperationException"/> when the type being built is not a struct.
 /// </para>
 /// <para>
-/// A readonly struct may declare no settable instance field and no automatic property that has a setter, so an
-/// advice that introduces one into such a type reports an error.
+/// A readonly struct may declare no settable instance field and no automatic property that has a setter. Metalama
+/// does not refuse an advice that introduces one, and the compiler reports the error on the generated
+/// declaration.
 /// </para>
 /// </remarks>
 new bool IsReadOnly { get; set; }
@@ -216,26 +217,32 @@ public advice method that reaches it, the two properties of section 3.2, and the
 
 ## 7. Open questions
 
-### 7.1. Does `IsRef` need a diagnostic of its own?
+None. Two questions that an earlier revision recorded are answered below.
 
-A ref struct carries restrictions that the compiler reports on generated code, which section 3.2 documents rather
-than enforces. Whether Metalama should refuse an advice that introduces a ref struct as a field of a class, which
-is the most likely mistake, is not decided here. What would settle it is the count of such mistakes that reach a
-user, which is not known before the feature ships.
+### 7.1. `IsRef` needs no diagnostic of its own
 
-The safe reading is that the compiler error is clear and names the generated declaration, so no Metalama diagnostic
-is added until one is asked for.
+A ref struct carries restrictions that the compiler reports on generated code, and Metalama does not refuse an
+advice that breaks one. Introducing a ref struct as the type of a field of a class is left to the aspect author,
+and the compiler reports the error on the generated declaration.
 
-### 7.2. Is the implicit parameterless constructor materialized?
+This is the general rule of section 3.2 of [`introducing-types.md`](introducing-types.md) rather than a decision
+about ref structs: the framework does not prevent an aspect author from generating invalid code, and a framework
+that reproduced the rules of the language would reproduce a part of them and be wrong about some of that part.
 
-`IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded` materializes a public parameterless constructor for
-an introduced class, because the final model is built from builders and is never re-read from Roslyn. A struct also
-has an implicit parameterless constructor, and whether the same treatment applies to it is not decided here.
+### 7.2. The implicit parameterless constructor is materialized in the code model and is not emitted
 
-What would settle it is whether an aspect can observe the difference. The constructor of a struct differs from the
-one of a class in that the language allows a struct to declare one explicitly only since C# 10, and in that it is
-not emitted into metadata. A test that reads `Constructors` on an introduced struct settles the question in one
-step, and the answer belongs in the implementation rather than in this document.
+A struct has an implicit parameterless constructor, and the code model of an introduced struct reports it, so that
+an introduced struct answers `Constructors` as a struct read from source does. That matches the behaviour of
+Roslyn, which is the standard the code model is held to.
+
+It is not emitted as syntax. The compiler synthesizes the constructor of a struct from the declaration, so emitting
+one would declare it twice. This is the distinction that section 5.2 of
+[`introducing-types.md`](introducing-types.md) draws for every synthesized member of the five kinds, and the struct
+is the smallest instance of it, which is a further reason for this issue to be implemented first.
+
+The precedent is `IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which materializes the
+parameterless constructor of an introduced class. It cannot be copied literally, because it adds a transformation
+that injects a member, and this one must register a builder without injecting anything.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/introducing-structs.md
+++ b/Metalama.Framework/docs/future/introducing-structs.md
@@ -236,13 +236,19 @@ an introduced struct answers `Constructors` as a struct read from source does. T
 Roslyn, which is the standard the code model is held to.
 
 It is not emitted as syntax. The compiler synthesizes the constructor of a struct from the declaration, so emitting
-one would declare it twice. This is the distinction that section 5.2 of
-[`introducing-types.md`](introducing-types.md) draws for every synthesized member of the five kinds, and the struct
-is the smallest instance of it, which is a further reason for this issue to be implemented first.
+one would declare it twice. Section 4.2 of [`introducing-types.md`](introducing-types.md) states the rule and the
+mechanism for all five kinds: the transformation implements `IIntroduceDeclarationTransformation`, does not
+implement `IInjectMemberTransformation`, and therefore reaches the code model while neither the linker nor the
+design-time generator emits it.
 
-The precedent is `IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which materializes the
-parameterless constructor of an introduced class. It cannot be copied literally, because it adds a transformation
-that injects a member, and this one must register a builder without injecting anything.
+The struct is the smallest instance of that rule, with one member and no facet, which is a further reason for this
+issue to be implemented first. The prototype that story S-29 asks for belongs here rather than in the union work,
+because this is where it is cheapest to run.
+
+`IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which materializes the parameterless constructor
+of an introduced class, is the precedent a reader reaches for and it is the wrong one: it derives from
+`IntroduceDeclarationTransformation<T>`, which implements both interfaces, so it emits the constructor as well.
+That is correct for a class and is not the shape this issue needs.
 
 ## 8. References
 

--- a/Metalama.Framework/docs/future/introducing-structs.md
+++ b/Metalama.Framework/docs/future/introducing-structs.md
@@ -28,8 +28,15 @@ public class GeneratePointAttribute : TypeAspect
                 t.IsReadOnly = true;
             } );
 
-        point.IntroduceAutomaticProperty( "X", typeof(double) );
-        point.IntroduceAutomaticProperty( "Y", typeof(double) );
+        point.IntroduceAutomaticProperty(
+            "X",
+            typeof(double),
+            buildProperty: p => p.Writeability = Writeability.InitOnly );
+
+        point.IntroduceAutomaticProperty(
+            "Y",
+            typeof(double),
+            buildProperty: p => p.Writeability = Writeability.InitOnly );
     }
 }
 ```
@@ -39,10 +46,15 @@ public class GeneratePointAttribute : TypeAspect
 ```csharp
 public readonly struct Point
 {
-    public double X { get; set; }
-    public double Y { get; set; }
+    public double X { get; init; }
+    public double Y { get; init; }
 }
 ```
+
+A readonly struct may declare no settable instance auto-property, which is why the example makes both properties
+init-only. Metalama does not refuse a settable one, and section 3.2 of
+[`introducing-types.md`](introducing-types.md) states why: the compiler reports the error on the generated
+declaration.
 
 ## 3. The interfaces
 
@@ -165,7 +177,7 @@ introduced struct beyond what the language refuses on any struct.
 ## 5. What the facet reports, and what this issue changes about facets
 
 A struct has no facet, so an introduced struct reports the empty collection, as an introduced class and an
-introduced interface do. This is the one of the five kinds that adds no facet.
+introduced interface do. It is the one of the five kinds that adds no facet.
 
 It is nevertheless the issue that changes how a builder answers `Facets`, because section 4 gives it the machinery
 that the five kinds share and this is part of it. Section 5.1 of [`introducing-types.md`](introducing-types.md)

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -418,6 +418,8 @@ asserts the exception, and it keeps its assertions that the flags do not throw.
 
 ## 6. Order of implementation
 
+### 6.1. The order
+
 This table supersedes section 6.2 of [`type-facets.md`](type-facets.md), which does not include the union and which
 records the superseded hierarchy decision.
 
@@ -430,12 +432,65 @@ records the superseded hierarchy decision.
 | [#1951](https://github.com/metalama/Metalama/issues/1951) | Introduce a union, with `IUnionBuilder`. This is user story S-29, narrowed to its first half: adding a case to a union that already exists is not supported, which section 6.5 of [`introducing-unions.md`](introducing-unions.md) decides. | #869, [#1941](https://github.com/metalama/Metalama/issues/1941), [#1945](https://github.com/metalama/Metalama/issues/1945) |
 
 The struct is first because it carries the machinery, and because it is the only one of the five whose design adds
-no public interface, so it exercises the emission path alone. The enum and the delegate are independent of each
-other and either may follow. The record is the last of the four issues, because it is the one that materializes
-synthesized members.
+no public interface, so it exercises the emission path alone. The record is the largest, because it registers the
+most synthesized members.
 
 The facet issues of section 6.1 of [`type-facets.md`](type-facets.md) are delivered, so no document of this set is
 blocked by one.
+
+### 6.2. What can be implemented concurrently
+
+The five are not independent, and they are not one piece of work either. The shared engine changes are few, they
+are all in the first issue, and once they are merged the remaining four touch mostly disjoint files.
+
+The changes that happen once, whatever the number of kinds, belong to
+[#869](https://github.com/metalama/Metalama/issues/869):
+
+| Site | Change |
+| --- | --- |
+| `NamedTypeBuilder.cs:186` | The assertion that restricts the kind is relaxed to accept every kind this set introduces. |
+| `NamedTypeBuilder.cs:336` | `Facets` throws, which is section 5.1. |
+| `IntroducedNamedType.cs:182` | `Facets` becomes `TypeFacetCollection.Create( this )`, which is what `SourceNamedTypeImpl` already does. |
+| `EligibilityRuleFactory.cs:101` and `:105` | The two rules test `IsDelegate` before reading the facet, which is section 5.1. |
+| A new transformation shape | Registers a builder without injecting a member, which is section 4.2. |
+| `IntroduceNamedTypeTransformation.cs:65` | The cast and the local widen to `MemberDeclarationSyntax`, which is section 4.1. |
+
+The third row is the one that decides the answer, and it is a single line rather than one line per kind.
+`TypeFacetCollection.Create` dispatches on `IsDelegate`, `IsUnion`, `IsRecord` and `IsEnum`, and
+`IntroducedNamedType` already declares all four. An introduced type therefore reports the facet of its kind as soon
+as its flag is correct, and no later issue edits that site.
+
+What each later issue adds, once those are merged:
+
+| Site | Which issues touch it |
+| --- | --- |
+| A public builder interface, an engine builder, a builder data type, and the tests | Each kind, in files of its own. |
+| The facet implementation, which needs a path that reads the code model rather than a Roslyn symbol | `EnumFacet`, `RecordFacet` and `UnionFacet`, one file each. `DelegateFacet` names no symbol and already works on an introduced type. |
+| `IAdviceFactory`, `AdviserExtensions` and `AdviceFactory` | Each kind, appending a method to a different part of each file. |
+| The arm of the switch in `IntroduceNamedTypeTransformation` | Each kind. |
+| The arm of `DesignTimeSyntaxTreeGenerator.CreatePartialType` | The enum and the delegate only. The class, struct, record class and record struct arms are already there. |
+| `ModifierHelper.GetTypeSyntaxModifierList` | The record only, for the `record` modifier. |
+
+The recommendation follows from the two tables. One issue first, implemented by one agent in one pull request,
+which is [#869](https://github.com/metalama/Metalama/issues/869) and which carries every row of the first table
+together with the struct itself. Then the enum, the delegate and the record concurrently, and the union beside them
+or after the record.
+
+Three things are worth knowing before that second phase starts.
+
+The textual conflicts are real but mechanical. Two agents adding an arm to the switch of
+`IntroduceNamedTypeTransformation` conflict, because the arms are adjacent lines, and so do two agents adding a
+field to `NamedTypeBuilderData`. Neither conflict is a design question, and a rebase resolves each of them.
+
+The semantic hazard is the reason the first phase exists. Section 4.2 is the part of this work that is easy to
+implement backwards, and an agent that meets it alone will implement it for its own kind. Two agents doing that
+independently produce two shapes for the same problem, and the second one to merge has to be rewritten rather than
+rebased. The struct issue settles it once, with one synthesized member and no facet to obscure it.
+
+Implementing all five in one pull request is the other way to avoid both, and it is not recommended. It produces a
+change of five public builder interfaces, five advice methods, four facet paths and the whole of the machinery
+above, which no reviewer can hold at once, and it serialises work that the tables show is mostly parallel. The
+first phase is small enough to review closely, which is what it needs, because every later issue is built on it.
 
 ## 7. The documents
 

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -147,7 +147,9 @@ implements `INamedTypeImpl`, because the compilation model requires it, so a bui
 `Invoke` method builder of a delegate, resolves a declaring type that is not null in the ordinary way. The public
 interface is a narrowed view of an object that is a named type internally.
 
-## 3. Member introduction is refused by advice validation
+## 3. What the framework refuses, and what it leaves to the aspect author
+
+### 3.1. Member introduction into an enum or a delegate is refused by advice validation
 
 Section 2.2 establishes that `IntroduceMethod`, `IntroduceField`, `IntroduceProperty`, `IntroduceEvent`,
 `IntroduceConstructor`, `IntroduceIndexer` and `ImplementInterface` remain callable on the result of introducing an
@@ -161,6 +163,27 @@ the same reason.
 An enum does declare members, and they are nevertheless covered by the same rule. They are added through
 `IEnumBuilder` while the type is being constructed, and not through the adviser afterwards. The enum document
 states why.
+
+### 3.2. The framework does not prevent an aspect from generating invalid code
+
+A builder refuses an operation when the operation cannot be represented, and not when the code it would produce is
+invalid for a reason of the language. Setting a base type on a struct is refused, because a struct declaration has
+nowhere to put one. Introducing a ref struct as the type of a field of a class is not refused, because the
+declaration is representable and the compiler reports the error on it.
+
+The reason is that the aspect author is responsible for the code the aspect generates, and a framework that tried
+to reproduce the rules of the language would reproduce a part of them, would be wrong about some of that part, and
+would refuse patterns that are valid in a context it did not model. The compiler is the authority on whether the
+generated code is valid, and its diagnostic names the generated declaration.
+
+Two exceptions are deliberate. Section 3 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) decides that the
+advices that a union declaration cannot carry are refused with a clear diagnostic, because the compiler reports
+those errors on generated code that the user cannot edit. And an operation whose result could not be expressed at
+all, rather than expressed and rejected, throws, which is what section 4 of each document lists.
+
+The practical test is whether the operation has a syntax to produce. Setting a base type on a struct has none, so
+it throws. Introducing a ref struct as the type of a field has one, so it is generated and the compiler judges
+it.
 
 ## 4. The emission machinery that the five kinds share
 
@@ -245,6 +268,15 @@ that the compiler synthesizes, and each of them has to be materialized. The prec
 `IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which already materializes the implicit
 constructor of an introduced class for exactly this reason.
 
+A member that the compiler synthesizes is materialized in the code model and is not emitted as syntax. Metalama
+generates the declaration of the type, which is the `record` or the `union` keyword and the header that follows it,
+and the compiler synthesizes the members from that declaration exactly as it does for a type the user wrote.
+Emitting them as well would declare them twice. The transformation that registers a builder without injecting a
+member is therefore a shape of its own, which story S-29 describes and models on the introduction of a namespace.
+This is the one point at which the code model and the generated code deliberately differ, and every document of
+this set states it for its own kind, because reading it the other way produces a type whose members are declared
+twice.
+
 ### 5.3. The facets are tested by unit tests and not by aspect tests
 
 An aspect test compares generated code against an expected file. It proves that the right declaration was emitted,
@@ -293,8 +325,7 @@ records the superseded hierarchy decision.
 | [#866](https://github.com/metalama/Metalama/issues/866) | Introduce an enum, with `IEnumBuilder`. | #869 |
 | [#865](https://github.com/metalama/Metalama/issues/865) | Introduce a delegate, with `IDelegateBuilder`. | #869 |
 | [#867](https://github.com/metalama/Metalama/issues/867) | Introduce a record class and a record struct, with `IRecordBuilder`. | #869 |
-| [#1951](https://github.com/metalama/Metalama/issues/1951) | Introduce a union, and a case on the attribute form, with `IUnionBuilder`. This is user story S-29. | #869, [#1941](https://github.com/metalama/Metalama/issues/1941), [#1945](https://github.com/metalama/Metalama/issues/1945) |
-| [#1952](https://github.com/metalama/Metalama/issues/1952) | Introduce a case into a `union` declaration. This is user story S-30, and it is filed only if question Q1 of [`OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) chooses to ship both authoring forms. | [#1951](https://github.com/metalama/Metalama/issues/1951) |
+| [#1951](https://github.com/metalama/Metalama/issues/1951) | Introduce a union, with `IUnionBuilder`. This is user story S-29, narrowed to its first half: adding a case to a union that already exists is not supported, which section 6.5 of [`introducing-unions.md`](introducing-unions.md) decides. | #869, [#1941](https://github.com/metalama/Metalama/issues/1941), [#1945](https://github.com/metalama/Metalama/issues/1945) |
 
 The struct is first because it carries the machinery, and because it is the only one of the five whose design adds
 no public interface, so it exercises the emission path alone. The enum and the delegate are independent of each
@@ -312,7 +343,7 @@ blocked by one.
 | [`introducing-enums.md`](introducing-enums.md) | Enum | [#866](https://github.com/metalama/Metalama/issues/866) |
 | [`introducing-delegates.md`](introducing-delegates.md) | Delegate | [#865](https://github.com/metalama/Metalama/issues/865) |
 | [`introducing-records.md`](introducing-records.md) | Record class and record struct | [#867](https://github.com/metalama/Metalama/issues/867) |
-| [`introducing-unions.md`](introducing-unions.md) | Union | [#1951](https://github.com/metalama/Metalama/issues/1951), [#1952](https://github.com/metalama/Metalama/issues/1952) |
+| [`introducing-unions.md`](introducing-unions.md) | Union | [#1951](https://github.com/metalama/Metalama/issues/1951) |
 
 ## 8. The issues
 
@@ -325,12 +356,20 @@ blocked by one.
 | [#865](https://github.com/metalama/Metalama/issues/865) | Type introduction: introduce delegate | open |
 | [#867](https://github.com/metalama/Metalama/issues/867) | Type introduction: introduce record struct/class | open |
 | [#1951](https://github.com/metalama/Metalama/issues/1951) | C# 15 unions: introducing a union and a case on the attribute form. User story S-29. | open |
-| [#1952](https://github.com/metalama/Metalama/issues/1952) | C# 15 unions: introducing a case into a `union` declaration. User story S-30. | open |
 
 The first four are imported issues that carry no body, and this set of documents is the design they lack. The last
-two are user stories whose body states the capability, the scope and the acceptance criteria, and which state no
+is a user story whose body states the capability, the scope and the acceptance criteria, and which states no
 application programming interface because section 11 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) forbids
 a story from doing so.
+
+One issue is withdrawn by this set rather than designed by it.
+[#1952](https://github.com/metalama/Metalama/issues/1952), user story S-30, which added a case to a type declared
+with the `union` keyword, is not implemented: the operation cannot be expressed in a generated partial part, so the
+editor and the build would disagree about the result. Section 6.5 of
+[`introducing-unions.md`](introducing-unions.md) carries the decision, the workaround for the other authoring form,
+and the condition under which it should be revisited. That section also narrows
+[#1951](https://github.com/metalama/Metalama/issues/1951), which carried the same operation for a type carrying the
+union attribute.
 
 ### 8.2. The issues that delivered the read side
 
@@ -368,7 +407,7 @@ are named so that a reader who implements one of the five knows what is adjacent
 | [#912](https://github.com/metalama/Metalama/issues/912) | Introductions: hidden visibility | Independent. |
 | [#1998](https://github.com/metalama/Metalama/issues/1998) | Code model: move the tuple type interfaces to the type namespace and add a tuple flag | A tuple is not declared and is not introduced, so it produces no document here. |
 | [#1999](https://github.com/metalama/Metalama/issues/1999) | Code model: an invoker on `IMethodBase` | It would let a consumer invoke the creation member of a union case, which [`introducing-unions.md`](introducing-unions.md) needs no more than the reader does. |
-| [#1954](https://github.com/metalama/Metalama/issues/1954) | Documentation: internal architecture documents. User story S-26. | It names S-28, S-29 and S-30 as blockers, so the sections it writes about an introduction interface follow the stories of this set. |
+| [#1954](https://github.com/metalama/Metalama/issues/1954) | Documentation: internal architecture documents. User story S-26. | It names S-28, S-29 and S-30 as blockers, so the sections it writes about an introduction interface follow the stories of this set. Its dependency on S-30 lapses, because section 6.5 of [`introducing-unions.md`](introducing-unions.md) withdraws that story. |
 
 The conceptual documentation of `metalama/Metalama.Documentation` carries a note that support for structs,
 delegates and enums will be added in a future release. Whichever of the five ships last removes it, and user story
@@ -379,8 +418,10 @@ S-27, which is the conceptual documentation of C# 15, names S-29 among its block
 - [`type-facets.md`](type-facets.md), sections 2.4, 5 and 6.2.
 - [`../compilation-model.md`](../compilation-model.md), the builder and builder data freeze pattern.
 - [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 4 and 11.
-- [`../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md`](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md)
-  and [`../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md`](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md).
+- [`../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md`](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md),
+  whose first half is designed here, and
+  [`../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md`](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md),
+  which is withdrawn.
 - [`../2027.0/analysis-reports/10-introducing-closed-and-unions.md`](../2027.0/analysis-reports/10-introducing-closed-and-unions.md),
   the audit of what can be introduced today.
 

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -219,6 +219,8 @@ it.
 
 ## 4. The emission machinery that the five kinds share
 
+### 4.1. The syntax that Metalama emits
+
 Four changes are common to the five documents, and the struct document owns them because it is the first of the
 five to be implemented.
 
@@ -240,6 +242,84 @@ easy to mistake for each other.
 Every new builder follows the freeze pattern that [`../compilation-model.md`](../compilation-model.md) describes: a
 mutable builder is handed to the aspect, is frozen at the end of the advice, and is snapshotted into an immutable
 builder data object that the compilation model stores.
+
+### 4.2. A member that the compiler synthesizes enters the code model and is emitted by nothing
+
+This is the decision that the five kinds share and that is easiest to implement backwards, so it is stated once
+here and each document names the members it applies to.
+
+Metalama emits the declaration of the type and nothing inside it. The compiler then synthesizes, from that
+declaration, exactly what it synthesizes for a type the user wrote: the `Invoke` method of a delegate, the
+`EqualityContract` property and the clone method of a record, the `Value` property and the per-case constructors of
+a union, the parameterless constructor of a struct. Those members must nevertheless exist in the code model,
+because the introduction pipeline never re-reads the final model from Roslyn, so an aspect that reads
+`INamedType.Facets` or `INamedType.Methods` on an introduced type would otherwise find nothing.
+
+A member that is registered in the code model and also emitted is declared twice, and the compiler reports the
+duplicate on generated code that the user cannot edit.
+
+The two are separate axes in the engine, which is what makes the rule implementable rather than a matter of care.
+
+| Question | What decides it |
+| --- | --- |
+| Is the member in the code model? | `CompilationModel.AddTransformation` ignores a transformation whose `Observability` is `TransformationObservability.None`, and registers any other. A transformation that implements `IIntroduceDeclarationTransformation` contributes its `DeclarationBuilderData`. |
+| Is the member emitted at build time? | `LinkerInjectionStep` collects the transformations that implement `IInjectMemberTransformation` and calls `GetInjectedMembers` on each. |
+| Is the member emitted at design time? | `DesignTimeSyntaxTreeGenerator` takes the transformations whose `Observability` is `TransformationObservability.Always` and switches on them; only the arm `case IInjectMemberTransformation` emits anything. |
+
+A synthesized member therefore needs a transformation that implements `IIntroduceDeclarationTransformation`, does
+**not** implement `IInjectMemberTransformation`, and whose `Observability` is not `None`. Both emitters are keyed
+on the same interface, so not implementing it satisfies both at once, and neither the linker nor the design-time
+generator needs a rule of its own.
+
+The precedent exists and is the one that story S-29 names:
+
+```csharp
+// Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceNamespaceTransformation.cs:15
+internal sealed class IntroduceNamespaceTransformation : BaseTransformation, IIntroduceDeclarationTransformation
+{
+    public override TransformationObservability Observability => TransformationObservability.Always;
+
+    DeclarationBuilderData IIntroduceDeclarationTransformation.DeclarationBuilderData => this._introducedDeclaration;
+}
+```
+
+It registers a namespace in the code model and emits nothing, because a namespace has no syntax of its own either.
+`Observability.Always` is correct there and here: the value decides whether the transformation reaches the code
+model and the design-time pipeline, and not whether syntax is produced, which the interface decides.
+
+The trap is the base class. `IntroduceDeclarationTransformation<T>`, which every existing introduce-declaration
+transformation derives from, implements both interfaces:
+
+```csharp
+// Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceDeclarationTransformation.cs:17
+internal abstract class IntroduceDeclarationTransformation<T> : BaseSyntaxTreeTransformation,
+                                                                IIntroduceDeclarationTransformation,
+                                                                IInjectMemberTransformation
+```
+
+So does `IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which materializes the parameterless
+constructor of an introduced class and is the precedent a reader reaches for first. It adds a transformation built
+on that base, so it emits the constructor as well as registering it. That is correct for a class, whose
+parameterless constructor Metalama does declare, and it is not the shape the five kinds need. A document that
+cites it as the precedent, as an earlier revision of the record and union documents did, is citing the half of it
+that does not carry.
+
+Which members each kind registers without emitting:
+
+| Kind | Registered and not emitted |
+| --- | --- |
+| Struct | The implicit parameterless constructor. |
+| Delegate | The `Invoke` method and the constructor of the delegate. |
+| Record | The six members that `IRecordFacet` names, the primary constructor, and `Equals`, `GetHashCode`, `ToString` and the equality operators. |
+| Union | The `Value` property and one constructor per case. |
+| Enum | None. The members of an enum are written by the aspect author and are part of the declaration that Metalama emits, so they are emitted and registered like any declared member. |
+
+The enum is the exception that shows the rule is about the compiler and not about Metalama: a member is exempt
+from emission exactly when the compiler creates it.
+
+Story S-29 asks for this step to be prototyped before the rest of the union work, because whether a member builder
+with no injected member survives the linker injection registry was not verified. The prototype answers the
+question for all five kinds at once and is worth running before the record work starts as well.
 
 ## 5. Facets, on a builder and on an introduced type
 
@@ -295,19 +375,9 @@ comment already says that the type introduction stories add the facet of the kin
 
 The facet of an introduced type is built from the builder data and not from a Roslyn symbol, because the
 introduction pipeline never re-reads the final model from Roslyn. Every member that a facet exposes must therefore
-exist as a builder. That is the reason the record is the largest of the five: an `IRecordFacet` names six members
-that the compiler synthesizes, and each of them has to be materialized. The precedent is
-`IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which already materializes the implicit
-constructor of an introduced class for exactly this reason.
-
-A member that the compiler synthesizes is materialized in the code model and is not emitted as syntax. Metalama
-generates the declaration of the type, which is the `record` or the `union` keyword and the header that follows it,
-and the compiler synthesizes the members from that declaration exactly as it does for a type the user wrote.
-Emitting them as well would declare them twice. The transformation that registers a builder without injecting a
-member is therefore a shape of its own, which story S-29 describes and models on the introduction of a namespace.
-This is the one point at which the code model and the generated code deliberately differ, and every document of
-this set states it for its own kind, because reading it the other way produces a type whose members are declared
-twice.
+exist as a builder, and must not be emitted, which is the decision of section 4.2. That is the reason the record is
+the largest of the five: an `IRecordFacet` names six members that the compiler synthesizes, and each of them has to
+be registered in the code model while the generated code stays a bare `record` declaration.
 
 ### 5.3. The facets are tested by unit tests and not by aspect tests
 

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -61,28 +61,29 @@ structs, delegates and enums will be added in a future release.
 
 ## 2. The builder hierarchy, and where it splits
 
-A record, a struct and a union declare members that an aspect can introduce. An enum and a delegate do not: the
-members of an enum are its own members and nothing else may be added, and a delegate declaration has no member
-list at all. The builders therefore derive from two different bases.
+A record, a struct and a union declare members that an aspect can introduce, and their builder is the builder of
+the type. An enum and a delegate do not: the members of an enum are its own members and nothing else may be added,
+and a delegate declaration has no member list at all. The builders therefore do not share one base, and the
+delegate does not even build the same thing as the other four.
 
-| Kind | Builder | Base |
-| --- | --- | --- |
-| Struct | none, `INamedTypeBuilder` is used directly | `INamedTypeBuilder` |
-| Record | `IRecordBuilder` | `INamedTypeBuilder` |
-| Union | `IUnionBuilder` | `INamedTypeBuilder` |
-| Enum | `IEnumBuilder` | `IMemberOrNamedTypeBuilder` |
-| Delegate | `IDelegateBuilder` | `IMemberOrNamedTypeBuilder` |
+| Kind | Builder | Base | What the builder is |
+| --- | --- | --- | --- |
+| Struct | none, `INamedTypeBuilder` is used directly | `INamedTypeBuilder` | the type |
+| Record | `IRecordBuilder` | `INamedTypeBuilder` | the type |
+| Union | `IUnionBuilder` | `INamedTypeBuilder` | the type |
+| Enum | `IEnumBuilder` | `IMemberOrNamedTypeBuilder` | the type |
+| Delegate | `IDelegateBuilder` | `IMethodBuilder` | the `Invoke` method of the type |
 
 Section 2.4 of [`type-facets.md`](type-facets.md) decided that all four builders derive from `INamedTypeBuilder`
 and that the inapplicable inherited operations throw, after the precedent of `IExtensionBlockBuilder`. That
-decision is kept for the record and the union and is revised for the enum and the delegate. Three findings support
-the revision, and each of them answers an alternative that a reader is likely to propose.
+decision is kept for the record and the union and is revised for the enum and the delegate, for reasons that are
+not the same in the two cases. Sections 2.1 to 2.3 give them.
 
-### 2.1. `IMemberBuilder` cannot serve
+### 2.1. An enum builder cannot derive from `IMemberBuilder`
 
 The first proposal a reader makes is that a builder for a kind without members should derive from `IMemberBuilder`
-rather than from `INamedTypeBuilder`. It cannot, because `IMemberBuilder` derives from `IMember`, which narrows the
-declaring type to a value that is not nullable:
+rather than from `INamedTypeBuilder`. For an enum it cannot, because `IMemberBuilder` derives from `IMember`, which
+narrows the declaring type to a value that is not nullable:
 
 ```csharp
 // Metalama.Framework/Code/IMemberOrNamedType.cs:49
@@ -92,12 +93,15 @@ INamedType? DeclaringType { get; }
 new INamedType DeclaringType { get; }
 ```
 
-An enum or a delegate declared in a namespace has no declaring type, so it cannot satisfy the second declaration.
+An enum declared in a namespace has no declaring type, so it cannot satisfy the second declaration.
 `IMemberBuilder` would also contribute `IsVirtual` and `IsExtern`, which apply to a type less than the members it
 would remove.
 
 `IMemberOrNamedTypeBuilder` is the common base of `IMemberBuilder` and `INamedTypeBuilder`, it keeps the nullable
-declaring type, and it is the base this document takes.
+declaring type, and it is the base the enum builder takes.
+
+This argument is about the enum and does not carry to the delegate, which section 2.3 settles differently. The
+difference is that an enum has no single member that carries its structure, while a delegate does.
 
 ### 2.2. The base does not decide whether members can be introduced
 
@@ -119,33 +123,56 @@ an aspect has to be able to use it as a type, so the result of introducing an en
 Refusing the operation is therefore an advice validation rule, described in section 3, and not a consequence of the
 hierarchy. The hierarchy decides what the callback that configures the type can do, and nothing more.
 
-### 2.3. The restriction is reduced and not removed
+### 2.3. A delegate builder is the builder of its `Invoke` method
+
+A delegate is the one kind of this set whose whole structure is one member. A delegate declaration is a method
+signature with the `delegate` keyword in front of it, and `IDelegateFacet` says the same thing on the read side:
+it declares `InvokeMethod`, and its `ReturnType` and `Parameters` are that method's.
+
+`IDelegateBuilder` therefore derives from `IMethodBuilder` and is the builder of the `Invoke` method. The
+obstacle of section 2.1 does not arise, because the declaring type of that method is the delegate, and a delegate
+always has one. What belongs to the type, which is its name, its accessibility, its custom attributes and its type
+parameters, is reached through `DeclaringType`, narrowed to `INamedTypeBuilder`.
+[`introducing-delegates.md`](introducing-delegates.md) carries the design and the cost.
+
+### 2.4. The restriction is reduced and not removed
+
+Neither choice produces a base on which every inherited member is valid, and no base in the hierarchy would. What
+each one does is make the invalid members few enough to list.
 
 `IMemberOrNamedTypeBuilder` declares six settable members: `Accessibility`, `Name`, `IsStatic`, `IsSealed`,
-`IsAbstract` and `IsPartial`. Two of them apply to an enum and to a delegate, and four do not, so four setters
-still throw. The choice does not produce a base on which every inherited member is valid, and no base in the
-hierarchy would.
+`IsAbstract` and `IsPartial`. Two of them apply to an enum and four do not, so four setters throw. What the choice
+removes is larger: compared with `INamedTypeBuilder`, the enum builder no longer inherits `BaseType`,
+`AddTypeParameter`, `IsClosed`, and the whole of `INamedType`, which is the member collections, the implemented
+interfaces, `PrimaryConstructor`, `ExtensionBlocks`, `MakeGenericInstance` and the type construction methods. That
+is approximately thirty members against the four that remain.
 
-What it removes is larger than what it leaves. Compared with `INamedTypeBuilder`, the enum builder and the delegate
-builder no longer inherit `BaseType`, `AddTypeParameter`, `IsClosed`, and the whole of `INamedType`, which is the
-member collections, the implemented interfaces, `PrimaryConstructor`, `ExtensionBlocks`, `MakeGenericInstance` and
-the type construction methods. That is approximately thirty members against the four that remain.
+The delegate trades differently, because its base is chosen for what it carries rather than for what it omits.
+`IMethodBuilder` gives the return type, the return parameter and the parameter operations, which are the whole of
+what an author configures on a delegate, and the members that throw are the ones that describe a method as a member
+of a type: its name, its accessibility, its own type parameters, its attributes and its modifiers. Section 4 of
+[`introducing-delegates.md`](introducing-delegates.md) lists them, and the count is close to the enum's.
 
-### 2.4. The consequence: the builder is not a type
+### 2.5. The consequence: neither builder is a type
 
-`INamedTypeBuilder` derives from `INamedType`, and `IMemberOrNamedTypeBuilder` does not. An `IEnumBuilder` and an
-`IDelegateBuilder` are therefore not types, and neither can be passed where an `IType` is expected. An aspect that
-needs the introduced type reads it from the result of the advice:
+`INamedTypeBuilder` derives from `INamedType`. Neither `IMemberOrNamedTypeBuilder` nor `IMethodBuilder` does, so an
+`IEnumBuilder` and an `IDelegateBuilder` are not types and neither can be passed where an `IType` is expected. An
+aspect that needs the introduced type reads it from the result of the advice:
 
 ```csharp
 var result = builder.IntroduceEnum( "Color" );
 var enumType = result.Declaration;
 ```
 
-This costs nothing in the implementation. The engine class still derives from `NamedTypeBuilder` and still
-implements `INamedTypeImpl`, because the compilation model requires it, so a builder nested inside it, such as the
-`Invoke` method builder of a delegate, resolves a declaring type that is not null in the ordinary way. The public
-interface is a narrowed view of an object that is a named type internally.
+`IDelegateBuilder.DeclaringType` is an `INamedTypeBuilder` and is therefore an `INamedType`, so it is a type in the
+sense of the compiler. It is not the finished delegate: it is the type under construction, whose members are not
+resolvable, so an aspect does not use it as the type of a declaration either. The result of the advice is the one
+object that is safe to use for that.
+
+This costs nothing in the implementation. The engine class behind a type builder derives from `NamedTypeBuilder`
+and implements `INamedTypeImpl`, because the compilation model requires it, so a builder nested inside it resolves
+a declaring type that is not null in the ordinary way. The public interface is a narrowed view of an object that is
+a named type internally.
 
 ## 3. What the framework refuses, and what it leaves to the aspect author
 
@@ -248,8 +275,9 @@ that an aspect supplies:
 The hierarchy of section 2 bounds that risk rather than leaving it open. `IEnumBuilder` and `IDelegateBuilder` do
 not derive from `INamedType`, so they declare no `Facets` member at all and an aspect cannot pass either of them
 where a type is expected. A delegate builder can therefore never be the type of an event. The builders that remain
-reachable as a type are those of a class, a struct, a record and a union, and `Facets.Delegate` is meaningless on
-all four.
+reachable as a type are those of a class, a struct, a record and a union, to which
+`IDelegateBuilder.DeclaringType` adds the delegate type under construction, and `Facets.Delegate` is meaningless on
+all of them while they are being built.
 
 ### 5.2. An introduced type reports its facet
 

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -233,11 +233,20 @@ of the switch quoted in section 1, and the type of the local variable it produce
 `ModifierHelper.GetTypeSyntaxModifierList` gains the `record` modifier. The `enum` and `delegate` keywords are not
 modifiers and belong to the syntax factory call of their arm.
 
-The design-time generator produces the partial type for the editor, and
-`DesignTimeSyntaxTreeGenerator.CreatePartialType` already has arms for a record class and a record struct. Those
-arms serve the reading of a type that the user wrote. Introducing a type of a new kind requires the same arms on
-the introduction path, and the record document states which of the two paths each arm serves, because the two are
-easy to mistake for each other.
+The design-time path needs no second emission of the declaration, and this is the point at which an implementer is
+most likely to go wrong. An introduced type is emitted at design time by
+`IntroduceNamedTypeTransformation.GetInjectedMembers`, which is the same method the build uses, as a member of the
+generated partial part of its containing type or of the generated file of its namespace.
+`DesignTimeSyntaxTreeGenerator.CreatePartialType` builds that containing part and nothing else. It returns a
+`TypeDeclarationSyntax` and emits the `partial` modifier, so it can never produce an enum or a delegate, and its
+arms for a class, a struct, a record class and a record struct describe the type that contains the introduction
+rather than the introduction itself.
+
+One guard is needed there nonetheless. `ProcessTransformationsOnNamespace` routes an introduced type that carries
+no transformation of its own into `ProcessTransformationsOnType`, so that it is emitted as an empty type, and that
+method calls `CreatePartialType` on it. An introduced enum or delegate reaching that path would fall to the default
+arm of the switch and throw, so the routing skips a kind that cannot be partial and cannot contain a member. That
+is a condition rather than a new arm, and the enum and the delegate documents own it.
 
 Every new builder follows the freeze pattern that [`../compilation-model.md`](../compilation-model.md) describes: a
 mutable builder is handed to the aspect, is frozen at the end of the advice, and is snapshotted into an immutable
@@ -429,7 +438,7 @@ records the superseded hierarchy decision.
 | [#866](https://github.com/metalama/Metalama/issues/866) | Introduce an enum, with `IEnumBuilder`. | #869 |
 | [#865](https://github.com/metalama/Metalama/issues/865) | Introduce a delegate, with `IDelegateBuilder`. | #869 |
 | [#867](https://github.com/metalama/Metalama/issues/867) | Introduce a record class and a record struct, with `IRecordBuilder`. | #869 |
-| [#1951](https://github.com/metalama/Metalama/issues/1951) | Introduce a union, with `IUnionBuilder`. This is user story S-29, narrowed to its first half: adding a case to a union that already exists is not supported, which section 6.5 of [`introducing-unions.md`](introducing-unions.md) decides. | #869, [#1941](https://github.com/metalama/Metalama/issues/1941), [#1945](https://github.com/metalama/Metalama/issues/1945) |
+| [#1951](https://github.com/metalama/Metalama/issues/1951) | Introduce a union, with `IUnionBuilder`. This is user story S-29, narrowed twice by sections 6.3 and 6.4 of [`introducing-unions.md`](introducing-unions.md): only the form written with the `union` keyword is introduced, and adding a case to a union that already exists is not supported. The issue is revised before the work starts. | #869, [#1941](https://github.com/metalama/Metalama/issues/1941), [#1945](https://github.com/metalama/Metalama/issues/1945) |
 
 The struct is first because it carries the machinery, and because it is the only one of the five whose design adds
 no public interface, so it exercises the emission path alone. The record is the largest, because it registers the
@@ -468,7 +477,7 @@ What each later issue adds, once those are merged:
 | The facet implementation, which needs a path that reads the code model rather than a Roslyn symbol | `EnumFacet`, `RecordFacet` and `UnionFacet`, one file each. `DelegateFacet` names no symbol and already works on an introduced type. |
 | `IAdviceFactory`, `AdviserExtensions` and `AdviceFactory` | Each kind, appending a method to a different part of each file. |
 | The arm of the switch in `IntroduceNamedTypeTransformation` | Each kind. |
-| The arm of `DesignTimeSyntaxTreeGenerator.CreatePartialType` | The enum and the delegate only. The class, struct, record class and record struct arms are already there. |
+| The guard in `DesignTimeSyntaxTreeGenerator.ProcessTransformationsOnNamespace` that keeps a kind which cannot be partial out of `CreatePartialType` | The enum and the delegate. Section 4.1 states why it is a condition and not an arm, and why `CreatePartialType` gains nothing. |
 | `ModifierHelper.GetTypeSyntaxModifierList` | The record only, for the `record` modifier. |
 
 The recommendation follows from the two tables. One issue first, implemented by one agent in one pull request,
@@ -564,7 +573,7 @@ are named so that a reader who implements one of the five knows what is adjacent
 | [#912](https://github.com/metalama/Metalama/issues/912) | Introductions: hidden visibility | Independent. |
 | [#1998](https://github.com/metalama/Metalama/issues/1998) | Code model: move the tuple type interfaces to the type namespace and add a tuple flag | A tuple is not declared and is not introduced, so it produces no document here. |
 | [#1999](https://github.com/metalama/Metalama/issues/1999) | Code model: an invoker on `IMethodBase` | It would let a consumer invoke the creation member of a union case, which [`introducing-unions.md`](introducing-unions.md) needs no more than the reader does. |
-| [#1954](https://github.com/metalama/Metalama/issues/1954) | Documentation: internal architecture documents. User story S-26. | It names S-28, S-29 and S-30 as blockers, so the sections it writes about an introduction interface follow the stories of this set. Its dependency on S-30 lapses, because section 6.5 of [`introducing-unions.md`](introducing-unions.md) withdraws that story. |
+| [#1954](https://github.com/metalama/Metalama/issues/1954) | Documentation: internal architecture documents. User story S-26. | It names S-28, S-29 and S-30 as blockers, so the sections it writes about an introduction interface follow the stories of this set. Its dependency on S-30 lapses, because section 6.4 of [`introducing-unions.md`](introducing-unions.md) withdraws that story. |
 
 The conceptual documentation of `metalama/Metalama.Documentation` carries a note that support for structs,
 delegates and enums will be added in a future release. Whichever of the five ships last removes it, and user story

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -72,7 +72,7 @@ delegate does not even build the same thing as the other four.
 | Record | `IRecordBuilder` | `INamedTypeBuilder` | the type |
 | Union | `IUnionBuilder` | `INamedTypeBuilder` | the type |
 | Enum | `IEnumBuilder` | `IMemberOrNamedTypeBuilder` | the type |
-| Delegate | `IDelegateBuilder` | `IMethodBuilder` | the `Invoke` method of the type |
+| Delegate | `IDelegateBuilder` | `IMethodBuilder` | the declaration, whose shape is a method signature |
 
 Section 2.4 of [`type-facets.md`](type-facets.md) decided that all four builders derive from `INamedTypeBuilder`
 and that the inapplicable inherited operations throw, after the precedent of `IExtensionBlockBuilder`. That
@@ -123,17 +123,20 @@ an aspect has to be able to use it as a type, so the result of introducing an en
 Refusing the operation is therefore an advice validation rule, described in section 3, and not a consequence of the
 hierarchy. The hierarchy decides what the callback that configures the type can do, and nothing more.
 
-### 2.3. A delegate builder is the builder of its `Invoke` method
+### 2.3. A delegate builder derives from `IMethodBuilder`
 
 A delegate is the one kind of this set whose whole structure is one member. A delegate declaration is a method
 signature with the `delegate` keyword in front of it, and `IDelegateFacet` says the same thing on the read side:
 it declares `InvokeMethod`, and its `ReturnType` and `Parameters` are that method's.
 
-`IDelegateBuilder` therefore derives from `IMethodBuilder` and is the builder of the `Invoke` method. The
-obstacle of section 2.1 does not arise, because the declaring type of that method is the delegate, and a delegate
-always has one. What belongs to the type, which is its name, its accessibility, its custom attributes and its type
-parameters, is reached through `DeclaringType`, narrowed to `INamedTypeBuilder`.
-[`introducing-delegates.md`](introducing-delegates.md) carries the design and the cost.
+`IDelegateBuilder` therefore derives from `IMethodBuilder` and declares no member of its own. The obstacle of
+section 2.1 does not arise, because `IMember.DeclaringType` reports the delegate type, and a delegate always has
+one. The inherited members that describe a declaration rather than a signature, which are `Name`, `Accessibility`,
+`AddAttribute` and `AddTypeParameter`, describe the delegate, because the `Invoke` method has no choice about any
+of them: the language names it `Invoke`, makes it public, gives it no attribute and forbids it to be generic. A
+setter that would otherwise be refused as invalid therefore carries one meaning and not two, and an aspect
+configures the delegate on one object. [`introducing-delegates.md`](introducing-delegates.md) carries the design,
+the alternatives and the one residue.
 
 ### 2.4. The restriction is reduced and not removed
 
@@ -148,10 +151,12 @@ interfaces, `PrimaryConstructor`, `ExtensionBlocks`, `MakeGenericInstance` and t
 is approximately thirty members against the four that remain.
 
 The delegate trades differently, because its base is chosen for what it carries rather than for what it omits.
-`IMethodBuilder` gives the return type, the return parameter and the parameter operations, which are the whole of
-what an author configures on a delegate, and the members that throw are the ones that describe a method as a member
-of a type: its name, its accessibility, its own type parameters, its attributes and its modifiers. Section 4 of
-[`introducing-delegates.md`](introducing-delegates.md) lists them, and the count is close to the enum's.
+`IMethodBuilder` gives the return type, the return parameter and the parameter operations, which are the signature,
+and the name, the accessibility, the attributes and the type parameters, which are the declaration. That is
+everything an author configures on a delegate. What throws is the set of modifiers that a delegate cannot carry,
+which is `IsStatic`, `IsSealed`, `IsAbstract`, `IsPartial`, `IsVirtual`, `IsExtern`, `IsReadOnly` and
+`OperatorKind`. Section 4 of [`introducing-delegates.md`](introducing-delegates.md) lists them, and the count is
+close to the enum's.
 
 ### 2.5. The consequence: neither builder is a type
 
@@ -164,10 +169,10 @@ var result = builder.IntroduceEnum( "Color" );
 var enumType = result.Declaration;
 ```
 
-`IDelegateBuilder.DeclaringType` is an `INamedTypeBuilder` and is therefore an `INamedType`, so it is a type in the
-sense of the compiler. It is not the finished delegate: it is the type under construction, whose members are not
-resolvable, so an aspect does not use it as the type of a declaration either. The result of the advice is the one
-object that is safe to use for that.
+`IDelegateBuilder.DeclaringType` reports the delegate type and is read-only, so it is an `INamedType` and is a
+type in the sense of the compiler. It is not the finished delegate: it is the type under construction, whose
+members are not resolvable, so an aspect does not use it as the type of a declaration either, and it has no reason
+to reach it at all. The result of the advice is the one object that is safe to use for that.
 
 This costs nothing in the implementation. The engine class behind a type builder derives from `NamedTypeBuilder`
 and implements `INamedTypeImpl`, because the compilation model requires it, so a builder nested inside it resolves
@@ -275,9 +280,8 @@ that an aspect supplies:
 The hierarchy of section 2 bounds that risk rather than leaving it open. `IEnumBuilder` and `IDelegateBuilder` do
 not derive from `INamedType`, so they declare no `Facets` member at all and an aspect cannot pass either of them
 where a type is expected. A delegate builder can therefore never be the type of an event. The builders that remain
-reachable as a type are those of a class, a struct, a record and a union, to which
-`IDelegateBuilder.DeclaringType` adds the delegate type under construction, and `Facets.Delegate` is meaningless on
-all of them while they are being built.
+reachable as a type are those of a class, a struct, a record and a union, and `Facets.Delegate` is meaningless on
+all four.
 
 ### 5.2. An introduced type reports its facet
 

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -186,20 +186,57 @@ Every new builder follows the freeze pattern that [`../compilation-model.md`](..
 mutable builder is handed to the aspect, is frozen at the end of the advice, and is snapshotted into an immutable
 builder data object that the compilation model stores.
 
-## 5. What an introduced type reports for `Facets`
+## 5. Facets, on a builder and on an introduced type
 
-Implementation guideline 5 of [`type-facets.md`](type-facets.md) states that the implementations of `INamedType`
-that back a builder return the empty facet collection rather than throwing. Each of the five documents replaces
-that guideline for its own kind: a type introduced as an enum reports an `IEnumFacet`, a type introduced as a
-record reports an `IRecordFacet`, and so on. The guideline continues to hold for a class and an interface, which
-have no facet.
+A builder and an introduced type answer `Facets` differently, and the difference is the subject of this section.
 
-Two sites implement it, and both carry a comment that names these stories:
+### 5.1. A builder throws
 
-- `Metalama.Framework.Engine/CodeModel/Introductions/Builders/NamedTypeBuilder.cs:336`, for the type under
-  construction.
-- `Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs:182`, for the introduced
-  type as the compilation model exposes it.
+`INamedType.Facets` throws a `NotSupportedException` on a type builder. A builder describes a type that is being
+constructed, whose members are not resolvable, so it has no structure to report and reporting an empty structure
+would be a false answer rather than an incomplete one. An aspect that reads the facet of a builder has made a
+mistake, and the exception says so at the place the mistake was made.
+
+This reverses implementation guideline 5 of [`type-facets.md`](type-facets.md), which states that the
+implementations of `INamedType` that back a builder return the empty collection rather than throwing. That
+guideline is superseded, and the one site that implements it,
+`Metalama.Framework.Engine/CodeModel/Introductions/Builders/NamedTypeBuilder.cs:336`, changes with it. The
+precedent for throwing is on the same class: `ExtensionBlocks`, a few lines above, already throws, and the comment
+that currently sits above `Facets` exists only to say that `Facets` does not follow it.
+
+The flags do not throw, and that distinction is what makes the change safe. `IsDelegate`, `IsEnum`, `IsRecord` and
+`IsUnion` are Boolean properties that a builder answers from its own kind without allocating anything, and section
+4.4 of [`type-facets.md`](type-facets.md) declares them for exactly this reason. A caller that asks what kind a type
+is keeps working on a builder; only a caller that asks for the structure meets the exception.
+
+Three readers have to be checked before the exception is introduced, because each of them reads `Facets` on a type
+that an aspect supplies:
+
+- `Metalama.Framework/Eligibility/EligibilityRuleFactory.cs:101` and `:105`, which read
+  `e.Type.Facets.Delegate?.ReturnType` and `e.Type.Facets.Delegate?.Parameters` for the eligibility of
+  `AdviceKind.OverrideEventInvoke`. These must test `e.Type.IsDelegate` first, so that a type that is not a
+  delegate reports that the advice is not eligible, as it does today, instead of throwing. Turning a clean
+  ineligibility into an exception would be a regression, and it is the failure that guideline 5 was written to
+  prevent.
+- `Metalama.Framework.Engine/CodeModel/Introductions/Builders/EventBuilder.cs:62`, which defines `Signature` as
+  `this.Type.Facets.Delegate.AssertNotNull().InvokeMethod`. The type of an event is supplied by the aspect through
+  `IEventBuilder.Type`.
+
+The hierarchy of section 2 bounds that risk rather than leaving it open. `IEnumBuilder` and `IDelegateBuilder` do
+not derive from `INamedType`, so they declare no `Facets` member at all and an aspect cannot pass either of them
+where a type is expected. A delegate builder can therefore never be the type of an event. The builders that remain
+reachable as a type are those of a class, a struct, a record and a union, and `Facets.Delegate` is meaningless on
+all four.
+
+### 5.2. An introduced type reports its facet
+
+`IntroducedNamedType`, which is how the compilation model exposes a type after the transformation is applied,
+reports the facet of its kind: a type introduced as an enum reports an `IEnumFacet`, a type introduced as a record
+reports an `IRecordFacet`, and so on. Each of the five documents states the mapping member by member. A type
+introduced as a class or an interface reports the empty collection, because those kinds have no facet.
+
+The site is `Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs:182`, whose
+comment already says that the type introduction stories add the facet of the kind that each of them introduces.
 
 The facet of an introduced type is built from the builder data and not from a Roslyn symbol, because the
 introduction pipeline never re-reads the final model from Roslyn. Every member that a facet exposes must therefore
@@ -207,6 +244,43 @@ exist as a builder. That is the reason the record is the largest of the five: an
 that the compiler synthesizes, and each of them has to be materialized. The precedent is
 `IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which already materializes the implicit
 constructor of an introduced class for exactly this reason.
+
+### 5.3. The facets are tested by unit tests and not by aspect tests
+
+An aspect test compares generated code against an expected file. It proves that the right declaration was emitted,
+and it cannot observe the code model that the pipeline built on the way there, so it cannot assert that an
+introduced enum reports an `IEnumFacet` whose `Members` are in declaration order. Each of the five kinds therefore
+carries unit tests for its facet, and the aspect tests of the same issue cover the generated syntax alone.
+
+The suite is `Metalama.Framework.Tests.UnitTests/CodeModel/TypeFacetTests.cs` for the shared behaviour, beside
+`EnumFacetTests.cs`, `RecordFacetTests.cs` and `UnionTypeTests.cs`, which the facet issues of section 8.2 added.
+The pattern for reaching an introduced declaration from a unit test already exists in
+`CodeModelUpdateTests.IntroducedTypes.cs` and in `TypeFacetTests.cs` itself:
+
+```csharp
+using var testContext = this.CreateTestContext();
+
+var compilation = testContext.CreateCompilationModel( "" ).CreateMutableClone();
+
+var builder = new NamedTypeBuilder( null!, compilation.GlobalNamespace, "IntroducedType", TypeKind.Class );
+builder.Freeze();
+compilation.AddTransformation( builder.CreateTransformation() );
+
+var introducedType = compilation.Types.OfName( "IntroducedType" ).Single();
+```
+
+Each kind adds tests of three shapes:
+
+1. Reading `Facets` on the builder throws a `NotSupportedException`, while `IsEnum`, `IsDelegate`, `IsRecord` and
+   `IsUnion` answer on the builder without throwing.
+2. The introduced type reports the facet of its kind, and every member of that facet holds the value that the
+   builder was given. This is the table that each document states in its own section 5.
+3. The introduced type and the equivalent type read from source report the same thing, which is the assertion that
+   catches a facet built from builder data that diverges from one built from a symbol.
+
+The existing test `TypeFacetTests.FacetsOfBuilderDoNotThrow` pins the behaviour that section 5.1 reverses, and its
+documentation comment cites guideline 5. It is replaced rather than deleted: the same test becomes the one that
+asserts the exception, and it keeps its assertions that the flags do not throw.
 
 ## 6. Order of implementation
 

--- a/Metalama.Framework/docs/future/introducing-types.md
+++ b/Metalama.Framework/docs/future/introducing-types.md
@@ -1,0 +1,313 @@
+# Introducing types
+
+This document proposes the addition of five capabilities to the advice interface: introducing a struct, an enum, a
+delegate, a record and a union. It carries the decisions that the five are subject to together, and the design of
+each kind is a document of its own, listed in section 7. It is a design proposal. Nothing described here is
+implemented.
+
+The companion document is [`type-facets.md`](type-facets.md), which designs the read side of the same five kinds.
+Section 2.4 of that document decided the shape of the builder interfaces, and section 2 below revises that decision
+for the enum and the delegate.
+
+## 1. What can be introduced today
+
+An aspect can introduce a class, an interface and an extension block. It can introduce nothing else, and the four
+places that refuse the other kinds are the following.
+
+The transformation that emits the declaration switches on three kinds and throws for the rest:
+
+```csharp
+// Metalama.Framework.Engine/AdviceImpl/Introduction/IntroduceNamedTypeTransformation.cs:61
+var type =
+    (this.BuilderData.TypeKind switch
+    {
+        TypeKind.Class => (TypeDeclarationSyntax) ClassDeclaration( /* ... */ ),
+        TypeKind.Struct => StructDeclaration( /* ... */ ),
+        TypeKind.Interface => InterfaceDeclaration( /* ... */ ),
+        _ => throw new AssertionFailedException( /* unsupported type kind */ )
+    }).NormalizeWhitespaceIfNecessary( context.SyntaxGenerationContext );
+```
+
+The `TypeKind.Struct` arm is reachable code that nothing reaches, because no public advice method constructs a
+builder of that kind. `AdviceFactory.IntroduceClass` passes `TypeKind.Class` and `AdviceFactory.IntroduceInterface`
+passes `TypeKind.Interface`, and there is no third caller.
+
+The builder refuses the other kinds before the transformation is reached:
+
+```csharp
+// Metalama.Framework.Engine/CodeModel/Introductions/Builders/NamedTypeBuilder.cs:186
+Invariant.Assert( typeKind is TypeKind.Class or TypeKind.Struct or TypeKind.Interface or TypeKind.Extension );
+Invariant.Assert( !isRecord ); // Introducing records is not yet supported.
+```
+
+The modifier emission has no token for the kinds that need one.
+`ModifierHelper.GetTypeSyntaxModifierList`, at line 198 of the same file, emits the accessibility, `static`, `new`,
+`closed`, `abstract`, `sealed`, `partial` and `unsafe`, and nothing else. The `record` modifier and the `enum` and
+`delegate` keywords have no source there.
+
+The introduced type reports no facet:
+
+```csharp
+// Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs:182
+public ITypeFacetCollection Facets => TypeFacetCollection.Empty;
+```
+
+The comment above that line states that the type introduction stories add the facet of the kind that each of them
+introduces, and section 5 below is that statement made precise.
+
+What a user sees is the note in the conceptual documentation, in
+`Metalama.Documentation/content/conceptual/aspects/advising/introducing-types.md`, which says that support for
+structs, delegates and enums will be added in a future release.
+
+## 2. The builder hierarchy, and where it splits
+
+A record, a struct and a union declare members that an aspect can introduce. An enum and a delegate do not: the
+members of an enum are its own members and nothing else may be added, and a delegate declaration has no member
+list at all. The builders therefore derive from two different bases.
+
+| Kind | Builder | Base |
+| --- | --- | --- |
+| Struct | none, `INamedTypeBuilder` is used directly | `INamedTypeBuilder` |
+| Record | `IRecordBuilder` | `INamedTypeBuilder` |
+| Union | `IUnionBuilder` | `INamedTypeBuilder` |
+| Enum | `IEnumBuilder` | `IMemberOrNamedTypeBuilder` |
+| Delegate | `IDelegateBuilder` | `IMemberOrNamedTypeBuilder` |
+
+Section 2.4 of [`type-facets.md`](type-facets.md) decided that all four builders derive from `INamedTypeBuilder`
+and that the inapplicable inherited operations throw, after the precedent of `IExtensionBlockBuilder`. That
+decision is kept for the record and the union and is revised for the enum and the delegate. Three findings support
+the revision, and each of them answers an alternative that a reader is likely to propose.
+
+### 2.1. `IMemberBuilder` cannot serve
+
+The first proposal a reader makes is that a builder for a kind without members should derive from `IMemberBuilder`
+rather than from `INamedTypeBuilder`. It cannot, because `IMemberBuilder` derives from `IMember`, which narrows the
+declaring type to a value that is not nullable:
+
+```csharp
+// Metalama.Framework/Code/IMemberOrNamedType.cs:49
+INamedType? DeclaringType { get; }
+
+// Metalama.Framework/Code/IMember.cs:57
+new INamedType DeclaringType { get; }
+```
+
+An enum or a delegate declared in a namespace has no declaring type, so it cannot satisfy the second declaration.
+`IMemberBuilder` would also contribute `IsVirtual` and `IsExtern`, which apply to a type less than the members it
+would remove.
+
+`IMemberOrNamedTypeBuilder` is the common base of `IMemberBuilder` and `INamedTypeBuilder`, it keeps the nullable
+declaring type, and it is the base this document takes.
+
+### 2.2. The base does not decide whether members can be introduced
+
+The second proposal is that deriving from a base without member operations is what prevents an aspect from adding a
+member to an introduced enum. It is not, because the member operations are not on the builder. They are extension
+methods on the adviser:
+
+```csharp
+// Metalama.Framework/Aspects/AdviserExtensions.cs:106
+public static IIntroductionAdviceResult<IMethod> IntroduceMethod(
+    this IAdviser<INamedType> adviser, /* ... */ )
+```
+
+`IIntroductionAdviceResult<T>` derives from `IAdviser<T>`, which is what makes
+`IntroduceClass( "Foo" ).IntroduceMethod( "Bar" )` compile. An introduced enum has to be an `INamedType`, because
+an aspect has to be able to use it as a type, so the result of introducing an enum is an
+`IIntroductionAdviceResult<INamedType>` and `IntroduceMethod` remains callable on it whatever base the builder has.
+
+Refusing the operation is therefore an advice validation rule, described in section 3, and not a consequence of the
+hierarchy. The hierarchy decides what the callback that configures the type can do, and nothing more.
+
+### 2.3. The restriction is reduced and not removed
+
+`IMemberOrNamedTypeBuilder` declares six settable members: `Accessibility`, `Name`, `IsStatic`, `IsSealed`,
+`IsAbstract` and `IsPartial`. Two of them apply to an enum and to a delegate, and four do not, so four setters
+still throw. The choice does not produce a base on which every inherited member is valid, and no base in the
+hierarchy would.
+
+What it removes is larger than what it leaves. Compared with `INamedTypeBuilder`, the enum builder and the delegate
+builder no longer inherit `BaseType`, `AddTypeParameter`, `IsClosed`, and the whole of `INamedType`, which is the
+member collections, the implemented interfaces, `PrimaryConstructor`, `ExtensionBlocks`, `MakeGenericInstance` and
+the type construction methods. That is approximately thirty members against the four that remain.
+
+### 2.4. The consequence: the builder is not a type
+
+`INamedTypeBuilder` derives from `INamedType`, and `IMemberOrNamedTypeBuilder` does not. An `IEnumBuilder` and an
+`IDelegateBuilder` are therefore not types, and neither can be passed where an `IType` is expected. An aspect that
+needs the introduced type reads it from the result of the advice:
+
+```csharp
+var result = builder.IntroduceEnum( "Color" );
+var enumType = result.Declaration;
+```
+
+This costs nothing in the implementation. The engine class still derives from `NamedTypeBuilder` and still
+implements `INamedTypeImpl`, because the compilation model requires it, so a builder nested inside it, such as the
+`Invoke` method builder of a delegate, resolves a declaring type that is not null in the ordinary way. The public
+interface is a narrowed view of an object that is a named type internally.
+
+## 3. Member introduction is refused by advice validation
+
+Section 2.2 establishes that `IntroduceMethod`, `IntroduceField`, `IntroduceProperty`, `IntroduceEvent`,
+`IntroduceConstructor`, `IntroduceIndexer` and `ImplementInterface` remain callable on the result of introducing an
+enum or a delegate. Each of them reports an error when the target type is one of those two kinds.
+
+The diagnostic states the kind of the target, because an aspect author who reaches this has usually introduced the
+wrong kind of type rather than misunderstood the language. The rule belongs with the other target validations of
+`AdviceFactory`, beside `ValidateNotExtensionBlock`, which refuses the same operations on an extension block for
+the same reason.
+
+An enum does declare members, and they are nevertheless covered by the same rule. They are added through
+`IEnumBuilder` while the type is being constructed, and not through the adviser afterwards. The enum document
+states why.
+
+## 4. The emission machinery that the five kinds share
+
+Four changes are common to the five documents, and the struct document owns them because it is the first of the
+five to be implemented.
+
+An enum declaration and a delegate declaration are not type declarations in the Roslyn syntax model.
+`EnumDeclarationSyntax` and `DelegateDeclarationSyntax` derive from `BaseTypeDeclarationSyntax` and from
+`MemberDeclarationSyntax` respectively, and neither derives from `TypeDeclarationSyntax`. The cast on the first arm
+of the switch quoted in section 1, and the type of the local variable it produces, therefore widen to
+`MemberDeclarationSyntax`. The code that wraps the declaration in a namespace already accepts that wider type.
+
+`ModifierHelper.GetTypeSyntaxModifierList` gains the `record` modifier. The `enum` and `delegate` keywords are not
+modifiers and belong to the syntax factory call of their arm.
+
+The design-time generator produces the partial type for the editor, and
+`DesignTimeSyntaxTreeGenerator.CreatePartialType` already has arms for a record class and a record struct. Those
+arms serve the reading of a type that the user wrote. Introducing a type of a new kind requires the same arms on
+the introduction path, and the record document states which of the two paths each arm serves, because the two are
+easy to mistake for each other.
+
+Every new builder follows the freeze pattern that [`../compilation-model.md`](../compilation-model.md) describes: a
+mutable builder is handed to the aspect, is frozen at the end of the advice, and is snapshotted into an immutable
+builder data object that the compilation model stores.
+
+## 5. What an introduced type reports for `Facets`
+
+Implementation guideline 5 of [`type-facets.md`](type-facets.md) states that the implementations of `INamedType`
+that back a builder return the empty facet collection rather than throwing. Each of the five documents replaces
+that guideline for its own kind: a type introduced as an enum reports an `IEnumFacet`, a type introduced as a
+record reports an `IRecordFacet`, and so on. The guideline continues to hold for a class and an interface, which
+have no facet.
+
+Two sites implement it, and both carry a comment that names these stories:
+
+- `Metalama.Framework.Engine/CodeModel/Introductions/Builders/NamedTypeBuilder.cs:336`, for the type under
+  construction.
+- `Metalama.Framework.Engine/CodeModel/Introductions/Introduced/IntroducedNamedType.cs:182`, for the introduced
+  type as the compilation model exposes it.
+
+The facet of an introduced type is built from the builder data and not from a Roslyn symbol, because the
+introduction pipeline never re-reads the final model from Roslyn. Every member that a facet exposes must therefore
+exist as a builder. That is the reason the record is the largest of the five: an `IRecordFacet` names six members
+that the compiler synthesizes, and each of them has to be materialized. The precedent is
+`IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded`, which already materializes the implicit
+constructor of an introduced class for exactly this reason.
+
+## 6. Order of implementation
+
+This table supersedes section 6.2 of [`type-facets.md`](type-facets.md), which does not include the union and which
+records the superseded hierarchy decision.
+
+| Issue | Content | Blocked by |
+| --- | --- | --- |
+| [#869](https://github.com/metalama/Metalama/issues/869) | Introduce a struct. It adds no builder interface, because a struct has no facet, and it carries the machinery of section 4 that the other four consume. | nothing |
+| [#866](https://github.com/metalama/Metalama/issues/866) | Introduce an enum, with `IEnumBuilder`. | #869 |
+| [#865](https://github.com/metalama/Metalama/issues/865) | Introduce a delegate, with `IDelegateBuilder`. | #869 |
+| [#867](https://github.com/metalama/Metalama/issues/867) | Introduce a record class and a record struct, with `IRecordBuilder`. | #869 |
+| [#1951](https://github.com/metalama/Metalama/issues/1951) | Introduce a union, and a case on the attribute form, with `IUnionBuilder`. This is user story S-29. | #869, [#1941](https://github.com/metalama/Metalama/issues/1941), [#1945](https://github.com/metalama/Metalama/issues/1945) |
+| [#1952](https://github.com/metalama/Metalama/issues/1952) | Introduce a case into a `union` declaration. This is user story S-30, and it is filed only if question Q1 of [`OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) chooses to ship both authoring forms. | [#1951](https://github.com/metalama/Metalama/issues/1951) |
+
+The struct is first because it carries the machinery, and because it is the only one of the five whose design adds
+no public interface, so it exercises the emission path alone. The enum and the delegate are independent of each
+other and either may follow. The record is the last of the four issues, because it is the one that materializes
+synthesized members.
+
+The facet issues of section 6.1 of [`type-facets.md`](type-facets.md) are delivered, so no document of this set is
+blocked by one.
+
+## 7. The documents
+
+| Document | Kind | Issue |
+| --- | --- | --- |
+| [`introducing-structs.md`](introducing-structs.md) | Struct | [#869](https://github.com/metalama/Metalama/issues/869) |
+| [`introducing-enums.md`](introducing-enums.md) | Enum | [#866](https://github.com/metalama/Metalama/issues/866) |
+| [`introducing-delegates.md`](introducing-delegates.md) | Delegate | [#865](https://github.com/metalama/Metalama/issues/865) |
+| [`introducing-records.md`](introducing-records.md) | Record class and record struct | [#867](https://github.com/metalama/Metalama/issues/867) |
+| [`introducing-unions.md`](introducing-unions.md) | Union | [#1951](https://github.com/metalama/Metalama/issues/1951), [#1952](https://github.com/metalama/Metalama/issues/1952) |
+
+## 8. The issues
+
+### 8.1. The issues this set of documents designs
+
+| Issue | Title | State |
+| --- | --- | --- |
+| [#869](https://github.com/metalama/Metalama/issues/869) | Type introduction: introduce struct | open |
+| [#866](https://github.com/metalama/Metalama/issues/866) | Type introduction: introduce enum | open |
+| [#865](https://github.com/metalama/Metalama/issues/865) | Type introduction: introduce delegate | open |
+| [#867](https://github.com/metalama/Metalama/issues/867) | Type introduction: introduce record struct/class | open |
+| [#1951](https://github.com/metalama/Metalama/issues/1951) | C# 15 unions: introducing a union and a case on the attribute form. User story S-29. | open |
+| [#1952](https://github.com/metalama/Metalama/issues/1952) | C# 15 unions: introducing a case into a `union` declaration. User story S-30. | open |
+
+The first four are imported issues that carry no body, and this set of documents is the design they lack. The last
+two are user stories whose body states the capability, the scope and the acceptance criteria, and which state no
+application programming interface because section 11 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) forbids
+a story from doing so.
+
+### 8.2. The issues that delivered the read side
+
+Every one of these is closed, and each delivered the facet that the matching document mirrors. No document of this
+set is blocked by any of them.
+
+| Issue | Title | Milestone |
+| --- | --- | --- |
+| [#1995](https://github.com/metalama/Metalama/issues/1995) | Code model: type facets and the delegate facet | 2027.0.2-preview |
+| [#1996](https://github.com/metalama/Metalama/issues/1996) | Code model: the enum facet | 2027.0.2-preview |
+| [#1997](https://github.com/metalama/Metalama/issues/1997) | Code model: the record facet | 2027.0.2-preview |
+| [#1941](https://github.com/metalama/Metalama/issues/1941) | C# 15 unions: code model, which delivered the union facet. User story S-18-1. | 2027.0.2-preview |
+
+### 8.3. The issues that are precedents
+
+| Issue | Why it matters |
+| --- | --- |
+| [#1950](https://github.com/metalama/Metalama/issues/1950) | C# 15 closed classes: introducing. User story S-28, closed. It is the most recent change to `INamedTypeBuilder` and it is the shape that a pull request of this set should resemble: a settable property, its validation, its storage in the builder data, its exposure on the introduced type and its token in `ModifierHelper`. |
+| [#1869](https://github.com/metalama/Metalama/issues/1869) | Cannot introduce a partial class, closed. It added `IsPartial` to the named type builder, so the member set that these documents extend changed in this release. |
+| [#1343](https://github.com/metalama/Metalama/issues/1343) | Support `meta.Proceed()` for compiler-synthesized record members, closed. It materializes the synthesized members of a record read from source, which [`introducing-records.md`](introducing-records.md) section 7.2 asks whether an introduced record can reuse. |
+| [#1622](https://github.com/metalama/Metalama/issues/1622) | Introduced constructor on introduced type missing at design time, closed. Story S-29 verifies its design-time claim against this fix rather than assuming it. |
+
+### 8.4. The rest of the type introduction backlog
+
+These issues are open, they are not designed by this set of documents, and each of them touches the same area. They
+are named so that a reader who implements one of the five knows what is adjacent to it.
+
+| Issue | Title | Relation |
+| --- | --- | --- |
+| [#868](https://github.com/metalama/Metalama/issues/868) | Type introduction: introduce primary constructor | [`introducing-records.md`](introducing-records.md) materializes the primary constructor of a record, which is part of this issue. The rest of it, which is a primary constructor on any type, stays open and is the subject of the comment `// TODO: Primary constructor handling.` on `INamedTypeBuilder`. |
+| [#862](https://github.com/metalama/Metalama/issues/862) | Type introduction: introduced attribute types | An introduced class that derives from `System.Attribute`. Independent of the five kinds. |
+| [#863](https://github.com/metalama/Metalama/issues/863) | Type introduction: reflection wrappers and syntax serialization | An introduced type of a new kind reaches the same reflection wrappers, so this issue may gain work from each of the five. |
+| [#861](https://github.com/metalama/Metalama/issues/861) | Type introduction: derived fabric on introduced type | Independent. |
+| [#860](https://github.com/metalama/Metalama/issues/860) | Type introductions: awaitable and iterable types based on introduced types | Independent. |
+| [#912](https://github.com/metalama/Metalama/issues/912) | Introductions: hidden visibility | Independent. |
+| [#1998](https://github.com/metalama/Metalama/issues/1998) | Code model: move the tuple type interfaces to the type namespace and add a tuple flag | A tuple is not declared and is not introduced, so it produces no document here. |
+| [#1999](https://github.com/metalama/Metalama/issues/1999) | Code model: an invoker on `IMethodBase` | It would let a consumer invoke the creation member of a union case, which [`introducing-unions.md`](introducing-unions.md) needs no more than the reader does. |
+| [#1954](https://github.com/metalama/Metalama/issues/1954) | Documentation: internal architecture documents. User story S-26. | It names S-28, S-29 and S-30 as blockers, so the sections it writes about an introduction interface follow the stories of this set. |
+
+The conceptual documentation of `metalama/Metalama.Documentation` carries a note that support for structs,
+delegates and enums will be added in a future release. Whichever of the five ships last removes it, and user story
+S-27, which is the conceptual documentation of C# 15, names S-29 among its blockers.
+
+## 9. References
+
+- [`type-facets.md`](type-facets.md), sections 2.4, 5 and 6.2.
+- [`../compilation-model.md`](../compilation-model.md), the builder and builder data freeze pattern.
+- [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 4 and 11.
+- [`../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md`](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md)
+  and [`../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md`](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md).
+- [`../2027.0/analysis-reports/10-introducing-closed-and-unions.md`](../2027.0/analysis-reports/10-introducing-closed-and-unions.md),
+  the audit of what can be introduced today.
+
+— Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/introducing-unions.md
+++ b/Metalama.Framework/docs/future/introducing-unions.md
@@ -260,6 +260,7 @@ it is the one that is most often misread.
 | `IsAbstract`, `IsSealed`, `IsStatic` | The setter throws a `NotSupportedException`. | Valid when the carrying type is a class, and refused otherwise, as for any struct. |
 | `IsReadOnly`, `IsRef` | The setter throws a `NotSupportedException`. | As for any struct or class. |
 | `IsClosed` | The setter throws an `InvalidOperationException`, as it does for any type that is not a class. | Valid when the carrying type is a class. |
+| `Facets` | The getter throws a `NotSupportedException`, as it does on every builder. | Same. |
 
 Member introduction through the adviser is valid on a union, and is restricted rather than refused. An instance
 field, an automatic property and a field-like event introduced into a union declaration produce the compiler error
@@ -269,8 +270,13 @@ is a further rule.
 
 ## 5. What the facet of the introduced union reports
 
-The introduced type reports an `IUnionFacet` rather than the empty collection, which replaces implementation
-guideline 5 of [`type-facets.md`](type-facets.md) for this kind.
+A union builder throws a `NotSupportedException` from `Facets`, which section 5.1 of
+[`introducing-types.md`](introducing-types.md) states for every builder. `IUnionBuilder` derives from `INamedType`
+and therefore declares the member, so the exception is reached through the public interface here. The cases that
+have been added so far are read from `IUnionBuilder.Cases`, which is the member that exists for that purpose, and
+the kind of a builder is read from `IsUnion`, which does not throw.
+
+The introduced type reports an `IUnionFacet`.
 
 | `IUnionFacet` member | Source |
 | --- | --- |
@@ -287,6 +293,13 @@ This is the substance of the story, and section 6.2 states why it is not free.
 `INamedType.IsUnion` reports `true`. `IType.TypeKind` reports `TypeKind.Struct` for a union declaration and the
 kind of the carrying type for the attribute form, because a union is not a kind of its own in the code model, which
 section 4.3 of [`type-facets.md`](type-facets.md) decides.
+
+The facet is tested by unit tests and not by aspect tests, for the reason that section 5.3 of
+[`introducing-types.md`](introducing-types.md) gives. The synthesized members of a union are in the same position
+as those of a record: the compiler creates them, an aspect test does not show them, and only a unit test can assert
+that they exist in the code model. The tests belong beside `UnionTypeTests.cs`, which issue
+[#1941](https://github.com/metalama/Metalama/issues/1941) added, and they cover both authoring forms, because the
+two differ in what the creation member of a case is.
 
 ## 6. Decisions
 

--- a/Metalama.Framework/docs/future/introducing-unions.md
+++ b/Metalama.Framework/docs/future/introducing-unions.md
@@ -1,0 +1,385 @@
+# Introducing a union
+
+This document designs the introduction of a union of C# 15, which is issues
+[#1951](https://github.com/metalama/Metalama/issues/1951) and
+[#1952](https://github.com/metalama/Metalama/issues/1952). It is a design proposal. Nothing described here is
+implemented.
+
+The two issues are user stories S-29 and S-30 of the 2027.0 release, and the capability, the scope and the
+acceptance criteria are stated there rather than here:
+
+| Issue | Story | Content |
+| --- | --- | --- |
+| [#1951](https://github.com/metalama/Metalama/issues/1951) | [S-29](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md) | Introducing a union type, and introducing a case into a type carrying the union attribute. |
+| [#1952](https://github.com/metalama/Metalama/issues/1952) | [S-30](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md) | Introducing a case into a type declared with the `union` keyword. Filed only if question Q1 of [`OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) chooses to ship both forms. |
+
+Section 11 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) rules that a story states no application
+programming interface, so the shape is designed here and the two stories keep their authority over the scope. This
+document does not restate them.
+
+The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md). A union declares members that an
+aspect can introduce, within the limits that section 4 states, so `IUnionBuilder` derives from `INamedTypeBuilder`
+and section 2 of that document does not revise it.
+
+## 1. What the aspect author writes
+
+A union declaration names its cases in its header:
+
+```csharp
+public class GenerateResultAttribute : TypeAspect
+{
+    public override void BuildAspect( IAspectBuilder<INamedType> builder )
+    {
+        builder.IntroduceUnion(
+            "Result",
+            UnionKind.Declaration,
+            buildUnion: u =>
+            {
+                u.Accessibility = Accessibility.Public;
+                u.AddCase( TypeFactory.GetType( typeof(int) ) );
+                u.AddCase( TypeFactory.GetType( typeof(string) ) );
+                u.AddCase( builder.Target );
+            } );
+    }
+}
+```
+
+The attribute form is a class or a struct carrying `UnionAttribute`, and it accepts members that a union
+declaration refuses:
+
+```csharp
+builder.IntroduceUnion(
+    "Result",
+    UnionKind.Attribute,
+    buildUnion: u =>
+    {
+        u.Accessibility = Accessibility.Public;
+        u.AddCase( TypeFactory.GetType( typeof(int) ) );
+        u.AddCase( TypeFactory.GetType( typeof(string) ) );
+    } );
+```
+
+Adding a case to a union that already exists is the second half of the work, and it is an advice on that type
+rather than a type introduction:
+
+```csharp
+builder.With( existingUnion ).IntroduceUnionCase( TypeFactory.GetType( typeof(decimal) ) );
+```
+
+## 2. What Metalama produces
+
+```csharp
+public union Result( int, string, TargetType );
+```
+
+```csharp
+[Union]
+public partial struct Result
+{
+    public Result( int value ) { /* ... */ }
+    public Result( string value ) { /* ... */ }
+    public object Value { get; }
+}
+```
+
+## 3. The interfaces
+
+### 3.1. `IUnionBuilder`
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IUnionBuilder.cs
+namespace Metalama.Framework.Code.DeclarationBuilders;
+
+/// <summary>
+/// Allows to complete the construction of a union that has been created by an advice. One interface serves a union
+/// declaration and the attribute form.
+/// </summary>
+/// <remarks>
+/// <para>
+/// The authoring form is chosen when the advice is called and is reported by <see cref="UnionKind"/>. The language
+/// applies the restrictions on the members of a union to a union declaration only, so the members that this
+/// interface refuses depend on that value. They are listed in the design document.
+/// </para>
+/// <para>
+/// A union requires at least one case, so an advice whose callback adds none reports an error.
+/// </para>
+/// <para>
+/// The members that the compiler synthesizes for a union declaration, which are one constructor per case and the
+/// <c>Value</c> property, are not set through this interface. They are created by the advice and are read through
+/// <see cref="Metalama.Framework.Code.INamedType.Facets"/> on the introduced type.
+/// </para>
+/// </remarks>
+/// <seealso cref="Metalama.Framework.Code.Types.IUnionFacet"/>
+/// <seealso href="@introducing-types"/>
+[InternalImplement]
+public interface IUnionBuilder : INamedTypeBuilder
+{
+    /// <summary>
+    /// Gets the authoring form of the union, which was chosen when the advice was called.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IUnionFacet.UnionKind"/>
+    UnionKind UnionKind { get; }
+
+    /// <summary>
+    /// Gets the cases that have been added so far, in the order in which they were added.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IUnionFacet.Cases"/>
+    IReadOnlyList<IUnionCaseBuilder> Cases { get; }
+
+    /// <summary>
+    /// Adds a case to the union.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The compiler reports the case types of a union as a set, so adding a case whose type is already a case of
+    /// this union throws an <see cref="ArgumentException"/> rather than declaring a second case.
+    /// </para>
+    /// <para>
+    /// The type of a case is an ordinary type declared elsewhere, and the union declares no type itself.
+    /// </para>
+    /// </remarks>
+    /// <param name="caseType">The type of the case.</param>
+    /// <returns>An <see cref="IUnionCaseBuilder"/> that allows you to further build the new case.</returns>
+    IUnionCaseBuilder AddCase( IType caseType );
+
+    /// <summary>
+    /// Adds a case to the union.
+    /// </summary>
+    /// <param name="caseType">The type of the case.</param>
+    /// <returns>An <see cref="IUnionCaseBuilder"/> that allows you to further build the new case.</returns>
+    IUnionCaseBuilder AddCase( Type caseType );
+}
+```
+
+### 3.2. `IUnionCaseBuilder`
+
+```csharp
+// Metalama.Framework/Code/DeclarationBuilders/IUnionCaseBuilder.cs
+namespace Metalama.Framework.Code.DeclarationBuilders;
+
+/// <summary>
+/// Allows to complete the construction of a case of a union that has been created by
+/// <see cref="IUnionBuilder.AddCase(IType)"/> or by the advice that adds a case to an existing union.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This interface is the counterpart of <see cref="Metalama.Framework.Code.Types.IUnionCase"/>, and it is not that
+/// interface. A case that is being built has no creation member yet, because the member is synthesized when the
+/// union is introduced, so an interface that declared
+/// <see cref="Metalama.Framework.Code.Types.IUnionCase.CreationMember"/> could not answer it. The creation member
+/// of an introduced union is read from the facet of the introduced type.
+/// </para>
+/// <para>
+/// Like <see cref="Metalama.Framework.Code.Types.IUnionCase"/>, and unlike every other builder of this namespace,
+/// this interface does not derive from <see cref="IDeclarationBuilder"/>. A case of a union is not a declaration:
+/// it declares no type, and the declaration that carries it is its creation member. The interface therefore
+/// carries no operation to add a custom attribute, because a case of a union takes none.
+/// </para>
+/// </remarks>
+/// <seealso cref="IUnionBuilder.AddCase(IType)"/>
+/// <seealso cref="Metalama.Framework.Code.Types.IUnionCase"/>
+[CompileTime]
+[InternalImplement]
+public interface IUnionCaseBuilder
+{
+    /// <summary>
+    /// Gets the type of the case.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IUnionCase.Type"/>
+    IType Type { get; }
+
+    /// <summary>
+    /// Gets the zero-based index of the case, in the order in which the cases were added.
+    /// </summary>
+    /// <seealso cref="Metalama.Framework.Code.Types.IUnionCase.Index"/>
+    int Index { get; }
+}
+```
+
+### 3.3. The advice methods
+
+```csharp
+// Metalama.Framework/Advising/IAdviceFactory.cs
+/// <summary>
+/// Introduces a new union to the target namespace or type.
+/// </summary>
+/// <param name="targetNamespaceOrType">The namespace or type into which the union must be introduced.</param>
+/// <param name="name">The name of the introduced union.</param>
+/// <param name="unionKind">Whether the union is declared with the <c>union</c> keyword or is a struct carrying the
+///     union attribute. <see cref="UnionKind.None"/> is not accepted, because it reports a union whose authoring
+///     form is not known and is not a form that can be written.</param>
+/// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
+///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
+/// <param name="buildUnion">A callback that configures the introduced union. It must add at least one case,
+///     because the language requires a union to have one.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
+/// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced union.</returns>
+IIntroductionAdviceResult<INamedType> IntroduceUnion(
+    INamespaceOrNamedType targetNamespaceOrType,
+    string name,
+    UnionKind unionKind,
+    OverrideStrategy whenExists = OverrideStrategy.Default,
+    Action<IUnionBuilder>? buildUnion = null );
+
+/// <summary>
+/// Adds a case to a union that already exists.
+/// </summary>
+/// <remarks>
+/// <para>
+/// For a type carrying the union attribute, the case is a constructor, a generated partial part expresses it, and
+/// the editor and the build agree about the result.
+/// </para>
+/// <para>
+/// For a type declared with the <c>union</c> keyword, exactly one part of the type carries the case list, so a
+/// generated partial part cannot add a case and the operation rewrites the part that the user wrote. It therefore
+/// takes effect at build time only, and the editor does not show the added case. A design-time diagnostic reports
+/// that divergence.
+/// </para>
+/// </remarks>
+/// <param name="targetUnion">The union into which the case must be added.</param>
+/// <param name="caseType">The type of the case.</param>
+/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> exposing the added case.</returns>
+IIntroductionAdviceResult<IUnionCase> IntroduceUnionCase( INamedType targetUnion, IType caseType );
+```
+
+The matching extension methods on `AdviserExtensions` follow the pattern of the other four documents:
+`IntroduceUnion` extends `IAdviser<INamespaceOrNamedType>` and `IntroduceUnionCase` extends `IAdviser<INamedType>`.
+
+## 4. The inherited operations that are not valid
+
+The language forbids an instance field, an automatic property and a field-like event in a union declaration, and
+allows all three in the attribute form. `ITypeSymbol.IsUnion` is true for both forms, so every rule states which of
+the two it tests. That condition is required by section 3 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) and
+it is the one that is most often misread.
+
+| Member | Union declaration | Attribute form |
+| --- | --- | --- |
+| `Accessibility`, `Name`, `IsPartial` | Valid. | Valid. |
+| `AddTypeParameter` | Valid. | Valid. |
+| `BaseType` | The setter throws a `NotSupportedException`. A union declaration is a struct. | Valid when the carrying type is a class. |
+| `IsAbstract`, `IsSealed`, `IsStatic` | The setter throws a `NotSupportedException`. | Valid when the carrying type is a class, and refused otherwise, as for any struct. |
+| `IsReadOnly`, `IsRef` | The setter throws a `NotSupportedException`. | As for any struct or class. |
+| `IsClosed` | The setter throws an `InvalidOperationException`, as it does for any type that is not a class. | Valid when the carrying type is a class. |
+
+Member introduction through the adviser is valid on a union, and is restricted rather than refused. An instance
+field, an automatic property and a field-like event introduced into a union declaration produce the compiler error
+CS9373, so the eligibility rules refuse them and report a Metalama diagnostic instead. The same advices are
+accepted on the attribute form. An explicit constructor of a union declaration must chain to a generated one, which
+is a further rule.
+
+## 5. What the facet of the introduced union reports
+
+The introduced type reports an `IUnionFacet` rather than the empty collection, which replaces implementation
+guideline 5 of [`type-facets.md`](type-facets.md) for this kind.
+
+| `IUnionFacet` member | Source |
+| --- | --- |
+| `UnionKind` | `IUnionBuilder.UnionKind`. |
+| `Cases` | One `IUnionCase` per `IUnionCaseBuilder`, in the order in which they were added. |
+| `ValueProperty` | The `Value` property, materialized as a builder. |
+| `FacetKind` | `TypeFacetKind.Union`. |
+| `Type` | The introduced type. |
+
+`IUnionCase.CreationMember` is the member that creates a value of the case, and it is materialized: a constructor
+that the compiler synthesizes for a union declaration, and the single-parameter constructor of the attribute form.
+This is the substance of the story, and section 6.2 states why it is not free.
+
+`INamedType.IsUnion` reports `true`. `IType.TypeKind` reports `TypeKind.Struct` for a union declaration and the
+kind of the carrying type for the attribute form, because a union is not a kind of its own in the code model, which
+section 4.3 of [`type-facets.md`](type-facets.md) decides.
+
+## 6. Decisions
+
+### 6.1. `AddCase` returns a builder and not an `IUnionCase`
+
+Section 2.4 of [`type-facets.md`](type-facets.md) drafts `IUnionCase AddCase( IType caseType );`. This design
+returns an `IUnionCaseBuilder` instead, and the reason is the one that the same section states two paragraphs
+later: a facet describes a type that exists, and a builder describes a type that is being constructed and whose
+members are not yet resolvable.
+
+`IUnionCase` declares `CreationMember`. That member is synthesized when the union is introduced, so a case that is
+still being built cannot answer it, and returning `IUnionCase` from `AddCase` would hand the author an object with
+one property that throws. The draft did not weigh that, because the interface it returned was designed for the
+reader.
+
+The same reasoning produces `IEnumMemberBuilder` in [`introducing-enums.md`](introducing-enums.md), where the
+member that cannot be answered during construction is the field.
+
+### 6.2. The synthesized members are materialized, and that is the risk of the story
+
+The introduction pipeline never re-reads the final model from Roslyn, so the `Value` property and the per-case
+creation members have to exist as builders. Story S-29 identifies the precedent as the introduction of a namespace,
+which registers a builder without injecting syntax, and not as the record materialization of
+[#1343](https://github.com/metalama/Metalama/issues/1343), which does not generalise because a user may not declare
+the synthesized union members at all and there is therefore no override to serve.
+
+S-29 asks for that step to be prototyped first, because whether a member builder with no injected member survives
+the linker injection registry was not verified. This document does not settle it, and it records that the answer
+decides whether the step is one day or three.
+
+### 6.3. One interface serves both authoring forms
+
+The two forms differ in what they refuse rather than in what they offer, which is the table of section 4, and the
+reader has already taken this decision: `IUnionFacet` is one interface with a `UnionKind` property and not two
+interfaces. The reasoning is that of section 6.1 of [`introducing-records.md`](introducing-records.md).
+
+### 6.4. `UnionKind` is reused and `None` is refused
+
+The enumeration exists and is shipped. `UnionKind.None` reports a union whose authoring form is not known, which is
+the case of a union read from a referenced assembly, and it is not a form that can be written. The advice method
+therefore accepts the two writable members and throws an `ArgumentOutOfRangeException` for `None`.
+
+The parameter has no default value, unlike the `RecordKind` parameter of
+[`introducing-records.md`](introducing-records.md), because the two forms differ in what the introduced type
+accepts afterwards and neither is the obvious choice. S-29 delivers the attribute form first, and that is a
+delivery order rather than a default.
+
+## 7. Open questions
+
+### 7.1. Does story S-30 ship at all?
+
+Question Q1 of [`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) chooses between shipping both
+authoring forms and shipping the attribute form alone. `IntroduceUnionCase` on a union declaration works at build
+time only, and the editor cannot show the added case, which needs a design-time diagnostic that reports the
+divergence without repairing it.
+
+The recommendation recorded in the story README is to ship both, taking the attribute form first. If only one form
+fits the release it is the attribute form, and [#1952](https://github.com/metalama/Metalama/issues/1952) is then
+not implemented. The interface above is unchanged either way: the method exists and reports that the operation is
+not supported on a union declaration.
+
+### 7.2. Is `IntroduceUnionCase` the right name and shape?
+
+The method adds a case to a type that already exists, so it is closer to `IntroduceParameter`, which changes the
+signature of a constructor the user wrote, than to the introduction of a declaration. Whether it should be named
+for the case or for the operation on the union is not decided, and neither is whether it should take a callback.
+
+What would settle it is the aspect that S-29 uses as its acceptance test. The precedent that S-29 names for the
+operation is the introduction of a parameter into a partial constructor, delivered for C# 14 in
+metalama/Metalama#1143, and the name of that advice is `IntroduceParameter`.
+
+### 7.3. What does `Cases` report while the union is being built?
+
+`IUnionCaseBuilder.Index` is the position in the order of addition. The compiler reports the case types of a union
+as a set, and `AddCase` refuses a duplicate, so the two orders agree for an introduced union. Whether they agree
+for a union that gains a case through `IntroduceUnionCase`, where the existing cases come from the source and the
+added one does not, is not verified here.
+
+## 8. References
+
+- [`introducing-types.md`](introducing-types.md), sections 2 and 5.
+- [`introducing-records.md`](introducing-records.md), section 6.1, and
+  [`introducing-enums.md`](introducing-enums.md), section 6.1, which take the same decisions for their kinds.
+- [`type-facets.md`](type-facets.md), sections 2.4 and 4.3, the first of which this document revises.
+- [`../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md`](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md)
+  and [`../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md`](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md).
+- [`../2027.0/analysis-reports/11-introducing-unions-design.md`](../2027.0/analysis-reports/11-introducing-unions-design.md),
+  which records the derivation of the case set of the attribute form.
+- [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 3, 4 and 11.
+- `Metalama.Framework/Code/Types/IUnionFacet.cs` and `IUnionCase.cs`, the interfaces this design mirrors.
+- Issues [#1951](https://github.com/metalama/Metalama/issues/1951) and
+  [#1952](https://github.com/metalama/Metalama/issues/1952), and their blockers
+  [#1941](https://github.com/metalama/Metalama/issues/1941) and
+  [#1945](https://github.com/metalama/Metalama/issues/1945).
+
+— Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/introducing-unions.md
+++ b/Metalama.Framework/docs/future/introducing-unions.md
@@ -9,19 +9,27 @@ stated there rather than here. Section 11 of [`../2027.0/DECISIONS.md`](../2027.
 states no application programming interface, so the shape is designed here and the story keeps its authority over
 the scope. This document does not restate it.
 
-The scope is narrower than that story. S-29 carries two halves, which are introducing a whole union and adding a
-case to a union that already exists, and this design delivers the first half only. Section 6.5 states why, and what
-an aspect author does instead. Issue [#1952](https://github.com/metalama/Metalama/issues/1952), user story S-30,
-which carried the second half for a type declared with the `union` keyword, is not implemented, and question Q1 of
+The scope is narrower than that story, in two ways, and the story has to be revised before it is implemented.
+
+S-29 carries two halves, which are introducing a whole union and adding a case to a union that already exists, and
+this design delivers the first half only. Section 6.4 states why, and what an aspect author does instead. Issue
+[#1952](https://github.com/metalama/Metalama/issues/1952), user story S-30, which carried the second half for a
+union declaration, is not implemented either, and question Q1 of
 [`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) is answered by that decision.
+
+S-29 also names the attribute form of a union, which is a class or a struct carrying
+`System.Runtime.CompilerServices.UnionAttribute`. `IntroduceUnion` produces a union written with the `union`
+keyword and no other form, and section 6.3 states why and what an aspect writes instead.
+
+Both narrowings are decisions of this design and not of the story, so the body of
+[#1951](https://github.com/metalama/Metalama/issues/1951) states a scope that this document does not deliver. The
+issue is revised before the work starts.
 
 The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md). A union declares members that an
 aspect can introduce, within the limits that section 4 states, so `IUnionBuilder` derives from `INamedTypeBuilder`
 and section 2 of that document does not revise it.
 
 ## 1. What the aspect author writes
-
-A union declaration names its cases in its header:
 
 ```csharp
 public class GenerateResultAttribute : TypeAspect
@@ -30,8 +38,7 @@ public class GenerateResultAttribute : TypeAspect
     {
         builder.IntroduceUnion(
             "Result",
-            UnionKind.Declaration,
-            buildUnion: u =>
+            u =>
             {
                 u.Accessibility = Accessibility.Public;
                 u.AddCase( typeof(int) );
@@ -42,38 +49,13 @@ public class GenerateResultAttribute : TypeAspect
 }
 ```
 
-The attribute form is a class or a struct carrying `UnionAttribute`, and it accepts members that a union
-declaration refuses:
-
-```csharp
-builder.IntroduceUnion(
-    "Result",
-    UnionKind.Attribute,
-    buildUnion: u =>
-    {
-        u.Accessibility = Accessibility.Public;
-        u.AddCase( typeof(int) );
-        u.AddCase( typeof(string) );
-    } );
-```
-
-There is no advice that adds a case to a union that already exists. Section 6.5 states why, and gives what an
-aspect author writes instead for a type carrying the union attribute.
+`IntroduceUnion` introduces a union written with the `union` keyword, and no other authoring form. Section 6.3
+states why, and what an aspect writes instead when it wants the attribute form.
 
 ## 2. What Metalama produces
 
 ```csharp
 public union Result( int, string, TargetType );
-```
-
-```csharp
-[Union]
-public partial struct Result
-{
-    public Result( int value ) { /* ... */ }
-    public Result( string value ) { /* ... */ }
-    public object Value { get; }
-}
 ```
 
 ## 3. The interfaces
@@ -90,15 +72,15 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 /// </summary>
 /// <remarks>
 /// <para>
-/// The authoring form is chosen when the advice is called and is reported by <see cref="UnionKind"/>. The language
-/// applies the restrictions on the members of a union to a union declaration only, so the members that this
-/// interface refuses depend on that value. They are listed in the design document.
+/// The union is written with the <c>union</c> keyword. The language applies the restrictions on the members of a
+/// union to that form, so an instance field, an automatic property and a field-like event may not be introduced
+/// into it. The design document lists what this interface refuses.
 /// </para>
 /// <para>
 /// A union requires at least one case, so an advice whose callback adds none reports an error.
 /// </para>
 /// <para>
-/// The members that the compiler synthesizes for a union declaration, which are one constructor per case and the
+/// The members that the compiler synthesizes for a union, which are one constructor per case and the
 /// <c>Value</c> property, are not set through this interface. They are created by the advice and are read through
 /// <see cref="Metalama.Framework.Code.INamedType.Facets"/> on the introduced type.
 /// </para>
@@ -108,14 +90,7 @@ namespace Metalama.Framework.Code.DeclarationBuilders;
 [InternalImplement]
 public interface IUnionBuilder : INamedTypeBuilder
 {
-    /// <summary>
-    /// Gets the authoring form of the union, which was chosen when the advice was called.
-    /// </summary>
-    /// <seealso cref="Metalama.Framework.Code.Types.IUnionFacet.UnionKind"/>
-    UnionKind UnionKind { get; }
-
-    /// <summary>
-    /// Gets the case types that have been added so far, in the order in which they were added.
+    /// <summary>    /// Gets the case types that have been added so far, in the order in which they were added.
     /// </summary>
     /// <remarks>
     /// <para>
@@ -157,54 +132,57 @@ public interface IUnionBuilder : INamedTypeBuilder
 ```csharp
 // Metalama.Framework/Advising/IAdviceFactory.cs
 /// <summary>
-/// Introduces a new union to the target namespace or type.
+/// Introduces a new union, written with the <c>union</c> keyword, to the target namespace or type.
 /// </summary>
 /// <param name="targetNamespaceOrType">The namespace or type into which the union must be introduced.</param>
 /// <param name="name">The name of the introduced union.</param>
-/// <param name="unionKind">Whether the union is declared with the <c>union</c> keyword or is a struct carrying the
-///     union attribute. <see cref="UnionKind.None"/> is not accepted, because it reports a union whose authoring
-///     form is not known and is not a form that can be written.</param>
+/// <param name="buildUnion">A callback that configures the introduced union. It must add at least one case,
+///     because the language requires a union to have one. The parameter is required and precedes
+///     <paramref name="whenExists"/> for that reason: an advice that adds no case reports an error, so a call
+///     that omitted the callback could never succeed.</param>
 /// <param name="whenExists">Determines the implementation strategy when a type of the same name is already declared
 ///     in the target namespace or type. The default strategy is to fail with a compile-time error.</param>
-/// <param name="buildUnion">A callback that configures the introduced union. It must add at least one case,
-///     because the language requires a union to have one.</param>
 /// <returns>An <see cref="IIntroductionAdviceResult{T}"/> representing the result of the advice. The
 /// <see cref="IIntroductionAdviceResult{T}.Declaration"/> property provides access to the introduced union.</returns>
 IIntroductionAdviceResult<INamedType> IntroduceUnion(
     INamespaceOrNamedType targetNamespaceOrType,
     string name,
-    UnionKind unionKind,
-    OverrideStrategy whenExists = OverrideStrategy.Default,
-    Action<IUnionBuilder>? buildUnion = null );
+    Action<IUnionBuilder> buildUnion,
+    OverrideStrategy whenExists = OverrideStrategy.Default );
 ```
 
 The matching extension method on `AdviserExtensions` follows the pattern of the other four documents:
 `IntroduceUnion` extends `IAdviser<INamespaceOrNamedType>`.
 
-There is no `IntroduceUnionCase`, and section 6.5 states why.
+`buildUnion` is the one callback of this set that is required, and it is the one parameter of this set that
+precedes `whenExists`. Every other introduction method configures a type that is well formed when the callback
+does nothing, so the callback is optional and sits last. A union with no case is not a declaration the language
+accepts, and the callback is the only way to add one, so a call that omitted it could only report an error.
+
+There is no `IntroduceUnionCase`, and section 6.4 states why.
 
 ## 4. The inherited operations that are not valid
 
-The language forbids an instance field, an automatic property and a field-like event in a union declaration, and
-allows all three in the attribute form. `ITypeSymbol.IsUnion` is true for both forms, so every rule states which of
-the two it tests. That condition is required by section 3 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) and
-it is the one that is most often misread.
+A union declaration is a struct, and the language forbids an instance field, an automatic property and a field-like
+event in it. Those restrictions belong to this form and not to the attribute form, which this advice does not
+introduce, so every rule this issue writes tests the form it has rather than `ITypeSymbol.IsUnion`. Section 3 of
+[`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) requires that distinction, and it is the one most often misread.
 
-| Member | Union declaration | Attribute form |
-| --- | --- | --- |
-| `Accessibility`, `Name`, `IsPartial` | Valid. | Valid. |
-| `AddTypeParameter` | Valid. | Valid. |
-| `BaseType` | The setter throws a `NotSupportedException`. A union declaration is a struct. | Valid when the carrying type is a class. |
-| `IsAbstract`, `IsSealed`, `IsStatic` | The setter throws a `NotSupportedException`. | Valid when the carrying type is a class, and refused otherwise, as for any struct. |
-| `IsReadOnly`, `IsRef` | The setter throws a `NotSupportedException`. | As for any struct or class. |
-| `IsClosed` | The setter throws an `InvalidOperationException`, as it does for any type that is not a class. | Valid when the carrying type is a class. |
-| `Facets` | The getter throws a `NotSupportedException`, as it does on every builder. | Same. |
+| Member | State |
+| --- | --- |
+| `Accessibility`, `Name`, `IsPartial` | Valid. |
+| `AddTypeParameter` | Valid. |
+| `BaseType` | The setter throws a `NotSupportedException`. A union declaration is a struct, and there is no base list to emit. |
+| `IsAbstract`, `IsSealed`, `IsStatic` | The setter throws a `NotSupportedException`. |
+| `IsReadOnly`, `IsRef` | The setter throws a `NotSupportedException`. |
+| `IsClosed` | The setter throws an `InvalidOperationException`, as it does for any type that is not a class. |
+| `Facets` | The getter throws a `NotSupportedException`, as it does on every builder. |
 
-Member introduction through the adviser is valid on a union, and is restricted rather than refused. An instance
-field, an automatic property and a field-like event introduced into a union declaration produce the compiler error
-CS9373, so the eligibility rules refuse them and report a Metalama diagnostic instead. The same advices are
-accepted on the attribute form. An explicit constructor of a union declaration must chain to a generated one, which
-is a further rule.
+Member introduction through the adviser is restricted rather than refused. An instance field, an automatic property
+and a field-like event introduced into a union produce the compiler error CS9373, so the eligibility rules refuse
+them and report a Metalama diagnostic instead. An explicit constructor must chain to a generated one, which is a
+further rule. These are the exception that section 3.2 of [`introducing-types.md`](introducing-types.md) names:
+the compiler reports those errors on generated code that the user cannot edit.
 
 ## 5. What the facet of the introduced union reports
 
@@ -218,7 +196,7 @@ The introduced type reports an `IUnionFacet`.
 
 | `IUnionFacet` member | Source |
 | --- | --- |
-| `UnionKind` | `IUnionBuilder.UnionKind`. |
+| `UnionKind` | `UnionKind.Declaration`, always, because this advice introduces no other form. |
 | `Cases` | One `IUnionCase` per case type added to the builder, in the order in which they were added. Each one carries its index and its creation member, which the builder does not. |
 | `ValueProperty` | The `Value` property, materialized as a builder. |
 | `FacetKind` | `TypeFacetKind.Union`. |
@@ -235,9 +213,8 @@ transformation that injected them as well would declare each of them twice. Sect
 [`introducing-types.md`](introducing-types.md) states the rule and the mechanism, and the table above therefore
 describes the code model rather than the generated code.
 
-`INamedType.IsUnion` reports `true`. `IType.TypeKind` reports `TypeKind.Struct` for a union declaration and the
-kind of the carrying type for the attribute form, because a union is not a kind of its own in the code model, which
-section 4.3 of [`type-facets.md`](type-facets.md) decides.
+`INamedType.IsUnion` reports `true`, and `IType.TypeKind` reports `TypeKind.Struct`, because a union is not a kind
+of its own in the code model, which section 4.3 of [`type-facets.md`](type-facets.md) decides.
 
 The facet is tested by unit tests and not by aspect tests, for the reason that section 5.3 of
 [`introducing-types.md`](introducing-types.md) gives. The synthesized members of a union are in the same position
@@ -301,43 +278,54 @@ the linker injection registry was not verified. This document does not settle it
 decides whether the step is one day or three. Every other kind of this set needs the same shape, so the prototype
 belongs with the struct work, which section 4.2 identifies as the cheapest place to run it.
 
-### 6.3. One interface serves both authoring forms
+### 6.3. Only the form written with the `union` keyword is introduced
 
-The two forms differ in what they refuse rather than in what they offer, which is the table of section 4, and the
-reader has already taken this decision: `IUnionFacet` is one interface with a `UnionKind` property and not two
-interfaces. The reasoning is that of section 6.1 of [`introducing-records.md`](introducing-records.md).
+`IntroduceUnion` produces a union declaration. It does not produce the attribute form, which is a class or a struct
+carrying `System.Runtime.CompilerServices.UnionAttribute`, and it takes no argument that would choose between the
+two.
 
-### 6.4. `UnionKind` is reused and `None` is refused
+The reason is that the attribute form needs nothing from this advice. It is an ordinary class or struct, and an
+aspect builds one with the advice that already exists:
 
-The enumeration exists and is shipped. `UnionKind.None` reports a union whose authoring form is not known, which is
-the case of a union read from a referenced assembly, and it is not a form that can be written. The advice method
-therefore accepts the two writable members and throws an `ArgumentOutOfRangeException` for `None`.
+```csharp
+var union = builder.IntroduceClass(
+    "Result",
+    buildType: t =>
+    {
+        t.Accessibility = Accessibility.Public;
+        t.AddAttribute( AttributeConstruction.Create( typeof(UnionAttribute) ) );
+    } );
 
-The parameter has no default value, unlike the `RecordKind` parameter of
-[`introducing-records.md`](introducing-records.md), because the two forms differ in what the introduced type
-accepts afterwards and neither is the obvious choice. S-29 delivers the attribute form first, and that is a
-delivery order rather than a default.
+union.IntroduceConstructor( nameof(this.CaseConstructor), buildConstructor: c => c.Accessibility = Accessibility.Public );
+union.IntroduceAutomaticProperty( "Value", typeof(object) );
+```
 
-### 6.5. Adding a case to a union that already exists is not supported
+An advice that served both forms would carry an argument that changes which of its own members are valid, a table
+of restrictions with two columns, and a set of eligibility rules that each state which form they test. The second
+form would buy an attribute and a naming convention.
+
+One thing is lost, which is the "almost" in that trade. `INamedType.IsUnion` is derived from the type kind and the
+builder data, and an introduced class that carries the union attribute is reported as an ordinary class:
+`IsUnion` is `false` for it and `Facets.Union` is `null`, although the compiler treats it as a union. A type the
+user wrote with the same attribute is reported correctly, because the code model reads its symbol. Deriving the
+flag from the attribute of an introduced type would close that gap and is not required here, because the aspect
+that wrote the attribute knows what it built.
+
+### 6.4. Adding a case to a union that already exists is not supported
 
 No advice adds a case to a union that the user wrote. An earlier revision of this design carried one, named
 `IntroduceUnionCase`, and it is withdrawn. The reason is that the two authoring forms cannot both be served.
 
-For a type declared with the `union` keyword the operation is not expressible at design time. Exactly one part of a
-partial union carries the case list: a second part carrying one is CS8863, and a part carrying none while no other
-part carries one is CS9370. A generated partial part therefore cannot add a case, so the operation would have to
-rewrite the part that the user wrote. It would take effect at build time only, the editor would show the union
-without the added case, and the code that the aspect generated against that case would not compile in the editor.
-An advice about which the editor and the build disagree is worse than no advice.
+For a union declaration the operation is not expressible at design time. Exactly one part of a partial union carries
+the case list: a second part carrying one is CS8863, and a part carrying none while no other part carries one is
+CS9370. A generated partial part therefore cannot add a case, so the operation would have to rewrite the part that
+the user wrote. It would take effect at build time only, the editor would show the union without the added case, and
+the code that the aspect generated against that case would not compile in the editor. An advice about which the
+editor and the build disagree is worse than no advice.
 
-For a type carrying the union attribute the operation is expressible. Roslyn derives the case set of that form from
-the public single-parameter constructors, so adding a case is adding such a constructor, and a generated partial
-part carries it. Metalama nevertheless declares no advice, because one method that works on one authoring form and
-reports an error on the other reads as a defect rather than as a design, and because the operation it would perform
-is one an aspect can already perform.
-
-That is the workaround, and it is not restricted. An aspect adds a case to a type carrying the union attribute by
-introducing the constructor that defines it:
+For a type carrying the union attribute the operation is expressible, and an aspect performs it with the advice that
+already exists. Roslyn derives the case set of that form from the public single-parameter constructors, so adding a
+case is adding such a constructor, and a generated partial part carries it:
 
 ```csharp
 [Template]
@@ -350,14 +338,15 @@ builder.With( existingUnion )
         buildConstructor: c => c.Accessibility = Accessibility.Public );
 ```
 
-The compiler reads the new case from that constructor, the generated partial part carries it, and the editor and
-the build agree. This follows the rule of section 3.2 of [`introducing-types.md`](introducing-types.md): the
-framework does not prevent an aspect author from generating code, and it declares no advice of its own only
-because the advice would be uneven across the two forms.
+The compiler reads the new case from that constructor, the generated partial part carries it, and the editor and the
+build agree. This follows the rule of section 3.2 of [`introducing-types.md`](introducing-types.md): the framework
+does not prevent an aspect author from generating invalid code, so it does not stand between the author and an
+operation the language allows. It declares no advice of its own for a different reason, which is that the advice
+would be uneven across the two authoring forms.
 
-There is no workaround for a type declared with the `union` keyword. An aspect cannot add a case to it, and the
-case list has to be written in source. An aspect that needs a case set it controls introduces the whole union, which
-is what this document designs.
+There is no workaround for a union declaration. An aspect cannot add a case to one, and the case list has to be
+written in source. An aspect that needs a case set it controls introduces the whole union, which is what this
+document designs.
 
 This decision answers question Q1 of [`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md), which chose
 between shipping both authoring forms of case addition and shipping the attribute form alone. Neither ships. It
@@ -385,7 +374,7 @@ reason `IUnionCase` carries `Index` at all.
 - [`../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md`](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md),
   whose first half this document designs, and
   [`../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md`](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md),
-  which section 6.5 withdraws.
+  which section 6.4 withdraws.
 - [`../2027.0/analysis-reports/11-introducing-unions-design.md`](../2027.0/analysis-reports/11-introducing-unions-design.md),
   which records the derivation of the case set of the attribute form.
 - [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 3, 4 and 11.
@@ -393,7 +382,7 @@ reason `IUnionCase` carries `Index` at all.
 - Issue [#1951](https://github.com/metalama/Metalama/issues/1951), which this document designs, and its blockers
   [#1941](https://github.com/metalama/Metalama/issues/1941) and
   [#1945](https://github.com/metalama/Metalama/issues/1945).
-- Issue [#1952](https://github.com/metalama/Metalama/issues/1952), which section 6.5 withdraws. It is closed
-  without being implemented, and the reason is recorded there.
+- Issue [#1952](https://github.com/metalama/Metalama/issues/1952), which section 6.4 withdraws. It stays open
+  until the product owner accepts the withdrawal, and the reason is recorded there.
 
 — Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/introducing-unions.md
+++ b/Metalama.Framework/docs/future/introducing-unions.md
@@ -231,9 +231,9 @@ This is the substance of the story, and section 6.2 states why it is not free.
 Materialized means present in the code model and not emitted as syntax. Metalama generates the union declaration,
 which for the declaration form is the `union` keyword, the name and the case list, and the compiler synthesizes the
 `Value` property and one constructor per case from it exactly as it does for a union the user wrote. A
-transformation that injected them as well would declare each of them twice. Section 5.2 of
-[`introducing-types.md`](introducing-types.md) states the rule, and the table above therefore describes the code
-model rather than the generated code.
+transformation that injected them as well would declare each of them twice. Section 4.2 of
+[`introducing-types.md`](introducing-types.md) states the rule and the mechanism, and the table above therefore
+describes the code model rather than the generated code.
 
 `INamedType.IsUnion` reports `true`. `IType.TypeKind` reports `TypeKind.Struct` for a union declaration and the
 kind of the carrying type for the attribute form, because a union is not a kind of its own in the code model, which
@@ -286,23 +286,20 @@ changes.
 
 The introduction pipeline never re-reads the final model from Roslyn, so the `Value` property and the per-case
 creation members have to exist as builders. They must not be emitted, because the compiler synthesizes them from
-the union declaration that Metalama does emit. The operation is therefore a transformation that registers a builder
-into the code model and injects no member, which is a shape that does not exist yet.
+the union declaration that Metalama does emit. Section 4.2 of [`introducing-types.md`](introducing-types.md) states
+the mechanism, which is a transformation implementing `IIntroduceDeclarationTransformation` and not
+`IInjectMemberTransformation`, and names `IntroduceNamespaceTransformation` as the precedent that story S-29 also
+names.
 
-Story S-29 identifies the precedent as the introduction of a namespace, which registers a builder without injecting
-syntax, and not as the record materialization of
-[#1343](https://github.com/metalama/Metalama/issues/1343), which does not generalise because a user may not declare
-the synthesized union members at all and there is therefore no override to serve. The analysis in
-[`../2027.0/analysis-reports/11-introducing-unions-design.md`](../2027.0/analysis-reports/11-introducing-unions-design.md)
-states why the record precedent cannot be copied literally:
-`IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded` adds a transformation, and
-`IntroduceDeclarationTransformation<T>` implements both the interface that registers a declaration and the one that
-injects a member, so using it would emit the member as well.
+What is specific to the union is the scale and the risk. This kind registers one constructor per case, so the
+number of registered members depends on what the aspect declares, and the record materialization of
+[#1343](https://github.com/metalama/Metalama/issues/1343) does not generalise to it, because a user may not declare
+the synthesized union members at all and there is therefore no override to serve.
 
 S-29 asks for that step to be prototyped first, because whether a member builder with no injected member survives
 the linker injection registry was not verified. This document does not settle it, and it records that the answer
 decides whether the step is one day or three. Every other kind of this set needs the same shape, so the prototype
-is worth running before the record work starts as well.
+belongs with the struct work, which section 4.2 identifies as the cheapest place to run it.
 
 ### 6.3. One interface serves both authoring forms
 

--- a/Metalama.Framework/docs/future/introducing-unions.md
+++ b/Metalama.Framework/docs/future/introducing-unions.md
@@ -1,21 +1,19 @@
 # Introducing a union
 
-This document designs the introduction of a union of C# 15, which is issues
-[#1951](https://github.com/metalama/Metalama/issues/1951) and
-[#1952](https://github.com/metalama/Metalama/issues/1952). It is a design proposal. Nothing described here is
+This document designs the introduction of a union of C# 15, which is issue
+[#1951](https://github.com/metalama/Metalama/issues/1951). It is a design proposal. Nothing described here is
 implemented.
 
-The two issues are user stories S-29 and S-30 of the 2027.0 release, and the capability, the scope and the
-acceptance criteria are stated there rather than here:
+The issue is user story S-29 of the 2027.0 release, and the capability, the scope and the acceptance criteria are
+stated there rather than here. Section 11 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) rules that a story
+states no application programming interface, so the shape is designed here and the story keeps its authority over
+the scope. This document does not restate it.
 
-| Issue | Story | Content |
-| --- | --- | --- |
-| [#1951](https://github.com/metalama/Metalama/issues/1951) | [S-29](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md) | Introducing a union type, and introducing a case into a type carrying the union attribute. |
-| [#1952](https://github.com/metalama/Metalama/issues/1952) | [S-30](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md) | Introducing a case into a type declared with the `union` keyword. Filed only if question Q1 of [`OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) chooses to ship both forms. |
-
-Section 11 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) rules that a story states no application
-programming interface, so the shape is designed here and the two stories keep their authority over the scope. This
-document does not restate them.
+The scope is narrower than that story. S-29 carries two halves, which are introducing a whole union and adding a
+case to a union that already exists, and this design delivers the first half only. Section 6.5 states why, and what
+an aspect author does instead. Issue [#1952](https://github.com/metalama/Metalama/issues/1952), user story S-30,
+which carried the second half for a type declared with the `union` keyword, is not implemented, and question Q1 of
+[`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) is answered by that decision.
 
 The cross-cutting decisions are in [`introducing-types.md`](introducing-types.md). A union declares members that an
 aspect can introduce, within the limits that section 4 states, so `IUnionBuilder` derives from `INamedTypeBuilder`
@@ -36,8 +34,8 @@ public class GenerateResultAttribute : TypeAspect
             buildUnion: u =>
             {
                 u.Accessibility = Accessibility.Public;
-                u.AddCase( TypeFactory.GetType( typeof(int) ) );
-                u.AddCase( TypeFactory.GetType( typeof(string) ) );
+                u.AddCase( typeof(int) );
+                u.AddCase( typeof(string) );
                 u.AddCase( builder.Target );
             } );
     }
@@ -54,17 +52,13 @@ builder.IntroduceUnion(
     buildUnion: u =>
     {
         u.Accessibility = Accessibility.Public;
-        u.AddCase( TypeFactory.GetType( typeof(int) ) );
-        u.AddCase( TypeFactory.GetType( typeof(string) ) );
+        u.AddCase( typeof(int) );
+        u.AddCase( typeof(string) );
     } );
 ```
 
-Adding a case to a union that already exists is the second half of the work, and it is an advice on that type
-rather than a type introduction:
-
-```csharp
-builder.With( existingUnion ).IntroduceUnionCase( TypeFactory.GetType( typeof(decimal) ) );
-```
+There is no advice that adds a case to a union that already exists. Section 6.5 states why, and gives what an
+aspect author writes instead for a type carrying the union attribute.
 
 ## 2. What Metalama produces
 
@@ -121,10 +115,19 @@ public interface IUnionBuilder : INamedTypeBuilder
     UnionKind UnionKind { get; }
 
     /// <summary>
-    /// Gets the cases that have been added so far, in the order in which they were added.
+    /// Gets the case types that have been added so far, in the order in which they were added.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The list holds types and not cases. A case of a union is a type and nothing else, which section 6.1 of the
+    /// design document establishes from the grammar of the language, so there is nothing else for an element of
+    /// this list to carry. <see cref="Metalama.Framework.Code.Types.IUnionCase"/>, which the introduced type
+    /// reports, carries the index and the creation member in addition, and neither exists while the union is being
+    /// built.
+    /// </para>
+    /// </remarks>
     /// <seealso cref="Metalama.Framework.Code.Types.IUnionFacet.Cases"/>
-    IReadOnlyList<IUnionCaseBuilder> Cases { get; }
+    IReadOnlyList<IType> Cases { get; }
 
     /// <summary>
     /// Adds a case to the union.
@@ -139,64 +142,17 @@ public interface IUnionBuilder : INamedTypeBuilder
     /// </para>
     /// </remarks>
     /// <param name="caseType">The type of the case.</param>
-    /// <returns>An <see cref="IUnionCaseBuilder"/> that allows you to further build the new case.</returns>
-    IUnionCaseBuilder AddCase( IType caseType );
+    void AddCase( IType caseType );
 
     /// <summary>
     /// Adds a case to the union.
     /// </summary>
     /// <param name="caseType">The type of the case.</param>
-    /// <returns>An <see cref="IUnionCaseBuilder"/> that allows you to further build the new case.</returns>
-    IUnionCaseBuilder AddCase( Type caseType );
+    void AddCase( Type caseType );
 }
 ```
 
-### 3.2. `IUnionCaseBuilder`
-
-```csharp
-// Metalama.Framework/Code/DeclarationBuilders/IUnionCaseBuilder.cs
-namespace Metalama.Framework.Code.DeclarationBuilders;
-
-/// <summary>
-/// Allows to complete the construction of a case of a union that has been created by
-/// <see cref="IUnionBuilder.AddCase(IType)"/> or by the advice that adds a case to an existing union.
-/// </summary>
-/// <remarks>
-/// <para>
-/// This interface is the counterpart of <see cref="Metalama.Framework.Code.Types.IUnionCase"/>, and it is not that
-/// interface. A case that is being built has no creation member yet, because the member is synthesized when the
-/// union is introduced, so an interface that declared
-/// <see cref="Metalama.Framework.Code.Types.IUnionCase.CreationMember"/> could not answer it. The creation member
-/// of an introduced union is read from the facet of the introduced type.
-/// </para>
-/// <para>
-/// Like <see cref="Metalama.Framework.Code.Types.IUnionCase"/>, and unlike every other builder of this namespace,
-/// this interface does not derive from <see cref="IDeclarationBuilder"/>. A case of a union is not a declaration:
-/// it declares no type, and the declaration that carries it is its creation member. The interface therefore
-/// carries no operation to add a custom attribute, because a case of a union takes none.
-/// </para>
-/// </remarks>
-/// <seealso cref="IUnionBuilder.AddCase(IType)"/>
-/// <seealso cref="Metalama.Framework.Code.Types.IUnionCase"/>
-[CompileTime]
-[InternalImplement]
-public interface IUnionCaseBuilder
-{
-    /// <summary>
-    /// Gets the type of the case.
-    /// </summary>
-    /// <seealso cref="Metalama.Framework.Code.Types.IUnionCase.Type"/>
-    IType Type { get; }
-
-    /// <summary>
-    /// Gets the zero-based index of the case, in the order in which the cases were added.
-    /// </summary>
-    /// <seealso cref="Metalama.Framework.Code.Types.IUnionCase.Index"/>
-    int Index { get; }
-}
-```
-
-### 3.3. The advice methods
+### 3.2. The advice method
 
 ```csharp
 // Metalama.Framework/Advising/IAdviceFactory.cs
@@ -220,30 +176,12 @@ IIntroductionAdviceResult<INamedType> IntroduceUnion(
     UnionKind unionKind,
     OverrideStrategy whenExists = OverrideStrategy.Default,
     Action<IUnionBuilder>? buildUnion = null );
-
-/// <summary>
-/// Adds a case to a union that already exists.
-/// </summary>
-/// <remarks>
-/// <para>
-/// For a type carrying the union attribute, the case is a constructor, a generated partial part expresses it, and
-/// the editor and the build agree about the result.
-/// </para>
-/// <para>
-/// For a type declared with the <c>union</c> keyword, exactly one part of the type carries the case list, so a
-/// generated partial part cannot add a case and the operation rewrites the part that the user wrote. It therefore
-/// takes effect at build time only, and the editor does not show the added case. A design-time diagnostic reports
-/// that divergence.
-/// </para>
-/// </remarks>
-/// <param name="targetUnion">The union into which the case must be added.</param>
-/// <param name="caseType">The type of the case.</param>
-/// <returns>An <see cref="IIntroductionAdviceResult{T}"/> exposing the added case.</returns>
-IIntroductionAdviceResult<IUnionCase> IntroduceUnionCase( INamedType targetUnion, IType caseType );
 ```
 
-The matching extension methods on `AdviserExtensions` follow the pattern of the other four documents:
-`IntroduceUnion` extends `IAdviser<INamespaceOrNamedType>` and `IntroduceUnionCase` extends `IAdviser<INamedType>`.
+The matching extension method on `AdviserExtensions` follows the pattern of the other four documents:
+`IntroduceUnion` extends `IAdviser<INamespaceOrNamedType>`.
+
+There is no `IntroduceUnionCase`, and section 6.5 states why.
 
 ## 4. The inherited operations that are not valid
 
@@ -281,7 +219,7 @@ The introduced type reports an `IUnionFacet`.
 | `IUnionFacet` member | Source |
 | --- | --- |
 | `UnionKind` | `IUnionBuilder.UnionKind`. |
-| `Cases` | One `IUnionCase` per `IUnionCaseBuilder`, in the order in which they were added. |
+| `Cases` | One `IUnionCase` per case type added to the builder, in the order in which they were added. Each one carries its index and its creation member, which the builder does not. |
 | `ValueProperty` | The `Value` property, materialized as a builder. |
 | `FacetKind` | `TypeFacetKind.Union`. |
 | `Type` | The introduced type. |
@@ -289,6 +227,13 @@ The introduced type reports an `IUnionFacet`.
 `IUnionCase.CreationMember` is the member that creates a value of the case, and it is materialized: a constructor
 that the compiler synthesizes for a union declaration, and the single-parameter constructor of the attribute form.
 This is the substance of the story, and section 6.2 states why it is not free.
+
+Materialized means present in the code model and not emitted as syntax. Metalama generates the union declaration,
+which for the declaration form is the `union` keyword, the name and the case list, and the compiler synthesizes the
+`Value` property and one constructor per case from it exactly as it does for a union the user wrote. A
+transformation that injected them as well would declare each of them twice. Section 5.2 of
+[`introducing-types.md`](introducing-types.md) states the rule, and the table above therefore describes the code
+model rather than the generated code.
 
 `INamedType.IsUnion` reports `true`. `IType.TypeKind` reports `TypeKind.Struct` for a union declaration and the
 kind of the carrying type for the attribute form, because a union is not a kind of its own in the code model, which
@@ -303,32 +248,61 @@ two differ in what the creation member of a case is.
 
 ## 6. Decisions
 
-### 6.1. `AddCase` returns a builder and not an `IUnionCase`
+### 6.1. A case is a type, so there is no case builder and `AddCase` returns nothing
 
 Section 2.4 of [`type-facets.md`](type-facets.md) drafts `IUnionCase AddCase( IType caseType );`. This design
-returns an `IUnionCaseBuilder` instead, and the reason is the one that the same section states two paragraphs
-later: a facet describes a type that exists, and a builder describes a type that is being constructed and whose
-members are not yet resolvable.
+returns nothing, and declares no builder for a case. Two findings settle it.
 
-`IUnionCase` declares `CreationMember`. That member is synthesized when the union is introduced, so a case that is
-still being built cannot answer it, and returning `IUnionCase` from `AddCase` would hand the author an object with
-one property that throws. The draft did not weigh that, because the interface it returned was designed for the
-reader.
+The first is the grammar. The language defines the case list as bare types:
 
-The same reasoning produces `IEnumMemberBuilder` in [`introducing-enums.md`](introducing-enums.md), where the
-member that cannot be answered during construction is the field.
+```antlr
+case_types
+    : type (',' type)*
+    ;
+```
 
-### 6.2. The synthesized members are materialized, and that is the risk of the story
+A case carries no attribute, no modifier and no name, the proposal states no plan to allow any of the three, and
+the analysis in
+[`../2027.0/analysis-reports/11-introducing-unions-design.md`](../2027.0/analysis-reports/11-introducing-unions-design.md)
+reaches the same conclusion from the other direction: Roslyn parses the case list as a parameter list whose
+parameters carry a type and no identifier, so a case has no name, no default value, no reference kind and no
+attribute list. A builder exists to carry what an author may choose about a declaration. An author chooses nothing
+about a case except its type, which is the argument of `AddCase`.
+
+The second is that `IUnionCase` cannot be returned either. It declares `CreationMember`, which is synthesized when
+the union is introduced, so a case that is still being built cannot answer it. Returning it would hand the author
+an object with a property that throws, which is the failure that the lifetime argument of section 2.4 of
+[`type-facets.md`](type-facets.md) predicts two paragraphs after the draft that ignores it.
+
+What remains is `Cases`, typed as an ordered list of `IType`, which is what the builder needs to store and what the
+transformation needs to emit. The same analysis reaches that shape independently and contrasts it with
+`TypeParameters`, whose elements are declarations the builder owns.
+
+This decision should be revisited if the language gains attributes or modifiers on a case. At that point a case
+becomes a declaration, a builder for it carries those, and `AddCase` returns one. Nothing else in this design
+changes.
+
+### 6.2. The synthesized members enter the code model without being emitted, and that is the risk of the story
 
 The introduction pipeline never re-reads the final model from Roslyn, so the `Value` property and the per-case
-creation members have to exist as builders. Story S-29 identifies the precedent as the introduction of a namespace,
-which registers a builder without injecting syntax, and not as the record materialization of
+creation members have to exist as builders. They must not be emitted, because the compiler synthesizes them from
+the union declaration that Metalama does emit. The operation is therefore a transformation that registers a builder
+into the code model and injects no member, which is a shape that does not exist yet.
+
+Story S-29 identifies the precedent as the introduction of a namespace, which registers a builder without injecting
+syntax, and not as the record materialization of
 [#1343](https://github.com/metalama/Metalama/issues/1343), which does not generalise because a user may not declare
-the synthesized union members at all and there is therefore no override to serve.
+the synthesized union members at all and there is therefore no override to serve. The analysis in
+[`../2027.0/analysis-reports/11-introducing-unions-design.md`](../2027.0/analysis-reports/11-introducing-unions-design.md)
+states why the record precedent cannot be copied literally:
+`IntroduceNamedTypeAdvice.IntroduceImplicitConstructorIfNeeded` adds a transformation, and
+`IntroduceDeclarationTransformation<T>` implements both the interface that registers a declaration and the one that
+injects a member, so using it would emit the member as well.
 
 S-29 asks for that step to be prototyped first, because whether a member builder with no injected member survives
 the linker injection registry was not verified. This document does not settle it, and it records that the answer
-decides whether the step is one day or three.
+decides whether the step is one day or three. Every other kind of this set needs the same shape, so the prototype
+is worth running before the record work starts as well.
 
 ### 6.3. One interface serves both authoring forms
 
@@ -347,36 +321,63 @@ The parameter has no default value, unlike the `RecordKind` parameter of
 accepts afterwards and neither is the obvious choice. S-29 delivers the attribute form first, and that is a
 delivery order rather than a default.
 
+### 6.5. Adding a case to a union that already exists is not supported
+
+No advice adds a case to a union that the user wrote. An earlier revision of this design carried one, named
+`IntroduceUnionCase`, and it is withdrawn. The reason is that the two authoring forms cannot both be served.
+
+For a type declared with the `union` keyword the operation is not expressible at design time. Exactly one part of a
+partial union carries the case list: a second part carrying one is CS8863, and a part carrying none while no other
+part carries one is CS9370. A generated partial part therefore cannot add a case, so the operation would have to
+rewrite the part that the user wrote. It would take effect at build time only, the editor would show the union
+without the added case, and the code that the aspect generated against that case would not compile in the editor.
+An advice about which the editor and the build disagree is worse than no advice.
+
+For a type carrying the union attribute the operation is expressible. Roslyn derives the case set of that form from
+the public single-parameter constructors, so adding a case is adding such a constructor, and a generated partial
+part carries it. Metalama nevertheless declares no advice, because one method that works on one authoring form and
+reports an error on the other reads as a defect rather than as a design, and because the operation it would perform
+is one an aspect can already perform.
+
+That is the workaround, and it is not restricted. An aspect adds a case to a type carrying the union attribute by
+introducing the constructor that defines it:
+
+```csharp
+[Template]
+public void UnionCaseConstructor( decimal value ) { }
+
+// in BuildAspect:
+builder.With( existingUnion )
+    .IntroduceConstructor(
+        nameof(this.UnionCaseConstructor),
+        buildConstructor: c => c.Accessibility = Accessibility.Public );
+```
+
+The compiler reads the new case from that constructor, the generated partial part carries it, and the editor and
+the build agree. This follows the rule of section 3.2 of [`introducing-types.md`](introducing-types.md): the
+framework does not prevent an aspect author from generating code, and it declares no advice of its own only
+because the advice would be uneven across the two forms.
+
+There is no workaround for a type declared with the `union` keyword. An aspect cannot add a case to it, and the
+case list has to be written in source. An aspect that needs a case set it controls introduces the whole union, which
+is what this document designs.
+
+This decision answers question Q1 of [`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md), which chose
+between shipping both authoring forms of case addition and shipping the attribute form alone. Neither ships. It
+should be revisited if the language ever lets a part of a partial union contribute cases, which would remove the
+reason.
+
 ## 7. Open questions
 
-### 7.1. Does story S-30 ship at all?
+### 7.1. Does the order of `Cases` survive the round trip?
 
-Question Q1 of [`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) chooses between shipping both
-authoring forms and shipping the attribute form alone. `IntroduceUnionCase` on a union declaration works at build
-time only, and the editor cannot show the added case, which needs a design-time diagnostic that reports the
-divergence without repairing it.
+`IUnionBuilder.Cases` is in the order of addition, and `IUnionFacet.Cases` on the introduced type is in the order
+that the creation members declare, which `IUnionCase.Index` numbers. The compiler reports the case types of a union
+as a set, and `AddCase` refuses a duplicate, so the two orders should agree for an introduced union.
 
-The recommendation recorded in the story README is to ship both, taking the attribute form first. If only one form
-fits the release it is the attribute form, and [#1952](https://github.com/metalama/Metalama/issues/1952) is then
-not implemented. The interface above is unchanged either way: the method exists and reports that the operation is
-not supported on a union declaration.
-
-### 7.2. Is `IntroduceUnionCase` the right name and shape?
-
-The method adds a case to a type that already exists, so it is closer to `IntroduceParameter`, which changes the
-signature of a constructor the user wrote, than to the introduction of a declaration. Whether it should be named
-for the case or for the operation on the union is not decided, and neither is whether it should take a callback.
-
-What would settle it is the aspect that S-29 uses as its acceptance test. The precedent that S-29 names for the
-operation is the introduction of a parameter into a partial constructor, delivered for C# 14 in
-metalama/Metalama#1143, and the name of that advice is `IntroduceParameter`.
-
-### 7.3. What does `Cases` report while the union is being built?
-
-`IUnionCaseBuilder.Index` is the position in the order of addition. The compiler reports the case types of a union
-as a set, and `AddCase` refuses a duplicate, so the two orders agree for an introduced union. Whether they agree
-for a union that gains a case through `IntroduceUnionCase`, where the existing cases come from the source and the
-added one does not, is not verified here.
+What would settle it is a unit test that adds three cases and reads the index of each from the facet of the
+introduced type. The order matters, because the index of a case is not recoverable from its type, which is the
+reason `IUnionCase` carries `Index` at all.
 
 ## 8. References
 
@@ -384,15 +385,18 @@ added one does not, is not verified here.
 - [`introducing-records.md`](introducing-records.md), section 6.1, and
   [`introducing-enums.md`](introducing-enums.md), section 6.1, which take the same decisions for their kinds.
 - [`type-facets.md`](type-facets.md), sections 2.4 and 4.3, the first of which this document revises.
-- [`../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md`](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md)
-  and [`../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md`](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md).
+- [`../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md`](../2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md),
+  whose first half this document designs, and
+  [`../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md`](../2027.0/user-stories/S-30-introduce-case-into-union-declaration.md),
+  which section 6.5 withdraws.
 - [`../2027.0/analysis-reports/11-introducing-unions-design.md`](../2027.0/analysis-reports/11-introducing-unions-design.md),
   which records the derivation of the case set of the attribute form.
 - [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md), sections 3, 4 and 11.
 - `Metalama.Framework/Code/Types/IUnionFacet.cs` and `IUnionCase.cs`, the interfaces this design mirrors.
-- Issues [#1951](https://github.com/metalama/Metalama/issues/1951) and
-  [#1952](https://github.com/metalama/Metalama/issues/1952), and their blockers
+- Issue [#1951](https://github.com/metalama/Metalama/issues/1951), which this document designs, and its blockers
   [#1941](https://github.com/metalama/Metalama/issues/1941) and
   [#1945](https://github.com/metalama/Metalama/issues/1945).
+- Issue [#1952](https://github.com/metalama/Metalama/issues/1952), which section 6.5 withdraws. It is closed
+  without being implemented, and the reason is recorded there.
 
 — Claude for @gfraiteur

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -504,6 +504,13 @@ These are constraints on the implementation, not a design of it.
    every type, so the common case must not allocate.
 5. The implementations of `INamedType` that back a builder return the empty collection rather than throwing.
    Eligibility rules and advice validation run against builders, so an exception there is reached in normal use.
+
+   > This guideline is superseded by section 5.1 of [`introducing-types.md`](introducing-types.md), which makes a
+   > builder throw a `NotSupportedException` instead: a builder describes a type whose members are not resolvable,
+   > so an empty structure is a false answer rather than an incomplete one. The concern that this guideline records
+   > is answered rather than dismissed. The flags of section 4.4 continue to answer on a builder without
+   > allocating, so a caller that asks what kind a type is keeps working, and the three readers that take a type
+   > from an aspect are guarded before the exception is introduced. That document names them.
 6. The facet interfaces name no Roslyn type. `Metalama.Framework` is not built per Roslyn version, while
    `Metalama.Framework.Engine` is, and the union facet reads `ITypeSymbol.IsUnion` and `ITypeSymbol.UnionCaseTypes`,
    which exist only in the latest variant. The conditional compilation is therefore confined to the construction of
@@ -533,7 +540,7 @@ behaviour before anything that cannot be revised is public.
 The four issues below are the type introduction backlog, which predates this proposal. They are named here because
 this document decides the shape of their builder interfaces, in section 2.4, and because each of them replaces
 implementation guideline 5 for its own kind: the type that the builder produces has to report the facet of that
-kind. They are not C# 15 work, they are not gated on the move to the stable Roslyn, and their milestone is a
+kind, and the builder itself throws rather than reporting an empty one. They are not C# 15 work, they are not gated on the move to the stable Roslyn, and their milestone is a
 separate decision.
 
 | Issue | Content | Blocked by |

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -374,6 +374,13 @@ compiler reports CS9373 for them in a union declaration.
 `IDelegateBuilder`, `IEnumBuilder` and `IRecordBuilder` follow the same shape. They are not part of this proposal
 beyond the shape, because the introduction of those kinds is not currently supported.
 
+> The builder interfaces are now designed in [`introducing-types.md`](introducing-types.md) and in the five
+> documents it indexes, which supersede this section on two points. First, `IEnumBuilder` and `IDelegateBuilder`
+> derive from `IMemberOrNamedTypeBuilder` rather than from `INamedTypeBuilder`, for the reasons that section 2 of
+> that document gives; `IRecordBuilder` and `IUnionBuilder` derive from `INamedTypeBuilder` as drafted here.
+> Second, `IUnionBuilder.AddCase` returns a builder rather than an `IUnionCase`, because a case that is being
+> built has no creation member yet, which is the lifetime argument that the next paragraph of this section makes.
+
 The reason for keeping the writing surface off the facet is that the reader and the writer have different
 lifetimes. A facet describes a type that exists. A builder describes a type that is being constructed and whose
 members are not yet resolvable.
@@ -537,7 +544,14 @@ separate decision.
 | [#867](https://github.com/metalama/Metalama/issues/867) | Introduce a record, with `IRecordBuilder`. The largest of the four, because the synthesized members have to exist as builders. | #1997, #869 |
 
 `IUnionBuilder` belongs to the union introduction stories S-29 and S-30 of
-[`../2027.0/user-stories/README.md`](../2027.0/user-stories/README.md), and not to an issue of its own.
+[`../2027.0/user-stories/README.md`](../2027.0/user-stories/README.md), which are filed as issues
+[#1951](https://github.com/metalama/Metalama/issues/1951) and
+[#1952](https://github.com/metalama/Metalama/issues/1952).
+
+> This table is superseded by section 6 of [`introducing-types.md`](introducing-types.md), which adds the two union
+> issues to it and records the revised hierarchy of section 2.4. The blockers listed above are satisfied: #1995,
+> #1996, #1997 and #1941 are closed, so only #869 blocks the other four. Each of the five kinds is designed in a
+> document of its own, and section 8 of that document indexes every related issue.
 
 ### 6.3. What the first issue measures
 

--- a/Metalama.Framework/docs/future/type-facets.md
+++ b/Metalama.Framework/docs/future/type-facets.md
@@ -378,8 +378,10 @@ beyond the shape, because the introduction of those kinds is not currently suppo
 > documents it indexes, which supersede this section on two points. First, `IEnumBuilder` and `IDelegateBuilder`
 > derive from `IMemberOrNamedTypeBuilder` rather than from `INamedTypeBuilder`, for the reasons that section 2 of
 > that document gives; `IRecordBuilder` and `IUnionBuilder` derive from `INamedTypeBuilder` as drafted here.
-> Second, `IUnionBuilder.AddCase` returns a builder rather than an `IUnionCase`, because a case that is being
-> built has no creation member yet, which is the lifetime argument that the next paragraph of this section makes.
+> Second, `IUnionBuilder.AddCase` returns nothing, and no interface describes a case under construction. A case is
+> a bare type in the grammar of the language, so there is nothing for a builder to carry, and `IUnionCase` cannot
+> be returned either, because a case that is being built has no creation member yet, which is the lifetime argument
+> that the next paragraph of this section makes.
 
 The reason for keeping the writing surface off the facet is that the reader and the writer have different
 lifetimes. A facet describes a type that exists. A builder describes a type that is being constructed and whose
@@ -555,10 +557,11 @@ separate decision.
 [#1951](https://github.com/metalama/Metalama/issues/1951) and
 [#1952](https://github.com/metalama/Metalama/issues/1952).
 
-> This table is superseded by section 6 of [`introducing-types.md`](introducing-types.md), which adds the two union
-> issues to it and records the revised hierarchy of section 2.4. The blockers listed above are satisfied: #1995,
-> #1996, #1997 and #1941 are closed, so only #869 blocks the other four. Each of the five kinds is designed in a
-> document of its own, and section 8 of that document indexes every related issue.
+> This table is superseded by section 6 of [`introducing-types.md`](introducing-types.md), which adds the union to
+> it and records the revised hierarchy of section 2.4. The facet blockers listed above are satisfied, because
+> #1995, #1996, #1997 and #1941 are closed, so #869 alone blocks the enum, the delegate and the record. The union
+> is blocked by #869 and also by #1945, which is open. Each of the five kinds is designed in a document of its own,
+> and section 8 of that document indexes every related issue.
 
 ### 6.3. What the first issue measures
 


### PR DESCRIPTION
## Summary

Adds six design documents under `Metalama.Framework/docs/future` that design the introduction of a struct, an enum, a delegate, a record and a union. Each document carries the complete C# declaration of every public type it proposes, with its documentation, in the manner of section 2.2 of `type-facets.md`.

The read side of those five kinds shipped as the type facets in #1995, #1996, #1997 and #1941. The write side does not exist: `INamedType.Facets` is documented as returning an empty collection for a type that an aspect introduces, and no advice method creates a builder of any kind other than a class or an interface.

Section 11 of `DECISIONS.md` rules that a user story specifies no application programming interface, so these documents are where the shapes are decided, and the stories keep their authority over the scope.

- `introducing-types.md` carries the decisions the five kinds share and indexes the other five.
- `introducing-structs.md` (#869), `introducing-enums.md` (#866), `introducing-delegates.md` (#865), `introducing-records.md` (#867) and `introducing-unions.md` (#1951) carry one kind each.
- `type-facets.md` gains two notes pointing at the documents that supersede its section 2.4 and its implementation guideline 5.

### The decisions worth reviewing

**The builder hierarchy splits.** `IEnumBuilder` and `IDelegateBuilder` derive from `IMemberOrNamedTypeBuilder` rather than from `INamedTypeBuilder`, because an enum and a delegate declare no member that an aspect can introduce. `IRecordBuilder` and `IUnionBuilder` keep `INamedTypeBuilder`. This revises section 2.4 of `type-facets.md`, which chose one base for all four.

Two findings are recorded so that they are not rediscovered. `IMemberBuilder` cannot serve as the base, because it derives from `IMember`, whose `DeclaringType` is not nullable, and a type declared in a namespace has none. And the base does not decide whether members can be introduced: `IntroduceMethod` and `IntroduceField` extend `IAdviser<INamedType>` rather than the builder, so the refusal is an advice validation rule whatever the hierarchy is.

**Facets throw on a builder and are reported by an introduced type.** This reverses implementation guideline 5 of `type-facets.md`. A builder describes a type whose members are not resolvable, so an empty structure is a false answer rather than an incomplete one. The flags `IsEnum`, `IsDelegate`, `IsRecord` and `IsUnion` continue to answer on a builder without allocating, so only a caller that asks for the structure meets the exception. Three readers take a type from the aspect and are guarded first, which section 5.1 names.

**Synthesized members are materialized in the code model and are not emitted.** Metalama generates the declaration, and the compiler synthesizes the members from it as it does for a type the user wrote. Emitting them would declare each of them twice. An enum is the exception, because its members are written by the author and are part of the declaration.

**The framework does not prevent an aspect from generating invalid code.** A builder refuses an operation that cannot be represented, such as a base type on a struct, and not one whose result the compiler will reject, such as a ref struct used as the type of a field.

**Adding a case to a union that already exists is withdrawn**, and with it user story S-30. For a type declared with the `union` keyword exactly one part carries the case list, so a generated partial part cannot add a case and the editor and the build would disagree about the result. For a type carrying the union attribute the operation is expressible, and the documented workaround is to introduce the public single-parameter constructor that defines the case, which nothing restricts. This answers question Q1 of `OPEN-QUESTIONS.md`.

## Breaking changes

None. No source file is modified, and no public application programming interface changes in this pull request. The designs themselves add public types, and the pull request that implements each of them carries that change.

## Issues fixed

None, deliberately. These documents design five capabilities and implement none of them, so no issue is closed and no closing keyword is used.

The issues they design are #869, #866, #865, #867 and #1951, each of which stays open and gains a design it did not have. The first four are imported issues with no body.

Two further outcomes need a decision from the product owner rather than from this pull request:

- #1952, user story S-30, is withdrawn by section 6.5 of `introducing-unions.md` and is not implemented. It is left open here rather than closed.
- #1951, user story S-29, is narrowed to its first half for the same reason.

Section 8 of `introducing-types.md` indexes every related issue, including the closed facet issues that delivered the read side, the precedents (#1950, #1869, #1343, #1622) and the rest of the type introduction backlog.

— Claude for @gfraiteur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
