### PR TITLE
Close question Q1: case introduction into a union does not ship

### DIFF
--- a/Metalama.Framework/docs/2027.0/DECISIONS.md
+++ b/Metalama.Framework/docs/2027.0/DECISIONS.md
@@ -64,16 +64,18 @@ producing code that the compiler rejects. Both halves are in scope.
 
 ## 4. Introducing unions, union cases and closed classes
 
-An aspect may introduce a closed class, a union, and a case into a union. All three are in scope for 2027.0 and all
-three are discretionary under section 2, in the order given: the closed class is the smallest and therefore the
-likeliest to survive a cut, and the two union stories go together, because the second is meaningless without the
-first.
+An aspect may introduce a closed class and a union. Both are in scope for 2027.0 and both are discretionary under
+section 2, in the order given: the closed class is the smallest and therefore the likeliest to survive a cut.
+
+Introducing a case into a union that already exists is not in scope, in either authoring form. That was question Q1
+of [`OPEN-QUESTIONS.md`](OPEN-QUESTIONS.md), the product owner answered it on 2026-09-11, and the subsection below
+records the answer and its reason.
 
 The four open introduction issues #865, #866, #867 and #869, which ask for enums, delegates, records and structs,
 stay out of scope. Union introduction is not grouped with them.
 
-Two documentation stories name a discretionary story as a blocker. The internal architecture documents wait on all
-three, and the conceptual documentation waits on the union introduction. They document what ships, so the sections
+Two documentation stories name a discretionary story as a blocker. The internal architecture documents wait on
+both, and the conceptual documentation waits on the union introduction. They document what ships, so the sections
 that describe an introduction interface slip with the story that delivers it, and the rest of each document does
 not wait for it.
 
@@ -138,10 +140,29 @@ property or a case constructor at all, so there is no override to serve and no b
 Nothing is imposed on the user in this case: the aspect emits the attribute form, the user never writes it, and the
 design-time result is correct.
 
-### Introducing a case into an existing union
+### Introducing a case into an existing union does not ship
 
-The two forms differ in kind here, and the difference is what question Q1 of
-[`OPEN-QUESTIONS.md`](OPEN-QUESTIONS.md) has to settle.
+No advice adds a case to a union that already exists, in either authoring form. This was question Q1 of
+[`OPEN-QUESTIONS.md`](OPEN-QUESTIONS.md), which asked whether case introduction into a `union` declaration ships
+given that it works at build time only. The answer is that it does not, and the attribute form does not ship
+either. The question is closed and has left that document.
+
+The reason for the `union` declaration is the one Q1 stated: the design-time half cannot be expressed at all, so
+the editor and the build would disagree, and an advice about which they disagree is worse than no advice.
+
+The reason for the attribute form is not the one Q1 weighed. Adding a case there is expressible, and an aspect
+performs it today with `IntroduceConstructor`, because Roslyn derives the case set of that form from the public
+single-parameter constructors. Metalama declares no advice of its own for it, because one method that serves one
+authoring form and fails on the other reads as a defect rather than as a design, and because the operation it would
+perform is one an aspect can already perform. The design is section 6.4 of
+[`../future/introducing-unions.md`](../future/introducing-unions.md).
+
+The consequence for the introduction of a whole union, which does ship, is section 6.3 of the same document: only
+the form written with the `union` keyword is introduced, because an advice that served both forms would carry an
+argument that changes which of its own members are valid, in exchange for an attribute and a naming convention.
+
+The paragraphs below record what the two forms would have required, because the analysis stands and the decision
+should be revisited if the language ever lets a part of a partial union contribute cases.
 
 For a type carrying the attribute, adding a case is the introduction of a constructor. That is ordinary member
 introduction, it is expressible in a generated partial part, and the editor and the build therefore agree. None of
@@ -157,7 +178,8 @@ the editor and the build disagree about conversions and about switch exhaustiven
 
 Telling a user that an aspect can add a case only if they abandon `union Pet(Cat, Dog)` for the attribute form is a
 poor answer, because the attribute form requires the author to write the case constructors and the `Value` property
-by hand. That is the usability cost that question Q1 weighs against a build-time-only capability.
+by hand. That was the usability cost that question Q1 weighed against a build-time-only capability, and the answer
+above declines both sides of it.
 
 The design analysis is in
 [`analysis-reports/11-introducing-unions-design.md`](analysis-reports/11-introducing-unions-design.md), which

--- a/Metalama.Framework/docs/2027.0/OPEN-QUESTIONS.md
+++ b/Metalama.Framework/docs/2027.0/OPEN-QUESTIONS.md
@@ -8,31 +8,6 @@ and what depends on it. An entry marked as blocking names the work that cannot s
 identifiers are stable, so a gap in the numbering means that a question has been answered and removed rather than
 that one is missing.
 
-## Product decisions
-
-### Q1. Does case introduction into a `union` declaration ship, given that it works at build time only?
-
-Blocking, for one story.
-
-Section 4 of [`DECISIONS.md`](DECISIONS.md) requires the introduction of a union case and establishes that the
-answer differs by the form of the union. For a type carrying `UnionAttribute`, adding a case is the introduction of
-a constructor, a generated partial part can express it, and the editor and the build agree. For a type declared
-with the `union` keyword, the case list lives in exactly one part and a generated part may not carry one, so the
-operation requires rewriting the part the user wrote. The build-time half is small, because the linker already
-rewrites a type parameter list in the same field and method for partial constructor parameter introduction. The
-design-time half cannot be expressed at all: every route from a generated part is closed by a compiler rule.
-
-- Option A, ship both forms. The attribute form has a correct design-time result. The declaration form is
-  build-time only and needs a design-time diagnostic saying that the editor cannot show the added case. The editor
-  and the build then disagree about conversions and about switch exhaustiveness, which the diagnostic reports but
-  does not repair.
-- Option B, ship the attribute form only. Nothing diverges, and an aspect cannot add a case to a union that a user
-  wrote with the concise syntax.
-
-The analysis recommends Option A, and states that if only one form fits the release it should be the attribute
-form. Under Option A the severity and the opt-out of that diagnostic are chosen when the story is written. Settled
-by the product owner.
-
 ## Measurements that the calendar settles
 
 ### Q5. Which Roslyn version and which private runtime does the November 2026 Visual Studio baseline carry?

--- a/Metalama.Framework/docs/2027.0/user-stories/README.md
+++ b/Metalama.Framework/docs/2027.0/user-stories/README.md
@@ -126,7 +126,10 @@ Introducing a union, and introducing a case into an existing union, is required,
 [`DECISIONS.md`](../DECISIONS.md). This is the largest single piece of C# 15
 work in the release and it is story S-29.
 
-What is still open is question Q1, the second half of that requirement.
+The second half of that requirement, which is introducing a case into a union that already exists, was question
+Q1 and is now answered: it does not ship, in either authoring form. Section 4 of [`DECISIONS.md`](../DECISIONS.md)
+records the answer, S-30 is withdrawn, and S-29 is narrowed to the introduction of a union written with the
+`union` keyword.
 
 - Option A, ship both authoring forms. For a type carrying the union attribute, adding a case is the introduction of
   a constructor, a generated partial part can express it, and the editor and the build agree. For a type declared
@@ -331,8 +334,8 @@ same time.
    2027.0 and which slips to 2027.1 if the release runs short. S-28, the introduction of a closed class, is the
    smallest and therefore the likeliest to survive a cut. Then S-29, the introduction of a union and of a case into a
    type carrying the union attribute, and S-30, the introduction of a case into a `union` declaration, which follows
-   S-29 and is filed only if question Q1 chooses Option A. This is the cut line of the release, and S-28 to S-30 are
-   consecutive so that a reader sees at once what may be dropped.
+   S-29 and is withdrawn, because question Q1 is answered and case introduction does not ship. This is the cut
+   line of the release, and S-28 to S-30 are consecutive so that a reader sees at once what may be dropped.
 
 Stage 9 is the one place where a story precedes a story it is blocked by, and the exception is deliberate. S-26 names
 S-28 and S-29 as blockers, and S-27 names S-29. They document what ships, so the sections that describe an
@@ -431,11 +434,11 @@ graph TD
 | [S-23](S-23-premium-union-and-closed-architecture-tests.md) | Metalama.Premium: union and closed architecture rule tests | S | `metalama/Metalama.Premium` | S-14, S-18-6 |
 | [S-24](S-24-platform-and-dependency-documentation.md) | Documentation: platform, dependency and extensibility documents | M | `metalama/Metalama` | S-13, S-15 |
 | [S-25](S-25-samples-target-frameworks.md) | Metalama.Samples: target frameworks of PB-2027.0 | M | `metalama/Metalama.Samples` | nothing. The story needs a published 2027.0 package to build against, which S-10, S-13 and S-15 gate in time but not in dependency. A sample that demonstrates a C# 15 feature, if the scope decides to add one, is written after S-15. |
-| [S-26](S-26-internal-architecture-documents.md) | Documentation: internal architecture documents | M | `metalama/Metalama` | S-18-1, S-18-3, S-18-5, S-28 and S-29, which are the stories whose result these documents describe, and S-30 if question Q1 of [`OPEN-QUESTIONS.md`](../OPEN-QUESTIONS.md) files it. |
+| [S-26](S-26-internal-architecture-documents.md) | Documentation: internal architecture documents | M | `metalama/Metalama` | S-18-1, S-18-3, S-18-5, S-28 and S-29, which are the stories whose result these documents describe, and not S-30, which is withdrawn. |
 | [S-27](S-27-conceptual-documentation-csharp-15.md) | Documentation: conceptual documentation of C# 15 and PB-2027.0 | L | `metalama/Metalama.Documentation` | S-15, S-16, S-19, S-21, S-24 and S-29 |
 | [S-28](S-28-introduce-closed-class.md) | C# 15 closed classes: introducing | M | `metalama/Metalama` | S-13, S-16 |
 | [S-29](S-29-introduce-union-and-case-attribute-form.md) | C# 15 unions: introducing a union and a case on the attribute form | L | `metalama/Metalama` | S-18-1, S-18-5 |
-| [S-30](S-30-introduce-case-into-union-declaration.md) | C# 15 unions: introducing a case into a `union` declaration | M | `metalama/Metalama` | S-29, and question Q1 of [`OPEN-QUESTIONS.md`](../OPEN-QUESTIONS.md) |
+| [S-30](S-30-introduce-case-into-union-declaration.md) | C# 15 unions: introducing a case into a `union` declaration. **Withdrawn on 2026-09-11**, because question Q1 is answered and case introduction does not ship. | M | `metalama/Metalama` | not filed |
 | [S-31](S-31-preview-roslyn-api-opt-in-flag.md) | Build: an opt-in flag to compile against the experimental Roslyn C# 15 API | S | `metalama/Metalama` | nothing. It runs beside S-10, and S-13 disables it without removing it. |
 
 ## Already in progress

--- a/Metalama.Framework/docs/2027.0/user-stories/S-26-internal-architecture-documents.md
+++ b/Metalama.Framework/docs/2027.0/user-stories/S-26-internal-architecture-documents.md
@@ -6,7 +6,7 @@
 - Repositories: `metalama/Metalama`
 - Size: M
 - Blocked by: S-18-1, S-18-3, S-18-5, S-28 and S-29, which are the stories whose result these documents describe, and
-  S-30 if question Q1 of [`OPEN-QUESTIONS.md`](../OPEN-QUESTIONS.md) files it. A documentation story is normally blocked
+  not S-30, which is withdrawn. A documentation story is normally blocked
   by the stories whose result it describes, because a document written before the code is a second thing to correct.
 - Findings: none
 
@@ -101,7 +101,7 @@ of this document.
   declaration. For a union declaration that parameter list is the case list and not a parameter list. S-18-3 requires
   the fallback path to preserve it and to stay out of the record and struct paths, and S-18-1 names
   `ImplicitLastOverrideReferenceInliner` and `LinkerLateTransformationRegistry` as the two consumers where the same
-  distinction applies. State the distinction in that section. If question Q1 files S-30, add to the section
+  distinction applies. State the distinction in that section. S-30 is withdrawn, so do not add to the section
   "Constructor Rewriting Flow", under "Source Constructors", that the case list of the part the user wrote is
   rewritten in the same field and by the same method as the parameter list of a partial constructor, which is the
   precedent S-30 follows.

--- a/Metalama.Framework/docs/2027.0/user-stories/S-27-conceptual-documentation-csharp-15.md
+++ b/Metalama.Framework/docs/2027.0/user-stories/S-27-conceptual-documentation-csharp-15.md
@@ -46,7 +46,7 @@ present in the environment of that analysis. It is still not present, so the que
 answered.
 
 The C# 15 subjects come from stories that this one follows. C# 15 as a supported language version is S-15. Reading a
-union in the code model is S-18-1 and introducing one is S-29, with S-30 conditional on question Q1. Reading a closed
+union in the code model is S-18-1 and introducing one is S-29. S-30 is withdrawn. Reading a closed
 hierarchy is S-16 and introducing a closed class is S-28. Extension indexers are S-21. The rejection of a labeled
 `break` or `continue` in a template is S-19, which follows section 5 of [`DECISIONS.md`](../DECISIONS.md).
 
@@ -91,7 +91,7 @@ reader has to be told before using the feature.
   aspect transforms is not affected.
 - State, on every page of the C# 15 set, which design-time hosts show the feature, and that a host whose Roslyn
   predates C# 15 reports the code as an error of its own rather than being reported by Metalama.
-- State that a case added to a `union` declaration is a build-time-only change, if question Q1 chooses to ship that
+- State that an aspect cannot add a case to a union that already exists, and what it writes instead for the
   form and S-30 is delivered.
 - Publish the page list, so that S-29, S-24 and S-30 reference this issue instead of enumerating pages in their own
   pull request descriptions.

--- a/Metalama.Framework/docs/2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md
+++ b/Metalama.Framework/docs/2027.0/user-stories/S-29-introduce-union-and-case-attribute-form.md
@@ -34,8 +34,12 @@ and it depends on a grammar rule that
 exactly one part of a partial union carries the case list, a second one is `CS8863`, and none is `CS9370`. The
 consequence is that a generated partial part can never add a case to a union declared with the `union` keyword, so
 that operation works at build time only, while the same operation on a type carrying the union attribute is ordinary
-member introduction whose design-time result is correct. Question Q1 chooses between shipping both forms and
-shipping the attribute form alone, and the build-time-only form is story S-30. About half of the work needs no
+member introduction whose design-time result is correct. Question Q1 chose between shipping both forms and
+shipping the attribute form alone, and the product owner answered on 2026-09-11 that neither ships, so the half of
+this story that adds a case is withdrawn and story S-30 is not filed. Section 4 of
+[`../DECISIONS.md`](../DECISIONS.md) records the answer, and sections 6.3 and 6.4 of
+[`../../future/introducing-unions.md`](../../future/introducing-unions.md) carry the design, which also narrows
+this story to the introduction of a union written with the `union` keyword. Issue #1951 is revised accordingly. About half of the work needs no
 C# 15 Roslyn member and can proceed before S-13.
 
 Two closed issues bound this work. #1622 reported that a constructor introduced into an introduced type was missing

--- a/Metalama.Framework/docs/2027.0/user-stories/S-30-introduce-case-into-union-declaration.md
+++ b/Metalama.Framework/docs/2027.0/user-stories/S-30-introduce-case-into-union-declaration.md
@@ -7,13 +7,21 @@
 - Size: M
 - Priority: nice to have for 2027.0. It is discretionary under the doctrine of section 2 of
   [`DECISIONS.md`](../DECISIONS.md) and slips to 2027.1 if the release runs short.
-- Blocked by: S-29, and question Q1 of [`OPEN-QUESTIONS.md`](../OPEN-QUESTIONS.md)
+- Status: **withdrawn on 2026-09-11.** Not filed, and issue #1952 is closed without being implemented.
 - Findings: none. The design is
   [`analysis-reports/11-introducing-unions-design.md`](../analysis-reports/11-introducing-unions-design.md).
 
 ---
 
-This story is filed only if question Q1 chooses Option A, which is to ship both authoring forms of case
+> This story is withdrawn. Question Q1 of [`OPEN-QUESTIONS.md`](../OPEN-QUESTIONS.md) asked whether case
+> introduction into a `union` declaration ships given that it works at build time only, and the product owner
+> answered on 2026-09-11 that it does not. Section 4 of [`DECISIONS.md`](../DECISIONS.md) records the answer, which
+> also declines the attribute form that S-29 carried, and section 6.4 of
+> [`../../future/introducing-unions.md`](../../future/introducing-unions.md) carries the design and what an aspect
+> writes instead. The text below is kept as the record of what the story would have required, because the analysis
+> stands and the decision should be revisited if the language ever lets a part of a partial union contribute cases.
+
+This story would have been filed only if question Q1 had chosen Option A, which is to ship both authoring forms of case
 introduction. It adds a case to a type declared with the `union` keyword, which S-29 leaves out because that
 operation works at build time only.
 

--- a/Metalama.Framework/docs/future/introducing-unions.md
+++ b/Metalama.Framework/docs/future/introducing-unions.md
@@ -14,8 +14,8 @@ The scope is narrower than that story, in two ways, and the story has to be revi
 S-29 carries two halves, which are introducing a whole union and adding a case to a union that already exists, and
 this design delivers the first half only. Section 6.4 states why, and what an aspect author does instead. Issue
 [#1952](https://github.com/metalama/Metalama/issues/1952), user story S-30, which carried the second half for a
-union declaration, is not implemented either, and question Q1 of
-[`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md) is answered by that decision.
+union declaration, is not implemented either. That was question Q1 of the release, the product owner answered it on
+2026-09-11, and section 4 of [`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) records the answer.
 
 S-29 also names the attribute form of a union, which is a class or a struct carrying
 `System.Runtime.CompilerServices.UnionAttribute`. `IntroduceUnion` produces a union written with the `union`
@@ -348,10 +348,11 @@ There is no workaround for a union declaration. An aspect cannot add a case to o
 written in source. An aspect that needs a case set it controls introduces the whole union, which is what this
 document designs.
 
-This decision answers question Q1 of [`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md), which chose
-between shipping both authoring forms of case addition and shipping the attribute form alone. Neither ships. It
-should be revisited if the language ever lets a part of a partial union contribute cases, which would remove the
-reason.
+This was question Q1 of the release, which chose between shipping both authoring forms of case addition and
+shipping the attribute form alone. The product owner answered on 2026-09-11 that neither ships, so the question is
+closed and has left [`../2027.0/OPEN-QUESTIONS.md`](../2027.0/OPEN-QUESTIONS.md); section 4 of
+[`../2027.0/DECISIONS.md`](../2027.0/DECISIONS.md) records it. The decision should be revisited if the language
+ever lets a part of a partial union contribute cases, which would remove the reason.
 
 ## 7. Open questions
 


### PR DESCRIPTION
## Summary

The product owner answered question Q1 on 2026-09-11: case introduction into a `union` declaration does not ship, and neither does the attribute form. No advice adds a case to a union that already exists.

- Q1 leaves `OPEN-QUESTIONS.md`, which is the convention that document states: a question leaves it when it is answered in `DECISIONS.md`, and a gap in the numbering means a question has been answered and removed. The `Product decisions` section held only Q1 and goes with it.
- Section 4 of `DECISIONS.md` records the answer and both reasons, which are not the same one. The `union` declaration is refused for the reason Q1 stated, which is that the design-time half cannot be expressed, so the editor and the build would disagree. The attribute form is refused for a reason Q1 did not weigh: the operation is expressible and an aspect already performs it with `IntroduceConstructor`, so one advice that serves one authoring form and fails on the other would read as a defect. The analysis of both forms is kept, because it stands and the decision should be revisited if the language ever lets a part of a partial union contribute cases.
- S-30 is withdrawn. Its file keeps the text as the record of what the story would have required, under a note that states the withdrawal.
- S-29 records that the half of it that adds a case is withdrawn and that it is narrowed to the form written with the `union` keyword.
- The story table, the ordering, and the two documentation stories that named S-30 as a conditional blocker, which are S-26 and S-27, no longer wait on a settled question.
- `introducing-unions.md` pointed at Q1 in `OPEN-QUESTIONS.md` in two places and now points at the decision that records the answer.

## Breaking changes

None. No source file is modified.

## Issues fixed

None, deliberately, and no closing keyword is used. This pull request records a product decision in the documents that hold it.

The decision closes [#1952](https://github.com/metalama/Metalama/issues/1952), which is the issue for S-30 and which is closed as not planned rather than by this pull request, and it narrows [#1951](https://github.com/metalama/Metalama/issues/1951), whose body was revised when the design merged in #2015.

— Claude for @gfraiteur

🤖 Generated with [Claude Code](https://claude.com/claude-code)
